### PR TITLE
Remove 23.1 doc builds from PR CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
       - name: Install again after codegen
         run: |
           rm -rf dist
-          make install
+          make install > /dev/null
 
       - name: Cache examples
         uses: actions/cache@v3
@@ -205,11 +205,7 @@ jobs:
             Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}
 
       - name: Build Documentation
-        run: |
-          ls -al src/ansys/fluent/core/solver
-          which python
-          ls -alR /home/ansys/actions-runner/_work/_tool/Python/3.9.12/x64
-          make build-doc DOCS_CNAME=fluentdocs.pyansys.com
+        run: make build-doc DOCS_CNAME=fluentdocs.pyansys.com
         env:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
       - name: Install again after codegen
         run: |
           rm -rf dist
-          make install > /dev/null
+          make install
 
       - name: Cache examples
         uses: actions/cache@v3
@@ -205,7 +205,11 @@ jobs:
             Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}
 
       - name: Build Documentation
-        run: make build-doc DOCS_CNAME=fluentdocs.pyansys.com
+        run: |
+          ls -al src/ansys/fluent/core/solver
+          which python
+          ls -alR /home/ansys/actions-runner/_work/_tool/Python/3.9.12/x64
+          make build-doc DOCS_CNAME=fluentdocs.pyansys.com
         env:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
     runs-on: [self-hosted, pyfluent]
     strategy:
       matrix:
-        image-tag: [v22.2.0, v23.1.0]
+        image-tag: [v22.2.0]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: [self-hosted, pyfluent]
     strategy:
       matrix:
-        image-tag: [v22.2.0]
+        image-tag: [v22.2.0, v23.1.0]
 
     steps:
       - uses: actions/checkout@v3
@@ -64,6 +64,7 @@ jobs:
           FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
 
       - name: Deploy
+        if: matrix.image-tag == 'v22.2.0'
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           repository-name: pyansys/pyfluent-dev-docs

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ style:
 install:
 	@pip install -r requirements/requirements_build.txt
 	@python -m build
-	@pip install dist/*.whl
+	@pip install -q --force-reinstall dist/*.whl
 
 version-info:
 	@bash -c "date -u +'Build date: %B %d, %Y %H:%M UTC ShaID: <id>' | xargs -I date sed -i 's/_VERSION_INFO = .*/_VERSION_INFO = \"date\"/g' src/ansys/fluent/core/__init__.py"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ style:
 install:
 	@pip install -r requirements/requirements_build.txt
 	@python -m build
-	@pip install -q dist/*.whl
+	@pip install dist/*.whl
 
 version-info:
 	@bash -c "date -u +'Build date: %B %d, %Y %H:%M UTC ShaID: <id>' | xargs -I date sed -i 's/_VERSION_INFO = .*/_VERSION_INFO = \"date\"/g' src/ansys/fluent/core/__init__.py"


### PR DESCRIPTION
Elijah reported a couple doc build failures this afternoon:

https://github.com/pyansys/pyfluent/pull/680/checks
https://github.com/pyansys/pyfluent/pull/664/checks

The problem seemed to be that the 'ansys.fluent.core.settings' package was not properly installed into the Python environment at the build step 'Install again after codegen'.  At that point we've already installed the package during the previous step labelled 'Install PyFluent', but without the generated code, and pip does not seem to overwrite it with the updated wheel.   Setting up `make install` to force re-installation does the trick.

I thought what we had agreed about the 23.1 doc builds was that we should just be building it once a day in the nightly doc pipeline, so added it there and removed it from the PR pipeline.     The development documentation at `dev.fluentdoc.pyansys.com` is updated in that pipeline using  22.2.

The PR pipeline is still running the tests 2x with both 22.2 and 23.1, which doubles the testing time:

![image](https://user-images.githubusercontent.com/18702052/181660680-a46d615a-a814-4c0d-9350-c98d9856565a.png)

It might be prudent to move the 23.1 PR testing to an additional nightly build pipeline as well.