### PR TITLE
Provide users option to set fluent version

### DIFF
--- a/codegen/tuigen.py
+++ b/codegen/tuigen.py
@@ -100,7 +100,7 @@ def _copy_tui_help_xml_file():
 
         client = docker.from_env()
         container = client.containers.create(_FLUENT_IMAGE_NAME)
-        xml_source = f"/ansys_inc/v{FLUENT_VERSION.replace('.', '')}/commonfiles/help/en-us/fluent_gui_help/fluent_gui_help.xml"
+        xml_source = f"/ansys_inc/v{FLUENT_VERSION[0].replace('.', '')}/commonfiles/help/en-us/fluent_gui_help/fluent_gui_help.xml"
         is_linux = platform.system() == "Linux"
         subprocess.run(
             f"docker cp {container.name}:{xml_source} {_XML_HELP_FILE}", shell=is_linux
@@ -342,7 +342,7 @@ class TUIGenerator:
 
 def generate():
     # pyfluent.set_log_level("WARNING")
-    if FLUENT_VERSION > "22.2":
+    if FLUENT_VERSION[0] > "22.2":
         _copy_tui_help_xml_file()
     _populate_xml_helpstrings()
     TUIGenerator(meshing=True).generate()

--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -6,7 +6,13 @@ from typing import Any, Optional
 import appdirs
 
 from ansys.fluent.core._version import __version__  # noqa: F401
-from ansys.fluent.core.launcher.launcher import LaunchModes, launch_fluent  # noqa: F401
+from ansys.fluent.core.launcher.launcher import (  # noqa: F401
+    FluentVersion,
+    LaunchModes,
+    launch_fluent,
+    set_ansys_version,
+    set_fluent_path,
+)
 from ansys.fluent.core.session import BaseSession as Fluent  # noqa: F401
 from ansys.fluent.core.utils.logging import LOG
 

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -25,8 +25,39 @@ import ansys.platform.instancemanagement as pypim
 
 _THIS_DIR = os.path.dirname(__file__)
 _OPTIONS_FILE = os.path.join(_THIS_DIR, "fluent_launcher_options.json")
-FLUENT_VERSION = "22.2"
-PIM_FLUENT_PRODUCT_VERSION = FLUENT_VERSION.replace(".", "")
+FLUENT_VERSION = ["22.2"]
+PIM_FLUENT_PRODUCT_VERSION = FLUENT_VERSION[0].replace(".", "")
+FLUENT_EXE_PATH = []
+
+
+class FluentVersion(Enum):
+    """Contains the standard ansys / fluent release."""
+
+    version_22R2 = "22.2"
+    version_23R1 = "23.1"
+
+
+def set_fluent_path(fluent_exe_path: Union[str, Path]) -> None:
+    """Lets the user set the fluent installation path manually.
+
+    This supersedes the fluent path set in the environment variable
+    """
+    FLUENT_EXE_PATH.append(str(fluent_exe_path))
+
+
+def set_ansys_version(version: Union[str, float, FluentVersion]) -> None:
+    """Lets the user set the fluent version manually.
+
+    Only works if the provided ansys version is installed and the
+    environment variables are updated properly. This supersedes the
+    fluent path set in the environment variable
+    """
+    if type(version) == str:
+        FLUENT_VERSION[0] = version
+    elif type(version) == float:
+        FLUENT_VERSION[0] = str(version)
+    else:
+        FLUENT_VERSION[0] = version.value
 
 
 class LaunchModes(Enum):
@@ -62,7 +93,7 @@ def get_fluent_path() -> Path:
         path = os.environ["PYFLUENT_FLUENT_ROOT"]
         return Path(path)
     else:
-        path = os.environ["AWP_ROOT" + "".join(FLUENT_VERSION.split("."))]
+        path = os.environ["AWP_ROOT" + "".join(FLUENT_VERSION[0].split("."))]
         return Path(path) / "fluent"
 
 
@@ -315,7 +346,10 @@ def launch_fluent(
             )
         )
     if start_instance:
