### PR TITLE
Disable flserver datamodel in Fluent

### DIFF
--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -70,6 +70,7 @@ def _get_subprocess_kwargs_for_fluent(env: Dict[str, Any]) -> Dict[str, Any]:
         kwargs.update(shell=True, start_new_session=True)
     fluent_env = os.environ.copy()
     fluent_env.update({k: str(v) for k, v in env.items()})
+    fluent_env["APP_LAUNCHED_FROM_CLIENT"] = "1"  # disables flserver datamodel
     kwargs.update(env=fluent_env)
     return kwargs
 


### PR DESCRIPTION
Reading cases with large no. of zones from PyFluent consumes too much time/memory as flserver datamodel is enabled in Fluent. Setting the env. var. `APP_LAUNCHED_FROM_CLIENT` (added for lbapp/gpuapp) in Fluent disables the flserver datamodel.