### PR TITLE
Run tests and doc build for 23.1 docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
       - name: Install again after codegen
         run: |
           rm -rf dist
-          make install
+          make install > /dev/null
 
       - name: Cache examples
         uses: actions/cache@v3
@@ -308,7 +308,7 @@ jobs:
       - name: Install again after codegen
         run: |
           rm -rf dist
-          make install
+          make install > /dev/null
 
       - name: Unit Testing
         run: make unittest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
     runs-on: [self-hosted, pyfluent]
     strategy:
       matrix:
-        image-tag: [v22.2.0]
+        image-tag: [v22.2.0, v23.1.0]
 
     steps:
       - uses: actions/checkout@v3
@@ -235,7 +235,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image-tag: [v22.2.0]
+        image-tag: [v22.2.0, v23.1.0]
 
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,15 @@ style:
 	@pre-commit run --all-files --show-diff-on-failure
 
 install:
-	@pip uninstall ansys-api-fluent -y
 	@pip install -r requirements/requirements_build.txt
 	@python -m build
-	@pip install dist/*.whl
+	@pip install dist/*.whl --quiet
 
 version-info:
 	@bash -c "date -u +'Build date: %B %d, %Y %H:%M UTC ShaID: <id>' | xargs -I date sed -i 's/_VERSION_INFO = .*/_VERSION_INFO = \"date\"/g' src/ansys/fluent/core/__init__.py"
 	@bash -c "git --no-pager log -n 1 --format='%h' | xargs -I hash sed -i 's/<id>/hash/g' src/ansys/fluent/core/__init__.py"
 
 docker-pull:
-	@pip install docker
 	@bash .ci/pull_fluent_image.sh
 
 test-import:
@@ -28,7 +26,7 @@ api-codegen:
 	@echo "Running API codegen"
 	@python -m venv env
 	@. env/bin/activate
-	@pip install -e .
+	@pip install -e .  --quiet
 	@python codegen/allapigen.py
 	@rm -rf env
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ style:
 install:
 	@pip install -r requirements/requirements_build.txt
 	@python -m build
-	@pip install dist/*.whl --quiet
+	@pip install -q dist/*.whl
 
 version-info:
 	@bash -c "date -u +'Build date: %B %d, %Y %H:%M UTC ShaID: <id>' | xargs -I date sed -i 's/_VERSION_INFO = .*/_VERSION_INFO = \"date\"/g' src/ansys/fluent/core/__init__.py"
@@ -26,7 +26,7 @@ api-codegen:
 	@echo "Running API codegen"
 	@python -m venv env
 	@. env/bin/activate
-	@pip install -e .  --quiet
+	@pip install -q -e .
 	@python codegen/allapigen.py
 	@rm -rf env
 


### PR DESCRIPTION
Only the 22.2 artifacts have been uploaded. ~One concern could be that the CI log is showing all settings API filenames (we should hide any 23.1 solver details).~