-        exe_path = _get_fluent_exe_path()
+        if FLUENT_EXE_PATH:
+            exe_path = FLUENT_EXE_PATH[0]
+        else:
+            exe_path = _get_fluent_exe_path()
         launch_string = exe_path
         launch_string += _build_fluent_launch_args_string(**argvals)
         if meshing_mode:

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -52,7 +52,7 @@ def set_fluent_path(fluent_exe_path: Union[str, Path]) -> None:
 
     This supersedes the fluent path set in the environment variable
     """
-    if Path(fluent_exe_path).exists() and str(fluent_exe_path).endswith("fluent.exe"):
+    if Path(fluent_exe_path).exists() and Path(fluent_exe_path).name == "fluent.exe":
         FLUENT_EXE_PATH.append(str(fluent_exe_path))
     else:
         raise RuntimeError(

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -52,7 +52,12 @@ def set_fluent_path(fluent_exe_path: Union[str, Path]) -> None:
 
     This supersedes the fluent path set in the environment variable
     """
-    FLUENT_EXE_PATH.append(str(fluent_exe_path))
+    if str(fluent_exe_path).endswith("fluent.exe"):
+        FLUENT_EXE_PATH.append(str(fluent_exe_path))
+    else:
+        raise RuntimeError(
+            f"The passed path '{fluent_exe_path}' does not contain a valid fluent executable file."
+        )
 
 
 def set_ansys_version(version: Union[str, float, FluentVersion]) -> None:

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -36,6 +36,16 @@ class FluentVersion(Enum):
     version_22R2 = "22.2"
     version_23R1 = "23.1"
 
+    @staticmethod
+    def get_version(version: str) -> "FluentVersion":
+        """Returns the available versions based on the version in string
+        format."""
+        for v in FluentVersion:
+            if version == v.value:
+                return v
+        else:
+            raise RuntimeError(f"The passed version '{version}' does not exist.")
+
 
 def set_fluent_path(fluent_exe_path: Union[str, Path]) -> None:
     """Lets the user set the fluent installation path manually.
@@ -52,11 +62,9 @@ def set_ansys_version(version: Union[str, float, FluentVersion]) -> None:
     environment variables are updated properly. This supersedes the
     fluent path set in the environment variable
     """
-    if type(version) == str:
-        FLUENT_VERSION[0] = version
-    elif type(version) == float:
-        FLUENT_VERSION[0] = str(version)
-    else:
+    if type(version) in [float, str]:
+        version = FluentVersion.get_version(str(version))
+    if version in FluentVersion or str(version) in FluentVersion.value:
         FLUENT_VERSION[0] = version.value
 
 

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -26,7 +26,7 @@ import ansys.platform.instancemanagement as pypim
 _THIS_DIR = os.path.dirname(__file__)
 _OPTIONS_FILE = os.path.join(_THIS_DIR, "fluent_launcher_options.json")
 FLUENT_VERSION = ["22.2"]
-PIM_FLUENT_PRODUCT_VERSION = FLUENT_VERSION[0].replace(".", "")
+PIM_FLUENT_PRODUCT_VERSION = [FLUENT_VERSION[0].replace(".", "")]
 FLUENT_EXE_PATH = []
 
 
