### PR TITLE
Use static info for tuigen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,8 +142,12 @@ jobs:
             src/ansys/fluent/core/meshing/tui.py
             src/ansys/fluent/core/solver/settings
             src/ansys/fluent/core/solver/tui.py
-          key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}-${{ hashFiles('codegen/**') }}-${{ github.sha }}
-          restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}-${{ hashFiles('codegen/**') }}
+            doc/source/api/core/meshing/tui
+            doc/source/api/core/meshing/datamodel
+            doc/source/api/core/solver/tui
+            doc/source/api/core/solver/datamodel
+          key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}-${{ hashFiles('codegen/**') }}
+          restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}
 
       - name: Login to GitHub Container Registry
         if: steps.cache-api-code.outputs.cache-hit != 'true'
@@ -177,9 +181,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: doc/source/examples
-          key: Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}-${{ hashFiles('examples/**') }}-${{ github.sha }}
+          key: Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}-${{ hashFiles('examples/**') }}
           restore-keys: |
-            Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}-${{ hashFiles('examples/**') }}
+            Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}
 
       - name: Build Documentation
         run: make build-doc DOCS_CNAME=fluentdocs.pyansys.com
@@ -256,8 +260,8 @@ jobs:
             doc/source/api/core/meshing/datamodel
             doc/source/api/core/solver/tui
             doc/source/api/core/solver/datamodel
-          key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}-${{ hashFiles('codegen/**') }}-${{ github.sha }}
-          restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}-${{ hashFiles('codegen/**') }}
+          key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}-${{ hashFiles('codegen/**') }}
+          restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}
 
       - name: Login to GitHub Container Registry
         if: steps.cache-api-code.outputs.cache-hit != 'true'

--- a/src/ansys/fluent/core/launcher/fluent_container.py
+++ b/src/ansys/fluent/core/launcher/fluent_container.py
@@ -57,7 +57,7 @@ def start_fluent_container(mounted_from: str, mounted_to: str, args: List[str]) 
                 "-e",
                 "FLUENT_LAUNCHED_FROM_PYFLUENT=1",
                 "ghcr.io/pyansys/pyfluent",
-                "-g",
+                "-gu",
                 f"-sifile={container_sifile}",
             ]
             + args

--- a/src/ansys/fluent/core/services/datamodel_tui.py
+++ b/src/ansys/fluent/core/services/datamodel_tui.py
@@ -2,8 +2,9 @@
 
 import keyword
 import types
-from typing import Any, Iterable, List, Tuple, Union
+from typing import Any, Dict, Iterable, List, Tuple, Union
 
+from google.protobuf.json_format import MessageToDict
 import grpc
 
 from ansys.api.fluent.v0 import datamodel_tui_pb2 as DataModelProtoModule
@@ -56,6 +57,10 @@ class DatamodelService:
         self, request: DataModelProtoModule.ExecuteQueryRequest
     ) -> DataModelProtoModule.ExecuteQueryResponse:
         return self.__stub.ExecuteQuery(request, metadata=self.__metadata)
+
+    @catch_grpc_error
+    def get_static_info(self, request):
+        return self.__stub.GetStaticInfo(request, metadata=self.__metadata)
 
 
 def _convert_value_to_gvalue(val: Any, gval: Variant):
@@ -196,6 +201,45 @@ class PyMenu:
             request.args["include_unavailable"] = 1
         response = self._service.get_attribute_value(request)
         return _convert_gvalue_to_value(response.value)
+
+    def get_static_info(self) -> Dict[str, Any]:
+        """Get static info at menu level.
+
+        Returns
+        -------
+        DataModelProtoModule.StaticInfo
+            static info
+        """
+        if hasattr(DataModelProtoModule, "GetStaticInfoRequest"):
+            request = DataModelProtoModule.GetStaticInfoRequest()
+            request.path = self._path
+            response = self._service.get_static_info(request)
+            return MessageToDict(response.info, including_default_value_fields=True)
+        else:
+            return _get_static_info_at_level(self)
+
+
+def _get_static_info_at_level(menu: PyMenu) -> Dict[str, Any]:
+    info = {}
+    info["help"] = menu.get_doc_string()
+    info["menus"] = {}
+    info["commands"] = {}
+    child_names = menu.get_child_names()
+    if child_names:
+        for child_name in child_names:
+            if child_name:
+                child_menu = PyMenu(
+                    menu._service,
+                    menu._path + ("" if menu._path.endswith("/") else "/") + child_name,
+                )
+                child_info = _get_static_info_at_level(child_menu)
+                if child_info.pop("is_command", False):
+                    info["commands"][child_name] = child_info
+                else:
+                    info["menus"][child_name] = child_info
+    else:
+        info["is_command"] = True
+    return info
 
 
 class TUIMenu:

--- a/src/ansys/fluent/core/services/datamodel_tui.py
+++ b/src/ansys/fluent/core/services/datamodel_tui.py
@@ -221,10 +221,10 @@ class PyMenu:
 
 def _get_static_info_at_level(menu: PyMenu) -> Dict[str, Any]:
     info = {}
-    info["help"] = menu.get_doc_string()
+    info["help"] = menu.get_doc_string(include_unavailable=True)
     info["menus"] = {}
     info["commands"] = {}
-    child_names = menu.get_child_names()
+    child_names = menu.get_child_names(include_unavailable=True)
     if child_names:
         for child_name in child_names:
             if child_name:

--- a/src/ansys/fluent/core/services/error_handler.py
+++ b/src/ansys/fluent/core/services/error_handler.py
@@ -3,8 +3,6 @@ from typing import Callable
 
 import grpc
 
-from ansys.fluent.core.utils.logging import LOG
-
 
 def catch_grpc_error(f: Callable) -> Callable:
     """Decorator to catch gRPC errors."""
@@ -14,7 +12,6 @@ def catch_grpc_error(f: Callable) -> Callable:
         try:
             return f(*args, **kwargs)
         except grpc.RpcError as ex:
-            LOG.error("GRPC_ERROR: %s", ex.details())
             raise RuntimeError(ex.details()) from None
 
     return func


### PR DESCRIPTION
For 23.1, `GetStaticInfo` rpc will be used for tuigen. I've also reduced the codegen frequency in CI. For 22.2, we shall always restore the generated code from cache (changes are not in the current PR).