@@ -52,7 +52,7 @@ def set_fluent_path(fluent_exe_path: Union[str, Path]) -> None:
 
     This supersedes the fluent path set in the environment variable
     """
-    if str(fluent_exe_path).endswith("fluent.exe"):
+    if Path(fluent_exe_path).exists() and str(fluent_exe_path).endswith("fluent.exe"):
         FLUENT_EXE_PATH.append(str(fluent_exe_path))
     else:
         raise RuntimeError(
@@ -71,6 +71,7 @@ def set_ansys_version(version: Union[str, float, FluentVersion]) -> None:
         version = FluentVersion.get_version(str(version))
     if version in FluentVersion or str(version) in FluentVersion.value:
         FLUENT_VERSION[0] = version.value
+        PIM_FLUENT_PRODUCT_VERSION[0] = FLUENT_VERSION[0].replace(".", "")
 
 
 class LaunchModes(Enum):
@@ -409,7 +410,7 @@ def launch_fluent(
                 "Starting Fluent remotely. The startup configuration will be ignored."
             )
             return launch_remote_fluent(
-                product_version=PIM_FLUENT_PRODUCT_VERSION,
+                product_version=PIM_FLUENT_PRODUCT_VERSION[0],
                 cleanup_on_exit=cleanup_on_exit,
                 meshing_mode=meshing_mode,
                 dimensionality=version,

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,7 +1,7 @@
 import pytest
 
 import ansys.fluent.core as pyfluent
-from ansys.fluent.core.launcher.launcher import FLUENT_EXE_PATH, FLUENT_VERSION
+from ansys.fluent.core.launcher.launcher import FLUENT_VERSION
 
 
 def test_manual_fluent_version_setting():
@@ -22,10 +22,6 @@ def test_manual_fluent_version_setting():
 
 def test_manual_fluent_path_setting():
     """Test case for setting up the path to fluent.exe via program"""
-    pyfluent.set_fluent_path("X:/dir_1/dir2/fluent.exe")
-    assert FLUENT_EXE_PATH[0] == "X:/dir_1/dir2/fluent.exe"
-
-    # fluent.exe does not exist
     with pytest.raises(RuntimeError):
         pyfluent.set_fluent_path("X:/dir_1/dir2/xxx.exe")
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,0 +1,33 @@
+import pytest
+
+import ansys.fluent.core as pyfluent
+from ansys.fluent.core.launcher.launcher import FLUENT_EXE_PATH, FLUENT_VERSION
+
+
+def test_manual_fluent_version_setting():
+    """Test case for setting up the Ansys / Fluent version via program"""
+    pyfluent.set_ansys_version("23.1")
+    assert FLUENT_VERSION[0] == "23.1"
+
+    pyfluent.set_ansys_version(22.2)
+    assert FLUENT_VERSION[0] == "22.2"
+
+    pyfluent.set_ansys_version(version=pyfluent.FluentVersion.version_23R1)
+    assert FLUENT_VERSION[0] == "23.1"
+
+    # version does not exist
+    with pytest.raises(RuntimeError):
+        pyfluent.set_ansys_version(22.1)
+
+
+def test_manual_fluent_path_setting():
+    """Test case for setting up the path to fluent.exe via program"""
+    pyfluent.set_fluent_path("X:/dir_1/dir2/fluent.exe")
+    assert FLUENT_EXE_PATH[0] == "X:/dir_1/dir2/fluent.exe"
+
+    # fluent.exe does not exist
+    with pytest.raises(RuntimeError):
+        pyfluent.set_fluent_path("X:/dir_1/dir2/xxx.exe")
+
+    with pytest.raises(RuntimeError):
+        pyfluent.set_fluent_path("X:/dir_1/dir2/fluent.bat")

--- a/tests/test_launcher_remote.py
+++ b/tests/test_launcher_remote.py
@@ -48,7 +48,7 @@ def test_launch_remote_instance(monkeypatch, new_solver_session):
     assert mock_is_configured.called
     assert mock_connect.called
     mock_client.create_instance.assert_called_with(
-        "fluent-3ddp", product_version=launcher.PIM_FLUENT_PRODUCT_VERSION
+        "fluent-3ddp", product_version=launcher.PIM_FLUENT_PRODUCT_VERSION[0]
     )
     assert mock_instance.wait_for_ready.called
     mock_instance.build_grpc_channel.assert_called_with()


### PR DESCRIPTION
Users / Developers will have option to either provide the fluent.exe file path or set the Ansys version manually.

Sample use case:
```
1. 
>>> pyfluent.set_ansys_version(version=pyfluent.FluentVersion.version_23R1)
>>> meshing = pyfluent.launch_fluent(precision="double", processor_count=2, mode="meshing")
2.
>>> pyfluent.set_fluent_path("---path---\fluent.exe")  # provide path in form of string or pathlib.Path
>>> solver = pyfluent.launch_fluent(precision="double", processor_count=2, mode="solver")
```
3.
In a certain case where both "set_ansys_version()" and "set_fluent_path()" are used together, then the path set to fluent.exe will have precedence.