### PR TITLE
Feat/mwf

### DIFF
--- a/codegen/allapigen.py
+++ b/codegen/allapigen.py
@@ -5,8 +5,6 @@ import tuigen
 
 if __name__ == "__main__":
     print_fluent_version.generate()
-    for mod in (tuigen, datamodelgen, settingsgen):
-        try:
-            mod.generate()
-        except BaseException as ex:
-            print("skipping generation of", str(mod), str(ex))
+    tuigen.generate()
+    datamodelgen.generate()
+    settingsgen.generate()

--- a/codegen/allapigen.py
+++ b/codegen/allapigen.py
@@ -5,6 +5,8 @@ import tuigen
 
 if __name__ == "__main__":
     print_fluent_version.generate()
-    tuigen.generate()
-    datamodelgen.generate()
-    settingsgen.generate()
+    for mod in (tuigen, datamodelgen, settingsgen):
+        try:
+            mod.generate()
+        except BaseException as ex:
+            print("skipping generation of", str(mod), str(ex))

--- a/codegen/datamodelgen.py
+++ b/codegen/datamodelgen.py
@@ -5,7 +5,7 @@ import shutil
 from typing import Any, Dict
 
 from ansys.api.fluent.v0 import datamodel_se_pb2 as DataModelProtoModule
-from ansys.fluent.core.session import BaseSession as Session
+from ansys.fluent.core.session import _BaseSession as Session
 
 _THIS_DIR = Path(__file__).parent
 

--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -13,7 +13,7 @@ from ansys.fluent.core.launcher.launcher import (  # noqa: F401
     set_ansys_version,
     set_fluent_path,
 )
-from ansys.fluent.core.session import BaseSession as Fluent  # noqa: F401
+from ansys.fluent.core.session import _BaseSession as Fluent  # noqa: F401
 from ansys.fluent.core.utils.logging import LOG
 
 _VERSION_INFO = None

--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -1,0 +1,273 @@
+from ctypes import c_int, sizeof
+import itertools
+import os
+import threading
+from typing import Callable, List, Optional, Tuple
+import weakref
+
+import grpc
+
+from ansys.fluent.core.services.datamodel_se import (
+    DatamodelService as DatamodelService_SE,
+)
+from ansys.fluent.core.services.datamodel_tui import (
+    DatamodelService as DatamodelService_TUI,
+)
+from ansys.fluent.core.services.events import EventsService
+from ansys.fluent.core.services.field_data import FieldData, FieldDataService, FieldInfo
+from ansys.fluent.core.services.health_check import HealthCheckService
+from ansys.fluent.core.services.monitor import MonitorsService
+from ansys.fluent.core.services.scheme_eval import SchemeEval, SchemeEvalService
+from ansys.fluent.core.services.settings import SettingsService
+from ansys.fluent.core.services.transcript import TranscriptService
+from ansys.fluent.core.solver.events_manager import EventsManager
+from ansys.fluent.core.solver.monitors_manager import MonitorsManager
+
+
+def _get_max_c_int_limit() -> int:
+    """Get the maximum limit of a C int.
+
+    Returns
+    -------
+    int
+        The maximum limit of a C int
+    """
+    return 2 ** (sizeof(c_int) * 8 - 1) - 1
+
+
+class MonitorThread(threading.Thread):
+    """A class used for monitoring a Fluent session.
+
+    Daemon thread which will ensure cleanup of session objects, shutdown of
+    non-deamon threads etc.
+
+    Attributes
+    ----------
+    cbs : List[Callable]
+        Cleanup/shutdown functions
+    """
+
+    def __init__(self):
+        super().__init__(daemon=True)
+        self.cbs: List[Callable] = []
+
+    def run(self) -> None:
+        main_thread = threading.main_thread()
+        main_thread.join()
+        for cb in self.cbs:
+            cb()
+
+
+class _FluentConnection:
+    """Encapsulates a Fluent connection.
+
+    Methods
+    -------
+    start_transcript()
+        Start streaming of Fluent transcript
+
+    stop_transcript()
+        Stop streaming of Fluent transcript
+
+    check_health()
+        Check health of Fluent connection
+
+    exit()
+        Close the Fluent connection and exit Fluent.
+    """
+
+    _on_exit_cbs: List[Callable] = []
+    _id_iter = itertools.count()
+    _monitor_thread: Optional[MonitorThread] = None
+
+    def __init__(
+        self,
+        ip: str = None,
+        port: int = None,
+        password: str = None,
+        channel: grpc.Channel = None,
+        cleanup_on_exit: bool = True,
+        start_transcript: bool = True,
+        remote_instance=None,
+    ):
+        """Instantiate a Session.
+
+        Parameters
+        ----------
+        ip : str, optional
+            IP address to connect to existing Fluent instance. Used only
+            when ``channel`` is ``None``.  Defaults to ``"127.0.0.1"``
+            and can also be set by the environment variable
+            ``PYFLUENT_FLUENT_IP=<ip>``.
+        port : int, optional
+            Port to connect to existing Fluent instance. Used only
+            when ``channel`` is ``None``.  Defaults value can be set by
+            the environment variable ``PYFLUENT_FLUENT_PORT=<port>``.
+        password : str, optional
+            Password to connect to existing Fluent instance.
+        channel : grpc.Channel, optional
+            Grpc channel to use to connect to existing Fluent instance.
+            ip and port arguments will be ignored when channel is
+            specified.
+        cleanup_on_exit : bool, optional
+            When True, the connected Fluent session will be shut down
+            when PyFluent is exited or exit() is called on the session
+            instance, by default True.
+        start_transcript : bool, optional
+            The Fluent transcript is started in the client only when
+            start_transcript is True. It can be started and stopped
+            subsequently via method calls on the Session object.
+        remote_instance : ansys.platform.instancemanagement.Instance
+            The corresponding remote instance when Fluent is launched through
+            PyPIM. This instance will be deleted when calling
+            ``Session.exit()``.
+        """
+        self._channel_str = None
+        if channel is not None:
+            self._channel = channel
+        else:
+            if not ip:
+                ip = os.getenv("PYFLUENT_FLUENT_IP", "127.0.0.1")
+            if not port:
+                port = os.getenv("PYFLUENT_FLUENT_PORT")
+            self._channel_str = f"{ip}:{port}"
+            if not port:
+                raise ValueError(
+                    "The port to connect to Fluent session is not provided."
+                )
+            # Same maximum message length is used in the server
+            max_message_length = _get_max_c_int_limit()
+            self._channel = grpc.insecure_channel(
+                f"{ip}:{port}",
+                options=[
+                    ("grpc.max_send_message_length", max_message_length),
+                    ("grpc.max_receive_message_length", max_message_length),
+                ],
+            )
+        self._metadata: List[Tuple[str, str]] = (
+            [("password", password)] if password else []
+        )
+        self._id = f"session-{next(_FluentConnection._id_iter)}"
+
+        if not _FluentConnection._monitor_thread:
+            _FluentConnection._monitor_thread = MonitorThread()
+            _FluentConnection._monitor_thread.start()
+
+        self._transcript_service = TranscriptService(self._channel, self._metadata)
+        self._transcript_thread: Optional[threading.Thread] = None
+
+        self._events_service = EventsService(self._channel, self._metadata)
+        self.events_manager = EventsManager(self._id, self._events_service)
+
+        self._monitors_service = MonitorsService(self._channel, self._metadata)
+        self.monitors_manager = MonitorsManager(self._id, self._monitors_service)
+
+        self.events_manager.register_callback(
+            "InitializedEvent", self.monitors_manager.refresh
+        )
+        self.events_manager.register_callback(
+            "DataReadEvent", self.monitors_manager.refresh
+        )
+        self.events_manager.start()
+        self.datamodel_service_tui = DatamodelService_TUI(self._channel, self._metadata)
+        self.datamodel_service_se = DatamodelService_SE(self._channel, self._metadata)
+        self.settings_service = SettingsService(self._channel, self._metadata)
+
+        self._field_data_service = FieldDataService(self._channel, self._metadata)
+        self.field_info = FieldInfo(self._field_data_service)
+        self.field_data = FieldData(self._field_data_service, self.field_info)
+
+        self._health_check_service = HealthCheckService(self._channel, self._metadata)
+
+        self._scheme_eval_service = SchemeEvalService(self._channel, self._metadata)
+        self.scheme_eval = SchemeEval(self._scheme_eval_service)
+
+        self._cleanup_on_exit = cleanup_on_exit
+        self._start_transcript = start_transcript
+
+        if start_transcript:
+            self.start_transcript()
+
+        self._remote_instance = remote_instance
+
+        self._finalizer = weakref.finalize(
+            self,
+            _FluentConnection._exit,
+            self._channel,
+            self._cleanup_on_exit,
+            self.scheme_eval,
+            self._transcript_service,
+            self.events_manager,
+            self._remote_instance,
+        )
+        _FluentConnection._monitor_thread.cbs.append(self._finalizer)
+
+    @property
+    def id(self) -> str:
+        """Return the session id."""
+        return self._id
+
+    @staticmethod
+    def _print_transcript(transcript: str):
+        print(transcript)
+
+    @staticmethod
+    def _process_transcript(transcript_service):
+        responses = transcript_service.begin_streaming()
+        transcript = ""
+        while True:
+            try:
+                response = next(responses)
+                transcript += response.transcript
+                if transcript[-1] == "\n":
+                    _FluentConnection._print_transcript(transcript[0:-1])
+                    transcript = ""
+            except StopIteration:
+                break
+
+    def start_transcript(self) -> None:
+        """Start streaming of Fluent transcript."""
+        self._transcript_thread = threading.Thread(
+            target=_FluentConnection._process_transcript,
+            args=(self._transcript_service,),
+        )
+
+        self._transcript_thread.start()
+
+    def stop_transcript(self) -> None:
+        """Stop streaming of Fluent transcript."""
+        self._transcript_service.end_streaming()
+
+    def check_health(self) -> str:
+        """Check health of Fluent connection."""
+        if self._channel:
+            try:
+                return self._health_check_service.check_health()
+            except Exception:
+                return HealthCheckService.Status.NOT_SERVING.name
+        else:
+            return HealthCheckService.Status.NOT_SERVING.name
+
+    def exit(self) -> None:
+        """Close the Fluent connection and exit Fluent."""
+        self._finalizer()
+
+    @staticmethod
+    def _exit(
+        channel,
+        cleanup_on_exit,
+        scheme_eval,
+        transcript_service,
+        events_manager,
+        remote_instance,
+    ) -> None:
+        if channel:
+            if cleanup_on_exit:
+                scheme_eval.exec(("(exit-server)",))
+            transcript_service.end_streaming()
+            events_manager.stop()
+            channel.close()
+            channel = None
+
+        if remote_instance:
+            remote_instance.delete()

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -14,6 +14,7 @@ import tempfile
 import time
 from typing import Any, Dict, Union
 
+from ansys.fluent.core.fluent_connection import _FluentConnection
 from ansys.fluent.core.launcher.fluent_container import start_fluent_container
 from ansys.fluent.core.session import BaseSession, Session
 from ansys.fluent.core.session_meshing import Meshing
@@ -428,16 +429,20 @@ def launch_fluent(
                 pyfluent.EXAMPLES_PATH, pyfluent.EXAMPLES_PATH, args
             )
             return new_session(
-                port=port,
-                cleanup_on_exit=cleanup_on_exit,
-                start_transcript=start_transcript,
+                _FluentConnection(
+                    port=port,
+                    cleanup_on_exit=cleanup_on_exit,
+                    start_transcript=start_transcript,
+                )
             )
         else:
             ip = argvals.get("ip", None)
             port = argvals.get("port", None)
             return new_session(
-                ip=ip,
-                port=port,
-                cleanup_on_exit=cleanup_on_exit,
-                start_transcript=start_transcript,
+                _FluentConnection(
+                    ip=ip,
+                    port=port,
+                    cleanup_on_exit=cleanup_on_exit,
+                    start_transcript=start_transcript,
+                )
             )

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, Union
 
 from ansys.fluent.core.fluent_connection import _FluentConnection
 from ansys.fluent.core.launcher.fluent_container import start_fluent_container
-from ansys.fluent.core.session import BaseSession, Session
+from ansys.fluent.core.session import Session, _BaseSession
 from ansys.fluent.core.session_meshing import Meshing
 from ansys.fluent.core.session_pure_meshing import PureMeshing
 from ansys.fluent.core.session_solver import Solver
@@ -240,8 +240,10 @@ def launch_remote_fluent(
     instance.wait_for_ready()
     # nb pymapdl sets max msg len here:
     channel = instance.build_grpc_channel()
-    return BaseSession(
-        channel=channel, cleanup_on_exit=cleanup_on_exit, remote_instance=instance
+    return _BaseSession(
+        fluent_connection=_FluentConnection(
+            channel=channel, cleanup_on_exit=cleanup_on_exit, remote_instance=instance
+        )
     )
 
 
@@ -263,7 +265,7 @@ def launch_fluent(
     case_filepath: str = None,
     meshing_mode: bool = None,
     mode: Union[LaunchModes, str, None] = None,
-) -> Union[BaseSession, Session]:
+) -> Union[_BaseSession, Session]:
     """Launch Fluent locally in server mode or connect to a running Fluent
     server instance.
 
@@ -439,7 +441,7 @@ def launch_fluent(
             ip = argvals.get("ip", None)
             port = argvals.get("port", None)
             return new_session(
-                _FluentConnection(
+                fluent_connection=_FluentConnection(
                     ip=ip,
                     port=port,
                     cleanup_on_exit=cleanup_on_exit,

--- a/src/ansys/fluent/core/meshing/workflow.py
+++ b/src/ansys/fluent/core/meshing/workflow.py
@@ -44,6 +44,10 @@ class MeshingWorkflow:
             self._cmd = None
             self.Arguments = MeshingWorkflow.Task.Args(self)
 
+        @property
+        def CommandArguments(self):
+            return self._refreshed_command()
+
         def get_command_argument_attribute_value(self, attribute_sub_path: str) -> Any:
             cmd = self._refreshed_command()
             return cmd.get_attrib_value(attribute_sub_path)

--- a/src/ansys/fluent/core/meshing/workflow.py
+++ b/src/ansys/fluent/core/meshing/workflow.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from ansys.fluent.core.services.datamodel_se import PyCallableStateObject
 
 
@@ -25,8 +27,15 @@ class MeshingWorkflow:
             def __getattr__(self, attr):
                 return getattr(self._args, attr)
 
-            def get_expanded_state(self):
-                return self._task.get_expanded_arg_state()
+            def get_command_argument_state(self) -> Any:
+                return self._task.get_command_argument_state()
+
+            def get_command_argument_attribute_value(
+                self, attribute_sub_path: str
+            ) -> Any:
+                return self._task.get_command_argument_attribute_value(
+                    attribute_sub_path
+                )
 
         def __init__(self, meshing, name):
             self._workflow = meshing._workflow
@@ -35,11 +44,18 @@ class MeshingWorkflow:
             self._cmd = None
             self.Arguments = MeshingWorkflow.Task.Args(self)
 
-        def get_expanded_arg_state(self):
+        def get_command_argument_attribute_value(self, attribute_sub_path: str) -> Any:
+            cmd = self._refreshed_command()
+            return cmd.get_attrib_value(attribute_sub_path)
+
+        def get_command_argument_state(self) -> Any:
+            return self._refreshed_command().get_state()
+
+        def _refreshed_command(self):
             task_arg_state = self.Arguments.get_state()
             cmd = self._command()
             cmd.set_state(task_arg_state)
-            return cmd.get_state()
+            return cmd
 
         def _command(self):
             if not self._cmd:

--- a/src/ansys/fluent/core/meshing/workflow.py
+++ b/src/ansys/fluent/core/meshing/workflow.py
@@ -49,9 +49,9 @@ class MeshingWorkflow:
         def __getattr__(self, attr):
             return getattr(self._task, attr)
 
-    def __init__(self, meshing):
-        self._workflow = meshing.workflow
-        self._meshing = meshing.meshing
+    def __init__(self, workflow, meshing):
+        self._workflow = workflow
+        self._meshing = meshing
 
     def task(self, name):
         return MeshingWorkflow.Task(self, name)

--- a/src/ansys/fluent/core/meshing/workflow.py
+++ b/src/ansys/fluent/core/meshing/workflow.py
@@ -1,0 +1,63 @@
+
+
+def new_command_for_task(task, meshing):
+
+    class NewCommandError(Exception):
+        def __init__(self, task_name):
+            super().__init__(
+                f"Could not create command for meshing task {task_name}")
+
+
+    task_cmd_name = task.CommandName()
+    cmd_creator = getattr(meshing, task_cmd_name)
+    if cmd_creator:
+        new_cmd = cmd_creator.new()
+        if new_cmd:
+            return new_cmd
+    raise NewCommandError(task._name_())
+
+
+class MeshingWorkflow:
+
+    class Task:
+
+        class Arguments:
+
+            def __init__(self, task):
+                self._task = task
+                self._args = task.Arguments
+                
+            def __getattr__(self, attr):
+                return getattr(self._args, attr)
+
+            def get_expanded_state(self):
+                return self._task.get_expanded_arg_state()
+
+
+        def __init__(self, meshing, name):
+            self._workflow = meshing._workflow
+            self._meshing = meshing._meshing
+            self._task = self._workflow.TaskObject[name]
+            self._cmd = None
+
+        def get_expanded_arg_state(self):
+            return self._command().get_state()
+
+        def _command(self):
+            if not self._cmd:
+                self._cmd = new_command_for_task(self._task, self._meshing)
+            return self._cmd
+
+        def __getattr__(self, attr):
+            return getattr(self._task, attr)
+
+
+    def __init__(self, meshing):
+        self._workflow = meshing.workflow
+        self._meshing = meshing.meshing
+
+    def task(self, name):
+        return MeshingWorkflow.Task(self, name)
+    
+    def __getattr__(self, attr):
+        return getattr(self._workflow, attr)

--- a/src/ansys/fluent/core/meshing/workflow.py
+++ b/src/ansys/fluent/core/meshing/workflow.py
@@ -17,20 +17,11 @@ def _new_command_for_task(task, meshing):
 
 class MeshingWorkflow:
     class Task(PyCallableStateObject):
-        class Args(PyCallableStateObject):
-            def __init__(self, task):
-                self._task = task
-                self._args = task.Arguments
-
-            def __getattr__(self, attr):
-                return getattr(self._args, attr)
-
         def __init__(self, meshing, name):
             self._workflow = meshing._workflow
             self._meshing = meshing._meshing
             self._task = self._workflow.TaskObject[name]
             self._cmd = None
-            self.Arguments = MeshingWorkflow.Task.Args(self)
 
         @property
         def CommandArguments(self):
@@ -50,6 +41,11 @@ class MeshingWorkflow:
         def __getattr__(self, attr):
             return getattr(self._task, attr)
 
+        def __dir__(self):
+            return sorted(
+                set(list(self.__dict__.keys()) + dir(type(self)) + dir(self._task))
+            )
+
     def __init__(self, workflow, meshing):
         self._workflow = workflow
         self._meshing = meshing
@@ -59,3 +55,11 @@ class MeshingWorkflow:
 
     def __getattr__(self, attr):
         return getattr(self._workflow, attr)
+
+    def __dir__(self):
+        return sorted(
+            set(list(self.__dict__.keys()) + dir(type(self)) + dir(self._workflow))
+        )
+
+    def __call__(self):
+        return self._workflow()

--- a/src/ansys/fluent/core/meshing/workflow.py
+++ b/src/ansys/fluent/core/meshing/workflow.py
@@ -1,12 +1,7 @@
-
-
 def new_command_for_task(task, meshing):
-
     class NewCommandError(Exception):
         def __init__(self, task_name):
-            super().__init__(
-                f"Could not create command for meshing task {task_name}")
-
+            super().__init__(f"Could not create command for meshing task {task_name}")
 
     task_cmd_name = task.CommandName()
     cmd_creator = getattr(meshing, task_cmd_name)
@@ -18,27 +13,24 @@ def new_command_for_task(task, meshing):
 
 
 class MeshingWorkflow:
-
     class Task:
-
-        class Arguments:
-
+        class Args:
             def __init__(self, task):
                 self._task = task
                 self._args = task.Arguments
-                
+
             def __getattr__(self, attr):
                 return getattr(self._args, attr)
 
             def get_expanded_state(self):
                 return self._task.get_expanded_arg_state()
 
-
         def __init__(self, meshing, name):
             self._workflow = meshing._workflow
             self._meshing = meshing._meshing
             self._task = self._workflow.TaskObject[name]
             self._cmd = None
+            self.Arguments = MeshingWorkflow.Task.Args(self)
 
         def get_expanded_arg_state(self):
             return self._command().get_state()
@@ -51,13 +43,12 @@ class MeshingWorkflow:
         def __getattr__(self, attr):
             return getattr(self._task, attr)
 
-
     def __init__(self, meshing):
         self._workflow = meshing.workflow
         self._meshing = meshing.meshing
 
     def task(self, name):
         return MeshingWorkflow.Task(self, name)
-    
+
     def __getattr__(self, attr):
         return getattr(self._workflow, attr)

--- a/src/ansys/fluent/core/meshing/workflow.py
+++ b/src/ansys/fluent/core/meshing/workflow.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from ansys.fluent.core.services.datamodel_se import PyCallableStateObject
 
 
@@ -26,7 +24,6 @@ class MeshingWorkflow:
 
             def __getattr__(self, attr):
                 return getattr(self._args, attr)
-
 
         def __init__(self, meshing, name):
             self._workflow = meshing._workflow

--- a/src/ansys/fluent/core/meshing/workflow.py
+++ b/src/ansys/fluent/core/meshing/workflow.py
@@ -27,15 +27,6 @@ class MeshingWorkflow:
             def __getattr__(self, attr):
                 return getattr(self._args, attr)
 
-            def get_command_argument_state(self) -> Any:
-                return self._task.get_command_argument_state()
-
-            def get_command_argument_attribute_value(
-                self, attribute_sub_path: str
-            ) -> Any:
-                return self._task.get_command_argument_attribute_value(
-                    attribute_sub_path
-                )
 
         def __init__(self, meshing, name):
             self._workflow = meshing._workflow
@@ -47,13 +38,6 @@ class MeshingWorkflow:
         @property
         def CommandArguments(self):
             return self._refreshed_command()
-
-        def get_command_argument_attribute_value(self, attribute_sub_path: str) -> Any:
-            cmd = self._refreshed_command()
-            return cmd.get_attrib_value(attribute_sub_path)
-
-        def get_command_argument_state(self) -> Any:
-            return self._refreshed_command().get_state()
 
         def _refreshed_command(self):
             task_arg_state = self.Arguments.get_state()

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -204,6 +204,7 @@ def _convert_path_to_se_path(path: Path) -> str:
     return se_path
 
 
+<<<<<<< HEAD
 class PyCallableStateObject:
     """Any object which can be called to get its state.
 
@@ -218,11 +219,19 @@ class PyCallableStateObject:
 
 
 class PyBasicStateContainer(PyCallableStateObject):
+=======
+class PyBasicStateContainer:
+>>>>>>> 52d87a3 (got the command server -> client)
     """Object class using StateEngine based DatamodelService as backend. Use
     this class instead of directly calling DatamodelService's method.
 
     Methods
     -------
+<<<<<<< HEAD
+=======
+    __call__()
+        Get state of the current object
+>>>>>>> 52d87a3 (got the command server -> client)
     get_attrib_value(attrib)
         Get the attribute value of the current object.
     getAttribValue(attrib)
@@ -270,6 +279,19 @@ class PyBasicStateContainer(PyCallableStateObject):
 
     setState = set_state
 
+<<<<<<< HEAD
+=======
+    def __call__(self, *args, **kwds) -> Any:
+        """Get state of the current object.
+
+        Returns
+        -------
+        Any
+            state
+        """
+        return self.get_state()
+
+>>>>>>> 52d87a3 (got the command server -> client)
     def get_attrib_value(self, attrib: str) -> Any:
         """Get attribute value of the current object.
 
@@ -538,6 +560,7 @@ class PyCommand:
 
     def __init__(
 <<<<<<< HEAD
+<<<<<<< HEAD
         self, service: DatamodelService, rules: str, command: str, path: Path = None
 =======
         self,
@@ -547,11 +570,13 @@ class PyCommand:
         path: Path = None,
         id: str = None,
 >>>>>>> 111d575 (still got the command server -> client)
+=======
+        self, service: DatamodelService, rules: str, command: str, path: Path = None
+>>>>>>> 52d87a3 (got the command server -> client)
     ):
         self.service = service
         self.rules = rules
         self.command = command
-        self.id = id
         if path is None:
             self.path = []
         else:
@@ -617,6 +642,7 @@ class PyCommandArgumentsSubItem(PyCallableStateObject):
             pass
 =======
     def __getitem__(self, key: str):
+<<<<<<< HEAD
         assert self.id is None
         new_cmd = PyCommand(self.service, self.rules, self.command, self.path, key)
         return new_cmd
@@ -697,6 +723,19 @@ class PyCommandArguments(PyBasicStateContainer):
         response = self.service.get_attribute_value(request)
         return _convert_variant_to_value(response.result)
 >>>>>>> 111d575 (still got the command server -> client)
+=======
+        return PyCommandArguments(
+            self.service, self.rules, self.command, self.path.copy(), key
+        )
+
+
+class PyCommandArguments(PyBasicStateContainer):
+    def __init__(
+        self, service: DatamodelService, rules: str, command: str, path: Path, id: str
+    ):
+        super().__init__(service, rules, path)
+        self.path.append((command, id))
+>>>>>>> 52d87a3 (got the command server -> client)
 
 
 class PyMenuGeneric(PyMenu):

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -616,6 +616,8 @@ class PyCommandArgumentsSubItem(PyCallableStateObject):
         attrib_path = f"{self.name}/{attrib}"
         return self.parent.get_attrib_value(attrib_path)
 
+    getAttribValue = get_attrib_value
+
     def help(self) -> None:
         pass
 

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -198,15 +198,13 @@ def _convert_path_to_se_path(path: Path) -> str:
     return se_path
 
 
-class PyMenu:
-    """Object class using the StateEngine-based DatamodelService as the
-    backend. Use this class instead of directly calling the DatamodelService's
-    method.
+
+class PyBasicStateContainer:
+    """Object class using StateEngine based DatamodelService as backend. Use
+    this class instead of directly calling DatamodelService's method.
 
     Methods
     -------
-    __setattr__(name, value)
-        Set the state of the child object.
     __call__()
         Get the state of the current object.
     get_attrib_value(attrib)
@@ -224,30 +222,19 @@ class PyMenu:
     set_state(state)
         Set the state of the current object.
     setState(state)
-        Set the state of the current object. (This method is the
-        same as the set_state(state) method.)
-    update_dict(dict_state)
-        Update the state of the current object if the current object
-        is a dictionary in the data model. Otherwise, throw a ``RuntimeError``
-        (which is currently not showing up in Python). The update is
-        executed according to dict.update semantics.
-    updateDict(dict_state)
-        Update the state of the current object if the current object
-        is a dictionary in the data model. Otherwise, throw a ``RuntimeError``
-        (which is currently not showing up in Python). The update is
-        executed according to dict.update semantics. (This method is
-        the same as the update_dict(dict_state) method.)
+        Set state of the current object (same as set_state(state))
     """
 
-    docstring = None
-
     def __init__(self, service: DatamodelService, rules: str, path: Path = None):
+        super().__init__()
         self.service = service
         self.rules = rules
         if path is None:
             self.path = []
         else:
             self.path = path
+
+    docstring = None
 
     def get_state(self) -> Any:
         request = DataModelProtoModule.GetStateRequest()
@@ -266,30 +253,6 @@ class PyMenu:
         self.service.set_state(request)
 
     setState = set_state
-
-    def update_dict(self, dict_state: Dict[str, Any]) -> None:
-        request = DataModelProtoModule.UpdateDictRequest()
-        request.rules = self.rules
-        request.path = _convert_path_to_se_path(self.path)
-        _convert_value_to_variant(dict_state, request.dicttomerge)
-        self.service.update_dict(request)
-
-    updateDict = update_dict
-
-    def __setattr__(self, name: str, value: Any):
-        """Set state of the child object.
-
-        Parameters
-        ----------
-        name : str
-            Name of the child object.
-        value : Any
-            State of the child object.
-        """
-        if hasattr(self, name) and isinstance(getattr(self, name), PyMenu):
-            getattr(self, name).set_state(value)
-        else:
-            super().__setattr__(name, value)
 
     def __call__(self, *args, **kwds) -> Any:
         """Get state of the current object.
@@ -333,6 +296,55 @@ class PyMenu:
             response.member, response.member.WhichOneof("as")
         ).common.helpstring
         print(help_string)
+
+
+class PyMenu(PyBasicStateContainer):
+    """Object class using StateEngine based DatamodelService as backend. Use
+    this class instead of directly calling DatamodelService's method.
+
+    Methods
+    -------
+    __setattr__(name, value)
+        Set state of the child object
+    update_dict(dict_state)
+        Update the state of the current object if the current object
+        is a Dict in the data model, else throws RuntimeError
+        (currently not showing up in Python). Update is executed according
+        to dict.update semantics
+    updateDict(dict_state)
+        Update the state of the current object if the current object
+        is a Dict in the data model, else throws RuntimeError
+        (currently not showing up in Python). Update is executed according
+        to dict.update semantics (same as update_dict(dict_state))
+    create_command_arguments(command)
+    """
+
+    def __init__(self, service: DatamodelService, rules: str, path: Path = None):
+        super().__init__(service, rules, path)
+
+    def update_dict(self, dict_state: Dict[str, Any]) -> None:
+        request = DataModelProtoModule.UpdateDictRequest()
+        request.rules = self.rules
+        request.path = _convert_path_to_se_path(self.path)
+        _convert_value_to_variant(dict_state, request.dicttomerge)
+        self.service.update_dict(request)
+
+    updateDict = update_dict
+
+    def __setattr__(self, name: str, value: Any):
+        """Set state of the child object.
+
+        Parameters
+        ----------
+        name : str
+            child object name
+        value : Any
+            state
+        """
+        if hasattr(self, name) and isinstance(getattr(self, name), PyMenu):
+            getattr(self, name).set_state(value)
+        else:
+            super().__setattr__(name, value)
 
     def rename(self, new_name: str) -> None:
         """Rename the named object.
@@ -519,17 +531,11 @@ class PyCommand:
     docstring = None
 
     def __init__(
-        self,
-        service: DatamodelService,
-        rules: str,
-        command: str,
-        path: Path = None,
-        id: str = None,
+        self, service: DatamodelService, rules: str, command: str, path: Path = None
     ):
         self.service = service
         self.rules = rules
         self.command = command
-        self.id = id
         if path is None:
             self.path = []
         else:
@@ -564,50 +570,17 @@ class PyCommand:
         print(help_string)
 
     def __getitem__(self, key: str):
-        assert self.id is None
-        new_cmd = PyCommand(self.service, self.rules, self.command, self.path, key)
-        return new_cmd
+        return PyCommandArguments(
+            self.service, self.rules, self.command, self.path.copy(), key
+        )
 
-    def get_state(self) -> Any:
-        request = DataModelProtoModule.GetStateRequest()
-        request.rules = self.rules
-        path = self.path + [(self.command, self.id)]
-        request.path = _convert_path_to_se_path(path)
-        response = self.service.get_state(request)
-        return _convert_variant_to_value(response.state)
 
-    getState = get_state
-
-    def set_state(self, state: Any) -> None:
-        request = DataModelProtoModule.SetStateRequest()
-        request.rules = self.rules
-        path = self.path + [(self.command, self.id)]
-        request.path = _convert_path_to_se_path(path)
-        _convert_value_to_variant(state, request.state)
-        self.service.set_state(request)
-
-    setState = set_state
-
-    def get_attrib_value(self, attrib: str) -> Any:
-        """Get attribute value of the current object.
-
-        Parameters
-        ----------
-        attrib : str
-            attribute name
-
-        Returns
-        -------
-        Any
-            attribute value
-        """
-        request = DataModelProtoModule.GetAttributeValueRequest()
-        request.rules = self.rules
-        path = self.path + [(self.command, self.id)]
-        request.path = _convert_path_to_se_path(path)
-        request.attribute = attrib
-        response = self.service.get_attribute_value(request)
-        return _convert_variant_to_value(response.result)
+class PyCommandArguments(PyBasicStateContainer):
+    def __init__(
+        self, service: DatamodelService, rules: str, command: str, path: Path, id: str
+    ):
+        super().__init__(service, rules, path)
+        self.path.append((command, id))
 
 
 class PyMenuGeneric(PyMenu):

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -204,14 +204,25 @@ def _convert_path_to_se_path(path: Path) -> str:
     return se_path
 
 
-class PyBasicStateContainer:
-    """Object class using StateEngine based DatamodelService as backend. Use
-    this class instead of directly calling DatamodelService's method.
+class PyCallableStateObject:
+    """Any object which can be called to get its state.
 
     Methods
     -------
     __call__()
         Get the state of the current object.
+    """
+
+    def __call__(self, *args, **kwds) -> Any:
+        return self.get_state()
+
+
+class PyBasicStateContainer(PyCallableStateObject):
+    """Object class using StateEngine based DatamodelService as backend. Use
+    this class instead of directly calling DatamodelService's method.
+
+    Methods
+    -------
     get_attrib_value(attrib)
         Get the attribute value of the current object.
     getAttribValue(attrib)
@@ -258,16 +269,6 @@ class PyBasicStateContainer:
         self.service.set_state(request)
 
     setState = set_state
-
-    def __call__(self, *args, **kwds) -> Any:
-        """Get state of the current object.
-
-        Returns
-        -------
-        Any
-            State of the object.
-        """
-        return self.get_state()
 
     def get_attrib_value(self, attrib: str) -> Any:
         """Get attribute value of the current object.
@@ -581,7 +582,7 @@ class PyCommand:
         )
 
 
-class PyCommandArgumentsSubItem:
+class PyCommandArgumentsSubItem(PyCallableStateObject):
     def __init__(self, parent, name: str):
         self.parent = parent
         self.name = name
@@ -602,9 +603,6 @@ class PyCommandArgumentsSubItem:
         self.parent.set_state({self.name: state})
 
     setState = set_state
-
-    def __call__(self, *args, **kwds) -> Any:
-        return self.get_state()
 
     def get_attrib_value(self, attrib: str) -> Any:
         attrib_path = f"{self.name}/{attrib}"

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -204,7 +204,6 @@ def _convert_path_to_se_path(path: Path) -> str:
     return se_path
 
 
-
 class PyBasicStateContainer:
     """Object class using StateEngine based DatamodelService as backend. Use
     this class instead of directly calling DatamodelService's method.

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -537,11 +537,21 @@ class PyCommand:
     docstring = None
 
     def __init__(
+<<<<<<< HEAD
         self, service: DatamodelService, rules: str, command: str, path: Path = None
+=======
+        self,
+        service: DatamodelService,
+        rules: str,
+        command: str,
+        path: Path = None,
+        id: str = None,
+>>>>>>> 111d575 (still got the command server -> client)
     ):
         self.service = service
         self.rules = rules
         self.command = command
+        self.id = id
         if path is None:
             self.path = []
         else:
@@ -575,6 +585,7 @@ class PyCommand:
         ).common.helpstring
         print(help_string)
 
+<<<<<<< HEAD
     def _create_command_arguments(self):
         request = DataModelProtoModule.CreateCommandArgumentsRequest()
         request.rules = self.rules
@@ -604,15 +615,39 @@ class PyCommandArgumentsSubItem(PyCallableStateObject):
             return parent_state[self.name]
         except KeyError:
             pass
+=======
+    def __getitem__(self, key: str):
+        assert self.id is None
+        new_cmd = PyCommand(self.service, self.rules, self.command, self.path, key)
+        return new_cmd
+
+    def get_state(self) -> Any:
+        request = DataModelProtoModule.GetStateRequest()
+        request.rules = self.rules
+        path = self.path + [(self.command, self.id)]
+        request.path = _convert_path_to_se_path(path)
+        response = self.service.get_state(request)
+        return _convert_variant_to_value(response.state)
+>>>>>>> 111d575 (still got the command server -> client)
 
     getState = get_state
 
     def set_state(self, state: Any) -> None:
+<<<<<<< HEAD
         self.parent.set_state({self.name: state})
+=======
+        request = DataModelProtoModule.SetStateRequest()
+        request.rules = self.rules
+        path = self.path + [(self.command, self.id)]
+        request.path = _convert_path_to_se_path(path)
+        _convert_value_to_variant(state, request.state)
+        self.service.set_state(request)
+>>>>>>> 111d575 (still got the command server -> client)
 
     setState = set_state
 
     def get_attrib_value(self, attrib: str) -> Any:
+<<<<<<< HEAD
         attrib_path = f"{self.name}/{attrib}"
         return self.parent.get_attrib_value(attrib_path)
 
@@ -641,6 +676,27 @@ class PyCommandArguments(PyBasicStateContainer):
 
     def __getattr__(self, attr):
         return PyCommandArgumentsSubItem(self, attr)
+=======
+        """Get attribute value of the current object.
+
+        Parameters
+        ----------
+        attrib : str
+            attribute name
+
+        Returns
+        -------
+        Any
+            attribute value
+        """
+        request = DataModelProtoModule.GetAttributeValueRequest()
+        request.rules = self.rules
+        path = self.path + [(self.command, self.id)]
+        request.path = _convert_path_to_se_path(path)
+        request.attribute = attrib
+        response = self.service.get_attribute_value(request)
+        return _convert_variant_to_value(response.result)
+>>>>>>> 111d575 (still got the command server -> client)
 
 
 class PyMenuGeneric(PyMenu):

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -583,8 +583,8 @@ class PyCommand:
         print(help_string)
 
     def _create_command_arguments(self):
-        # pending the proto changes
         pass
+        # pending the proto changes
         """
         request = DataModelProtoModule.CreateCommandArgumentsRequest()
         request.rules = self.rules

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -367,6 +367,14 @@ class PyMenu(PyBasicStateContainer):
                 f"{self.__class__.__name__} is not a named object class."
             )
 
+    def create_command_arguments(self, command):
+        request = DataModelProtoModule.CreateCommandArgumentsRequest()
+        request.rules = self.rules
+        request.path = _convert_path_to_se_path(self.path)
+        request.command = command
+        response = self.service.create_command_arguments(request)
+        return response.commandid
+
 
 class PyNamedObjectContainer:
     """Container class using the StateEngine-based DatamodelService as the

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -729,6 +729,39 @@ class PyCommandArguments(PyBasicStateContainer):
         )
 
 
+class PyCommandArgumentsSubItem:
+    def __init__(self, parent, name: str):
+        self.parent = parent
+        self.name = name
+
+    def __getattr__(self, attr):
+        return PyCommandArgumentsSubItem(self, attr)
+
+    def get_state(self) -> Any:
+        parent_state = self.parent.get_state()
+        try:
+            return parent_state[self.name]
+        except KeyError:
+            pass
+
+    getState = get_state
+
+    def set_state(self, state: Any) -> None:
+        self.parent.set_state({self.name: state})
+
+    setState = set_state
+
+    def __call__(self, *args, **kwds) -> Any:
+        return self.get_state()
+
+    def get_attrib_value(self, attrib: str) -> Any:
+        attrib_path = f"{self.name}/{attrib}"
+        return self.parent.get_attrib_value(attrib_path)
+
+    def help(self) -> None:
+        pass
+
+
 class PyCommandArguments(PyBasicStateContainer):
     def __init__(
         self, service: DatamodelService, rules: str, command: str, path: Path, id: str
@@ -736,6 +769,9 @@ class PyCommandArguments(PyBasicStateContainer):
         super().__init__(service, rules, path)
         self.path.append((command, id))
 >>>>>>> 52d87a3 (got the command server -> client)
+
+    def __getattr__(self, attr):
+        return PyCommandArgumentsSubItem(self, attr)
 
 
 class PyMenuGeneric(PyMenu):

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -576,12 +576,48 @@ class PyCommand:
         )
 
 
+class PyCommandArgumentsSubItem:
+    def __init__(self, parent, name: str):
+        self.parent = parent
+        self.name = name
+
+    def __getattr__(self, attr):
+        return PyCommandArgumentsSubItem(self, attr)
+
+    def get_state(self) -> Any:
+        parent_state = self.parent.get_state()
+        try:
+            return parent_state[self.name]
+        except KeyError:
+            pass
+
+    getState = get_state
+
+    def set_state(self, state: Any) -> None:
+        self.parent.set_state({self.name: state})
+
+    setState = set_state
+
+    def __call__(self, *args, **kwds) -> Any:
+        return self.get_state()
+
+    def get_attrib_value(self, attrib: str) -> Any:
+        attrib_path = f"{self.name}/{attrib}"
+        return self.parent.get_attrib_value(attrib_path)
+
+    def help(self) -> None:
+        pass
+
+
 class PyCommandArguments(PyBasicStateContainer):
     def __init__(
         self, service: DatamodelService, rules: str, command: str, path: Path, id: str
     ):
         super().__init__(service, rules, path)
         self.path.append((command, id))
+
+    def __getattr__(self, attr):
+        return PyCommandArgumentsSubItem(self, attr)
 
 
 class PyMenuGeneric(PyMenu):

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -569,7 +569,7 @@ class PyCommand:
         response = self.service.create_command_arguments(request)
         return response.commandid
 
-    def instance(self):
+    def new(self):
         id = self._create_command_arguments()
         return PyCommandArguments(
             self.service, self.rules, self.command, self.path.copy(), id
@@ -615,6 +615,14 @@ class PyCommandArguments(PyBasicStateContainer):
     ):
         super().__init__(service, rules, path)
         self.path.append((command, id))
+
+    def __del__(self):
+        request = DataModelProtoModule.DeleteCommandArgumentsRequest()
+        request.rules = self.rules
+        request.path = _convert_path_to_se_path(self.path[:-1])
+        request.command = self.path[-1][0]
+        request.commandid = self.path[-1][1]
+        response = self.service.delete_command_arguments(request)
 
     def __getattr__(self, attr):
         return PyCommandArgumentsSubItem(self, attr)

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -389,14 +389,6 @@ class PyMenu(PyBasicStateContainer):
                 f"{self.__class__.__name__} is not a named object class."
             )
 
-    def create_command_arguments(self, command):
-        request = DataModelProtoModule.CreateCommandArgumentsRequest()
-        request.rules = self.rules
-        request.path = _convert_path_to_se_path(self.path)
-        request.command = command
-        response = self.service.create_command_arguments(request)
-        return response.commandid
-
 
 class PyNamedObjectContainer:
     """Container class using the StateEngine-based DatamodelService as the
@@ -611,6 +603,9 @@ class PyCommand:
         print(help_string)
 
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> 9dd010f (got the command server -> client)
     def _create_command_arguments(self):
         request = DataModelProtoModule.CreateCommandArgumentsRequest()
         request.rules = self.rules
@@ -619,6 +614,7 @@ class PyCommand:
         response = self.service.create_command_arguments(request)
         return response.commandid
 
+<<<<<<< HEAD
     def new(self):
         id = self._create_command_arguments()
         return PyCommandArguments(
@@ -724,8 +720,12 @@ class PyCommandArguments(PyBasicStateContainer):
         return _convert_variant_to_value(response.result)
 >>>>>>> 111d575 (still got the command server -> client)
 =======
+=======
+    def instance(self):
+        id = self._create_command_arguments()
+>>>>>>> 9dd010f (got the command server -> client)
         return PyCommandArguments(
-            self.service, self.rules, self.command, self.path.copy(), key
+            self.service, self.rules, self.command, self.path.copy(), id
         )
 
 

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -524,10 +524,12 @@ class PyCommand:
         rules: str,
         command: str,
         path: Path = None,
+        id: str = None,
     ):
         self.service = service
         self.rules = rules
         self.command = command
+        self.id = id
         if path is None:
             self.path = []
         else:
@@ -560,6 +562,52 @@ class PyCommand:
             response.member, response.member.WhichOneof("as")
         ).common.helpstring
         print(help_string)
+
+    def __getitem__(self, key: str):
+        assert self.id is None
+        new_cmd = PyCommand(self.service, self.rules, self.command, self.path, key)
+        return new_cmd
+
+    def get_state(self) -> Any:
+        request = DataModelProtoModule.GetStateRequest()
+        request.rules = self.rules
+        path = self.path + [(self.command, self.id)]
+        request.path = _convert_path_to_se_path(path)
+        response = self.service.get_state(request)
+        return _convert_variant_to_value(response.state)
+
+    getState = get_state
+
+    def set_state(self, state: Any) -> None:
+        request = DataModelProtoModule.SetStateRequest()
+        request.rules = self.rules
+        path = self.path + [(self.command, self.id)]
+        request.path = _convert_path_to_se_path(path)
+        _convert_value_to_variant(state, request.state)
+        self.service.set_state(request)
+
+    setState = set_state
+
+    def get_attrib_value(self, attrib: str) -> Any:
+        """Get attribute value of the current object.
+
+        Parameters
+        ----------
+        attrib : str
+            attribute name
+
+        Returns
+        -------
+        Any
+            attribute value
+        """
+        request = DataModelProtoModule.GetAttributeValueRequest()
+        request.rules = self.rules
+        path = self.path + [(self.command, self.id)]
+        request.path = _convert_path_to_se_path(path)
+        request.attribute = attrib
+        response = self.service.get_attribute_value(request)
+        return _convert_variant_to_value(response.result)
 
 
 class PyMenuGeneric(PyMenu):

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -111,6 +111,12 @@ class DatamodelService:
         return self.__stub.createCommandArguments(request, metadata=self.__metadata)
 
     @catch_grpc_error
+    def delete_command_arguments(
+        self, request: DataModelProtoModule.DeleteCommandArgumentsRequest
+    ) -> DataModelProtoModule.DeleteCommandArgumentsResponse:
+        return self.__stub.deleteCommandArguments(request, metadata=self.__metadata)
+
+    @catch_grpc_error
     def get_specs(
         self, request: DataModelProtoModule.GetSpecsRequest
     ) -> DataModelProtoModule.GetSpecsResponse:
@@ -622,7 +628,11 @@ class PyCommandArguments(PyBasicStateContainer):
         request.path = _convert_path_to_se_path(self.path[:-1])
         request.command = self.path[-1][0]
         request.commandid = self.path[-1][1]
-        response = self.service.delete_command_arguments(request)
+        try:
+            self.service.delete_command_arguments(request)
+        except ValueError:
+            # "Cannot invoke RPC on closed channel!"
+            pass
 
     def __getattr__(self, attr):
         return PyCommandArgumentsSubItem(self, attr)

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -361,14 +361,6 @@ class PyMenu(PyBasicStateContainer):
                 f"{self.__class__.__name__} is not a named object class."
             )
 
-    def create_command_arguments(self, command):
-        request = DataModelProtoModule.CreateCommandArgumentsRequest()
-        request.rules = self.rules
-        request.path = _convert_path_to_se_path(self.path)
-        request.command = command
-        response = self.service.create_command_arguments(request)
-        return response.commandid
-
 
 class PyNamedObjectContainer:
     """Container class using the StateEngine-based DatamodelService as the
@@ -569,9 +561,18 @@ class PyCommand:
         ).common.helpstring
         print(help_string)
 
-    def __getitem__(self, key: str):
+    def _create_command_arguments(self):
+        request = DataModelProtoModule.CreateCommandArgumentsRequest()
+        request.rules = self.rules
+        request.path = _convert_path_to_se_path(self.path)
+        request.command = self.command
+        response = self.service.create_command_arguments(request)
+        return response.commandid
+
+    def instance(self):
+        id = self._create_command_arguments()
         return PyCommandArguments(
-            self.service, self.rules, self.command, self.path.copy(), key
+            self.service, self.rules, self.command, self.path.copy(), id
         )
 
 

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -104,6 +104,8 @@ class DatamodelService:
     ) -> DataModelProtoModule.ExecuteCommandResponse:
         return self.__stub.executeCommand(request, metadata=self.__metadata)
 
+    # pending the proto changes
+    """
     @catch_grpc_error
     def create_command_arguments(
         self, request: DataModelProtoModule.CreateCommandArgumentsRequest
@@ -115,6 +117,7 @@ class DatamodelService:
         self, request: DataModelProtoModule.DeleteCommandArgumentsRequest
     ) -> DataModelProtoModule.DeleteCommandArgumentsResponse:
         return self.__stub.deleteCommandArguments(request, metadata=self.__metadata)
+    """
 
     @catch_grpc_error
     def get_specs(
@@ -368,12 +371,16 @@ class PyMenu(PyBasicStateContainer):
             )
 
     def create_command_arguments(self, command):
+        pass
+        # pending the proto changes
+        """
         request = DataModelProtoModule.CreateCommandArgumentsRequest()
         request.rules = self.rules
         request.path = _convert_path_to_se_path(self.path)
         request.command = command
         response = self.service.create_command_arguments(request)
         return response.commandid
+        """
 
 
 class PyNamedObjectContainer:
@@ -576,18 +583,26 @@ class PyCommand:
         print(help_string)
 
     def _create_command_arguments(self):
+        # pending the proto changes
+        pass
+        """
         request = DataModelProtoModule.CreateCommandArgumentsRequest()
         request.rules = self.rules
         request.path = _convert_path_to_se_path(self.path)
         request.command = self.command
         response = self.service.create_command_arguments(request)
         return response.commandid
+        """
 
     def new(self):
+        # pending the proto changes
+        pass
+        """
         id = self._create_command_arguments()
         return PyCommandArguments(
             self.service, self.rules, self.command, self.path.copy(), id
         )
+        """
 
 
 class PyCommandArgumentsSubItem(PyCallableStateObject):
@@ -630,6 +645,9 @@ class PyCommandArguments(PyBasicStateContainer):
         self.path.append((command, id))
 
     def __del__(self):
+        # pending the proto changes
+        pass
+        """
         request = DataModelProtoModule.DeleteCommandArgumentsRequest()
         request.rules = self.rules
         request.path = _convert_path_to_se_path(self.path[:-1])
@@ -640,6 +658,7 @@ class PyCommandArguments(PyBasicStateContainer):
         except ValueError:
             # "Cannot invoke RPC on closed channel!"
             pass
+        """
 
     def __getattr__(self, attr):
         return PyCommandArgumentsSubItem(self, attr)

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -105,6 +105,12 @@ class DatamodelService:
         return self.__stub.executeCommand(request, metadata=self.__metadata)
 
     @catch_grpc_error
+    def create_command_arguments(
+        self, request: DataModelProtoModule.CreateCommandArgumentsRequest
+    ) -> DataModelProtoModule.CreateCommandArgumentsResponse:
+        return self.__stub.createCommandArguments(request, metadata=self.__metadata)
+
+    @catch_grpc_error
     def get_specs(
         self, request: DataModelProtoModule.GetSpecsRequest
     ) -> DataModelProtoModule.GetSpecsResponse:
@@ -342,6 +348,14 @@ class PyMenu:
             raise RuntimeError(
                 f"{self.__class__.__name__} is not a named object class."
             )
+
+    def create_command_arguments(self, command):
+        request = DataModelProtoModule.CreateCommandArgumentsRequest()
+        request.rules = self.rules
+        request.path = _convert_path_to_se_path(self.path)
+        request.command = command
+        response = self.service.create_command_arguments(request)
+        return response.commandid
 
 
 class PyNamedObjectContainer:

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -204,7 +204,6 @@ def _convert_path_to_se_path(path: Path) -> str:
     return se_path
 
 
-<<<<<<< HEAD
 class PyCallableStateObject:
     """Any object which can be called to get its state.
 
@@ -219,19 +218,11 @@ class PyCallableStateObject:
 
 
 class PyBasicStateContainer(PyCallableStateObject):
-=======
-class PyBasicStateContainer:
->>>>>>> 52d87a3 (got the command server -> client)
     """Object class using StateEngine based DatamodelService as backend. Use
     this class instead of directly calling DatamodelService's method.
 
     Methods
     -------
-<<<<<<< HEAD
-=======
-    __call__()
-        Get state of the current object
->>>>>>> 52d87a3 (got the command server -> client)
     get_attrib_value(attrib)
         Get the attribute value of the current object.
     getAttribValue(attrib)
@@ -279,19 +270,6 @@ class PyBasicStateContainer:
 
     setState = set_state
 
-<<<<<<< HEAD
-=======
-    def __call__(self, *args, **kwds) -> Any:
-        """Get state of the current object.
-
-        Returns
-        -------
-        Any
-            state
-        """
-        return self.get_state()
-
->>>>>>> 52d87a3 (got the command server -> client)
     def get_attrib_value(self, attrib: str) -> Any:
         """Get attribute value of the current object.
 
@@ -388,6 +366,14 @@ class PyMenu(PyBasicStateContainer):
             raise RuntimeError(
                 f"{self.__class__.__name__} is not a named object class."
             )
+
+    def create_command_arguments(self, command):
+        request = DataModelProtoModule.CreateCommandArgumentsRequest()
+        request.rules = self.rules
+        request.path = _convert_path_to_se_path(self.path)
+        request.command = command
+        response = self.service.create_command_arguments(request)
+        return response.commandid
 
 
 class PyNamedObjectContainer:
@@ -551,20 +537,7 @@ class PyCommand:
     docstring = None
 
     def __init__(
-<<<<<<< HEAD
-<<<<<<< HEAD
         self, service: DatamodelService, rules: str, command: str, path: Path = None
-=======
-        self,
-        service: DatamodelService,
-        rules: str,
-        command: str,
-        path: Path = None,
-        id: str = None,
->>>>>>> 111d575 (still got the command server -> client)
-=======
-        self, service: DatamodelService, rules: str, command: str, path: Path = None
->>>>>>> 52d87a3 (got the command server -> client)
     ):
         self.service = service
         self.rules = rules
@@ -602,10 +575,6 @@ class PyCommand:
         ).common.helpstring
         print(help_string)
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> 9dd010f (got the command server -> client)
     def _create_command_arguments(self):
         request = DataModelProtoModule.CreateCommandArgumentsRequest()
         request.rules = self.rules
@@ -614,7 +583,6 @@ class PyCommand:
         response = self.service.create_command_arguments(request)
         return response.commandid
 
-<<<<<<< HEAD
     def new(self):
         id = self._create_command_arguments()
         return PyCommandArguments(
@@ -636,40 +604,15 @@ class PyCommandArgumentsSubItem(PyCallableStateObject):
             return parent_state[self.name]
         except KeyError:
             pass
-=======
-    def __getitem__(self, key: str):
-<<<<<<< HEAD
-        assert self.id is None
-        new_cmd = PyCommand(self.service, self.rules, self.command, self.path, key)
-        return new_cmd
-
-    def get_state(self) -> Any:
-        request = DataModelProtoModule.GetStateRequest()
-        request.rules = self.rules
-        path = self.path + [(self.command, self.id)]
-        request.path = _convert_path_to_se_path(path)
-        response = self.service.get_state(request)
-        return _convert_variant_to_value(response.state)
->>>>>>> 111d575 (still got the command server -> client)
 
     getState = get_state
 
     def set_state(self, state: Any) -> None:
-<<<<<<< HEAD
         self.parent.set_state({self.name: state})
-=======
-        request = DataModelProtoModule.SetStateRequest()
-        request.rules = self.rules
-        path = self.path + [(self.command, self.id)]
-        request.path = _convert_path_to_se_path(path)
-        _convert_value_to_variant(state, request.state)
-        self.service.set_state(request)
->>>>>>> 111d575 (still got the command server -> client)
 
     setState = set_state
 
     def get_attrib_value(self, attrib: str) -> Any:
-<<<<<<< HEAD
         attrib_path = f"{self.name}/{attrib}"
         return self.parent.get_attrib_value(attrib_path)
 
@@ -695,80 +638,6 @@ class PyCommandArguments(PyBasicStateContainer):
         except ValueError:
             # "Cannot invoke RPC on closed channel!"
             pass
-
-    def __getattr__(self, attr):
-        return PyCommandArgumentsSubItem(self, attr)
-=======
-        """Get attribute value of the current object.
-
-        Parameters
-        ----------
-        attrib : str
-            attribute name
-
-        Returns
-        -------
-        Any
-            attribute value
-        """
-        request = DataModelProtoModule.GetAttributeValueRequest()
-        request.rules = self.rules
-        path = self.path + [(self.command, self.id)]
-        request.path = _convert_path_to_se_path(path)
-        request.attribute = attrib
-        response = self.service.get_attribute_value(request)
-        return _convert_variant_to_value(response.result)
->>>>>>> 111d575 (still got the command server -> client)
-=======
-=======
-    def instance(self):
-        id = self._create_command_arguments()
->>>>>>> 9dd010f (got the command server -> client)
-        return PyCommandArguments(
-            self.service, self.rules, self.command, self.path.copy(), id
-        )
-
-
-class PyCommandArgumentsSubItem:
-    def __init__(self, parent, name: str):
-        self.parent = parent
-        self.name = name
-
-    def __getattr__(self, attr):
-        return PyCommandArgumentsSubItem(self, attr)
-
-    def get_state(self) -> Any:
-        parent_state = self.parent.get_state()
-        try:
-            return parent_state[self.name]
-        except KeyError:
-            pass
-
-    getState = get_state
-
-    def set_state(self, state: Any) -> None:
-        self.parent.set_state({self.name: state})
-
-    setState = set_state
-
-    def __call__(self, *args, **kwds) -> Any:
-        return self.get_state()
-
-    def get_attrib_value(self, attrib: str) -> Any:
-        attrib_path = f"{self.name}/{attrib}"
-        return self.parent.get_attrib_value(attrib_path)
-
-    def help(self) -> None:
-        pass
-
-
-class PyCommandArguments(PyBasicStateContainer):
-    def __init__(
-        self, service: DatamodelService, rules: str, command: str, path: Path, id: str
-    ):
-        super().__init__(service, rules, path)
-        self.path.append((command, id))
->>>>>>> 52d87a3 (got the command server -> client)
 
     def __getattr__(self, attr):
         return PyCommandArgumentsSubItem(self, attr)

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -136,6 +136,15 @@ class _BaseSession:
     def __getattr__(self, attr):
         return getattr(self.fluent_connection, attr)
 
+    def __dir__(self):
+        return sorted(
+            set(
+                list(self.__dict__.keys())
+                + dir(type(self))
+                + dir(self.fluent_connection)
+            )
+        )
+
 
 class Session:
     """Instantiates a Fluent connection. This is a deprecated class. This has
@@ -274,6 +283,15 @@ class Session:
 
     def __getattr__(self, attr):
         return getattr(self.fluent_connection, attr)
+
+    def __dir__(self):
+        return sorted(
+            set(
+                list(self.__dict__.keys())
+                + dir(type(self))
+                + dir(self.fluent_connection)
+            )
+        )
 
     class Solver:
         def __init__(

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -1,34 +1,19 @@
 """Module containing class encapsulating Fluent connection and the Base
 Session."""
-from ctypes import c_int, sizeof
-import itertools
-import os
-import threading
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any
 import warnings
-import weakref
 
 import grpc
 
-from ansys.fluent.core.services.datamodel_se import (
-    DatamodelService as DatamodelService_SE,
-)
+from ansys.fluent.core.fluent_connection import _FluentConnection
 from ansys.fluent.core.services.datamodel_tui import (
     DatamodelService as DatamodelService_TUI,
 )
 from ansys.fluent.core.services.datamodel_tui import TUIMenuGeneric
-from ansys.fluent.core.services.events import EventsService
-from ansys.fluent.core.services.field_data import FieldData, FieldDataService, FieldInfo
-from ansys.fluent.core.services.health_check import HealthCheckService
-from ansys.fluent.core.services.monitor import MonitorsService
-from ansys.fluent.core.services.scheme_eval import SchemeEval, SchemeEvalService
 from ansys.fluent.core.services.settings import SettingsService
-from ansys.fluent.core.services.transcript import TranscriptService
 from ansys.fluent.core.session_base_meshing import BaseMeshing
 from ansys.fluent.core.session_shared import _CODEGEN_MSG_TUI
-from ansys.fluent.core.solver.events_manager import EventsManager
 from ansys.fluent.core.solver.flobject import get_root as settings_get_root
-from ansys.fluent.core.solver.monitors_manager import MonitorsManager
 from ansys.fluent.core.utils.logging import LOG
 
 try:
@@ -45,255 +30,6 @@ def parse_server_info_file(filename: str):
     port = int(ip_and_port[1])
     password = lines[1].strip()
     return ip, port, password
-
-
-class MonitorThread(threading.Thread):
-    """A class used for monitoring a Fluent session.
-
-    Daemon thread which will ensure cleanup of session objects, shutdown of
-    non-deamon threads etc.
-
-    Attributes
-    ----------
-    cbs : List[Callable]
-        Cleanup/shutdown functions
-    """
-
-    def __init__(self):
-        super().__init__(daemon=True)
-        self.cbs: List[Callable] = []
-
-    def run(self) -> None:
-        main_thread = threading.main_thread()
-        main_thread.join()
-        for cb in self.cbs:
-            cb()
-
-
-def _get_max_c_int_limit() -> int:
-    """Get the maximum limit of a C int.
-
-    Returns
-    -------
-    int
-        The maximum limit of a C int
-    """
-    return 2 ** (sizeof(c_int) * 8 - 1) - 1
-
-
-class _FluentConnection:
-    """Encapsulates a Fluent connection.
-
-    Methods
-    -------
-    start_transcript()
-        Start streaming of Fluent transcript
-
-    stop_transcript()
-        Stop streaming of Fluent transcript
-
-    check_health()
-        Check health of Fluent connection
-
-    exit()
-        Close the Fluent connection and exit Fluent.
-    """
-
-    _on_exit_cbs: List[Callable] = []
-    _id_iter = itertools.count()
-    _monitor_thread: Optional[MonitorThread] = None
-
-    def __init__(
-        self,
-        ip: str = None,
-        port: int = None,
-        password: str = None,
-        channel: grpc.Channel = None,
-        cleanup_on_exit: bool = True,
-        start_transcript: bool = True,
-        remote_instance=None,
-    ):
-        """Instantiate a Session.
-
-        Parameters
-        ----------
-        ip : str, optional
-            IP address to connect to existing Fluent instance. Used only
-            when ``channel`` is ``None``.  Defaults to ``"127.0.0.1"``
-            and can also be set by the environment variable
-            ``PYFLUENT_FLUENT_IP=<ip>``.
-        port : int, optional
-            Port to connect to existing Fluent instance. Used only
-            when ``channel`` is ``None``.  Defaults value can be set by
-            the environment variable ``PYFLUENT_FLUENT_PORT=<port>``.
-        password : str, optional
-            Password to connect to existing Fluent instance.
-        channel : grpc.Channel, optional
-            Grpc channel to use to connect to existing Fluent instance.
-            ip and port arguments will be ignored when channel is
-            specified.
-        cleanup_on_exit : bool, optional
-            When True, the connected Fluent session will be shut down
-            when PyFluent is exited or exit() is called on the session
-            instance, by default True.
-        start_transcript : bool, optional
-            The Fluent transcript is started in the client only when
-            start_transcript is True. It can be started and stopped
-            subsequently via method calls on the Session object.
-        remote_instance : ansys.platform.instancemanagement.Instance
-            The corresponding remote instance when Fluent is launched through
-            PyPIM. This instance will be deleted when calling
-            ``Session.exit()``.
-        """
-        self._channel_str = None
-        if channel is not None:
-            self._channel = channel
-        else:
-            if not ip:
-                ip = os.getenv("PYFLUENT_FLUENT_IP", "127.0.0.1")
-            if not port:
-                port = os.getenv("PYFLUENT_FLUENT_PORT")
-            self._channel_str = f"{ip}:{port}"
-            if not port:
-                raise ValueError(
-                    "The port to connect to Fluent session is not provided."
-                )
-            # Same maximum message length is used in the server
-            max_message_length = _get_max_c_int_limit()
-            self._channel = grpc.insecure_channel(
-                f"{ip}:{port}",
-                options=[
-                    ("grpc.max_send_message_length", max_message_length),
-                    ("grpc.max_receive_message_length", max_message_length),
-                ],
-            )
-        self._metadata: List[Tuple[str, str]] = (
-            [("password", password)] if password else []
-        )
-        self._id = f"session-{next(_FluentConnection._id_iter)}"
-
-        if not _FluentConnection._monitor_thread:
-            _FluentConnection._monitor_thread = MonitorThread()
-            _FluentConnection._monitor_thread.start()
-
-        self._transcript_service = TranscriptService(self._channel, self._metadata)
-        self._transcript_thread: Optional[threading.Thread] = None
-
-        self._events_service = EventsService(self._channel, self._metadata)
-        self.events_manager = EventsManager(self._id, self._events_service)
-
-        self._monitors_service = MonitorsService(self._channel, self._metadata)
-        self.monitors_manager = MonitorsManager(self._id, self._monitors_service)
-
-        self.events_manager.register_callback(
-            "InitializedEvent", self.monitors_manager.refresh
-        )
-        self.events_manager.register_callback(
-            "DataReadEvent", self.monitors_manager.refresh
-        )
-        self.events_manager.start()
-        self.datamodel_service_tui = DatamodelService_TUI(self._channel, self._metadata)
-        self.datamodel_service_se = DatamodelService_SE(self._channel, self._metadata)
-        self.settings_service = SettingsService(self._channel, self._metadata)
-
-        self._field_data_service = FieldDataService(self._channel, self._metadata)
-        self.field_info = FieldInfo(self._field_data_service)
-        self.field_data = FieldData(self._field_data_service, self.field_info)
-
-        self._health_check_service = HealthCheckService(self._channel, self._metadata)
-
-        self._scheme_eval_service = SchemeEvalService(self._channel, self._metadata)
-        self.scheme_eval = SchemeEval(self._scheme_eval_service)
-
-        self._cleanup_on_exit = cleanup_on_exit
-        self._start_transcript = start_transcript
-
-        if start_transcript:
-            self.start_transcript()
-
-        self._remote_instance = remote_instance
-
-        self._finalizer = weakref.finalize(
-            self,
-            _FluentConnection._exit,
-            self._channel,
-            self._cleanup_on_exit,
-            self.scheme_eval,
-            self._transcript_service,
-            self.events_manager,
-            self._remote_instance,
-        )
-        _FluentConnection._monitor_thread.cbs.append(self._finalizer)
-
-    @property
-    def id(self) -> str:
-        """Return the session id."""
-        return self._id
-
-    @staticmethod
-    def _print_transcript(transcript: str):
-        print(transcript)
-
-    @staticmethod
-    def _process_transcript(transcript_service):
-        responses = transcript_service.begin_streaming()
-        transcript = ""
-        while True:
-            try:
-                response = next(responses)
-                transcript += response.transcript
-                if transcript[-1] == "\n":
-                    _FluentConnection._print_transcript(transcript[0:-1])
-                    transcript = ""
-            except StopIteration:
-                break
-
-    def start_transcript(self) -> None:
-        """Start streaming of Fluent transcript."""
-        self._transcript_thread = threading.Thread(
-            target=_FluentConnection._process_transcript,
-            args=(self._transcript_service,),
-        )
-
-        self._transcript_thread.start()
-
-    def stop_transcript(self) -> None:
-        """Stop streaming of Fluent transcript."""
-        self._transcript_service.end_streaming()
-
-    def check_health(self) -> str:
-        """Check health of Fluent connection."""
-        if self._channel:
-            try:
-                return self._health_check_service.check_health()
-            except Exception:
-                return HealthCheckService.Status.NOT_SERVING.name
-        else:
-            return HealthCheckService.Status.NOT_SERVING.name
-
-    def exit(self) -> None:
-        """Close the Fluent connection and exit Fluent."""
-        self._finalizer()
-
-    @staticmethod
-    def _exit(
-        channel,
-        cleanup_on_exit,
-        scheme_eval,
-        transcript_service,
-        events_manager,
-        remote_instance,
-    ) -> None:
-        if channel:
-            if cleanup_on_exit:
-                scheme_eval.exec(("(exit-server)",))
-            transcript_service.end_streaming()
-            events_manager.stop()
-            channel.close()
-            channel = None
-
-        if remote_instance:
-            remote_instance.delete()
 
 
 class BaseSession:
@@ -325,30 +61,8 @@ class BaseSession:
         Close the Fluent connection and exit Fluent.
     """
 
-    def __init__(
-        self,
-        ip: str = None,
-        port: int = None,
-        password: str = None,
-        channel: grpc.Channel = None,
-        cleanup_on_exit: bool = True,
-        start_transcript: bool = True,
-        remote_instance=None,
-        fluent_connection=None,
-    ):
-        if not fluent_connection:
-            self.fluent_connection = _FluentConnection(
-                ip=ip,
-                port=port,
-                password=password,
-                channel=channel,
-                cleanup_on_exit=cleanup_on_exit,
-                start_transcript=start_transcript,
-                remote_instance=remote_instance,
-            )
-        else:
-            self.fluent_connection = fluent_connection
-
+    def __init__(self, fluent_connection: _FluentConnection):
+        self.fluent_connection = fluent_connection
         self.scheme_eval = self.fluent_connection.scheme_eval
 
     @classmethod
@@ -381,11 +95,13 @@ class BaseSession:
         """
         ip, port, password = parse_server_info_file(server_info_filepath)
         session = cls(
-            ip=ip,
-            port=port,
-            password=password,
-            cleanup_on_exit=cleanup_on_exit,
-            start_transcript=start_transcript,
+            _FluentConnection(
+                ip=ip,
+                port=port,
+                password=password,
+                cleanup_on_exit=cleanup_on_exit,
+                start_transcript=start_transcript,
+            )
         )
         return session
 
@@ -476,13 +192,11 @@ class Session:
 
         self.scheme_eval = self.fluent_connection.scheme_eval
 
+        self.meshing = BaseMeshing(self.fluent_connection)
+
         self._datamodel_service_tui = self.fluent_connection.datamodel_service_tui
-        self._datamodel_service_se = self.fluent_connection.datamodel_service_se
         self._settings_service = self.fluent_connection.settings_service
 
-        self.meshing = BaseMeshing(
-            self._datamodel_service_tui, self._datamodel_service_se
-        )
         self.solver = Session.Solver(
             self._datamodel_service_tui, self._settings_service
         )
@@ -517,11 +231,13 @@ class Session:
         """
         ip, port, password = parse_server_info_file(server_info_filepath)
         session = Session(
-            ip=ip,
-            port=port,
-            password=password,
-            cleanup_on_exit=cleanup_on_exit,
-            start_transcript=start_transcript,
+            _FluentConnection(
+                ip=ip,
+                port=port,
+                password=password,
+                cleanup_on_exit=cleanup_on_exit,
+                start_transcript=start_transcript,
+            )
         )
         return session
 

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -11,7 +11,7 @@ from ansys.fluent.core.services.datamodel_tui import (
 )
 from ansys.fluent.core.services.datamodel_tui import TUIMenuGeneric
 from ansys.fluent.core.services.settings import SettingsService
-from ansys.fluent.core.session_base_meshing import BaseMeshing
+from ansys.fluent.core.session_base_meshing import _BaseMeshing
 from ansys.fluent.core.session_shared import _CODEGEN_MSG_TUI
 from ansys.fluent.core.solver.flobject import get_root as settings_get_root
 from ansys.fluent.core.utils.logging import LOG
@@ -32,7 +32,7 @@ def parse_server_info_file(filename: str):
     return ip, port, password
 
 
-class BaseSession:
+class _BaseSession:
     """Instantiates a Fluent connection.
 
     Attributes
@@ -95,7 +95,7 @@ class BaseSession:
         """
         ip, port, password = parse_server_info_file(server_info_filepath)
         session = cls(
-            _FluentConnection(
+            fluent_connection=_FluentConnection(
                 ip=ip,
                 port=port,
                 password=password,
@@ -133,11 +133,14 @@ class BaseSession:
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any):
         self.fluent_connection.exit()
 
+    def __getattr__(self, attr):
+        return getattr(self.fluent_connection, attr)
+
 
 class Session:
     """Instantiates a Fluent connection. This is a deprecated class. This has
-    been replaced by the "BaseSession" class to implement the new fluent launch
-    modes.
+    been replaced by the "_BaseSession" class to implement the new fluent
+    launch modes.
 
     Attributes
     ----------
@@ -192,7 +195,7 @@ class Session:
 
         self.scheme_eval = self.fluent_connection.scheme_eval
 
-        self.meshing = BaseMeshing(self.fluent_connection)
+        self.meshing = _BaseMeshing(self.fluent_connection)
 
         self._datamodel_service_tui = self.fluent_connection.datamodel_service_tui
         self._settings_service = self.fluent_connection.settings_service
@@ -231,7 +234,7 @@ class Session:
         """
         ip, port, password = parse_server_info_file(server_info_filepath)
         session = Session(
-            _FluentConnection(
+            fluent_connection=_FluentConnection(
                 ip=ip,
                 port=port,
                 password=password,
@@ -268,6 +271,9 @@ class Session:
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any):
         self.fluent_connection.exit()
+
+    def __getattr__(self, attr):
+        return getattr(self.fluent_connection, attr)
 
     class Solver:
         def __init__(

--- a/src/ansys/fluent/core/session_base_meshing.py
+++ b/src/ansys/fluent/core/session_base_meshing.py
@@ -1,20 +1,13 @@
-from ansys.fluent.core.services.datamodel_se import (
-    DatamodelService as DatamodelService_SE,
-)
+from ansys.fluent.core.fluent_connection import _FluentConnection
 from ansys.fluent.core.services.datamodel_se import PyMenuGeneric
-from ansys.fluent.core.services.datamodel_tui import (
-    DatamodelService as DatamodelService_TUI,
-)
 from ansys.fluent.core.services.datamodel_tui import TUIMenuGeneric
 from ansys.fluent.core.session_shared import _CODEGEN_MSG_DATAMODEL, _CODEGEN_MSG_TUI
 
 
 class BaseMeshing:
-    def __init__(
-        self, tui_service: DatamodelService_TUI, se_service: DatamodelService_SE
-    ):
-        self._tui_service = tui_service
-        self._se_service = se_service
+    def __init__(self, fluent_connection: _FluentConnection):
+        self._tui_service = fluent_connection.datamodel_service_tui
+        self._se_service = fluent_connection.datamodel_service_se
         self._tui = None
         self._meshing = None
         self._workflow = None

--- a/src/ansys/fluent/core/session_base_meshing.py
+++ b/src/ansys/fluent/core/session_base_meshing.py
@@ -1,4 +1,5 @@
 from ansys.fluent.core.fluent_connection import _FluentConnection
+from ansys.fluent.core.meshing.workflow import MeshingWorkflow
 from ansys.fluent.core.services.datamodel_se import PyMenuGeneric
 from ansys.fluent.core.services.datamodel_tui import TUIMenuGeneric
 from ansys.fluent.core.session_shared import _CODEGEN_MSG_DATAMODEL, _CODEGEN_MSG_TUI
@@ -42,16 +43,21 @@ class BaseMeshing:
         return self._meshing
 
     @property
-    def workflow(self):
+    def _workflow_se(self):
         """workflow datamodel root."""
-        if self._workflow is None:
-            try:
-                from ansys.fluent.core.datamodel.workflow import Root as workflow_root
+        try:
+            from ansys.fluent.core.datamodel.workflow import Root as workflow_root
 
-                self._workflow = workflow_root(self._se_service, "workflow", [])
-            except (ImportError, ModuleNotFoundError):
-                LOG.warning(_CODEGEN_MSG_DATAMODEL)
-                self._workflow = PyMenuGeneric(self._se_service, "workflow")
+            workflow_se = workflow_root(self._se_service, "workflow", [])
+        except (ImportError, ModuleNotFoundError):
+            LOG.warning(_CODEGEN_MSG_DATAMODEL)
+            workflow_se = PyMenuGeneric(self._se_service, "workflow")
+        return workflow_se
+
+    @property
+    def workflow(self):
+        if not self._workflow:
+            self._workflow = MeshingWorkflow(self._workflow_se, self.meshing)
         return self._workflow
 
     @property

--- a/src/ansys/fluent/core/session_base_meshing.py
+++ b/src/ansys/fluent/core/session_base_meshing.py
@@ -1,44 +1,20 @@
-"""Module containing class encapsulating Fluent connection.
-
-**********PRESENTLY SAME AS MESHING WITHOUT THE SWITCH TO SOLVER***********
-"""
-import grpc
-
+from ansys.fluent.core.services.datamodel_se import (
+    DatamodelService as DatamodelService_SE,
+)
 from ansys.fluent.core.services.datamodel_se import PyMenuGeneric
+from ansys.fluent.core.services.datamodel_tui import (
+    DatamodelService as DatamodelService_TUI,
+)
 from ansys.fluent.core.services.datamodel_tui import TUIMenuGeneric
-from ansys.fluent.core.session import BaseSession
 from ansys.fluent.core.session_shared import _CODEGEN_MSG_DATAMODEL, _CODEGEN_MSG_TUI
-from ansys.fluent.core.utils.logging import LOG
 
 
-class PureMeshing(BaseSession):
-    """Encapsulates a Fluent - Pure Meshing session connection.
-    PureMeshing(BaseSession) holds the top-level objects
-    for meshing TUI and various meshing datamodel API calls."""
-
+class BaseMeshing:
     def __init__(
-        self,
-        ip: str = None,
-        port: int = None,
-        password: str = None,
-        channel: grpc.Channel = None,
-        cleanup_on_exit: bool = True,
-        start_transcript: bool = True,
-        remote_instance=None,
-        fluent_connection=None,
+        self, tui_service: DatamodelService_TUI, se_service: DatamodelService_SE
     ):
-        super().__init__(
-            ip=ip,
-            port=port,
-            password=password,
-            channel=channel,
-            cleanup_on_exit=cleanup_on_exit,
-            start_transcript=start_transcript,
-            remote_instance=remote_instance,
-            fluent_connection=fluent_connection,
-        )
-        self._tui_service = self.fluent_connection.datamodel_service_tui
-        self._se_service = self.fluent_connection.datamodel_service_se
+        self._tui_service = tui_service
+        self._se_service = se_service
         self._tui = None
         self._meshing = None
         self._workflow = None

--- a/src/ansys/fluent/core/session_base_meshing.py
+++ b/src/ansys/fluent/core/session_base_meshing.py
@@ -3,6 +3,7 @@ from ansys.fluent.core.meshing.workflow import MeshingWorkflow
 from ansys.fluent.core.services.datamodel_se import PyMenuGeneric
 from ansys.fluent.core.services.datamodel_tui import TUIMenuGeneric
 from ansys.fluent.core.session_shared import _CODEGEN_MSG_DATAMODEL, _CODEGEN_MSG_TUI
+from ansys.fluent.core.utils.logging import LOG
 
 
 class _BaseMeshing:

--- a/src/ansys/fluent/core/session_base_meshing.py
+++ b/src/ansys/fluent/core/session_base_meshing.py
@@ -5,7 +5,10 @@ from ansys.fluent.core.services.datamodel_tui import TUIMenuGeneric
 from ansys.fluent.core.session_shared import _CODEGEN_MSG_DATAMODEL, _CODEGEN_MSG_TUI
 
 
-class BaseMeshing:
+class _BaseMeshing:
+
+    meshing_attrs = ("tui", "meshing", "workflow", "PartManagement", "PMFileManagement")
+
     def __init__(self, fluent_connection: _FluentConnection):
         self._tui_service = fluent_connection.datamodel_service_tui
         self._se_service = fluent_connection.datamodel_service_se

--- a/src/ansys/fluent/core/session_meshing.py
+++ b/src/ansys/fluent/core/session_meshing.py
@@ -2,6 +2,7 @@
 # import weakref
 
 
+from ansys.fluent.core.fluent_connection import _FluentConnection
 from ansys.fluent.core.session_pure_meshing import PureMeshing
 from ansys.fluent.core.session_solver import Solver
 
@@ -19,6 +20,12 @@ class Meshing(PureMeshing):
         Meshing._alive.append(self)
         return weakref.proxy(self)
     """
+
+    def __init__(
+        self,
+        fluent_connection: _FluentConnection,
+    ):
+        super(Meshing, self).__init__(fluent_connection=fluent_connection)
 
     def switch_to_solver(self):
         self.tui.switch_to_solution_mode("yes")

--- a/src/ansys/fluent/core/session_meshing.py
+++ b/src/ansys/fluent/core/session_meshing.py
@@ -2,7 +2,10 @@
 # import weakref
 
 
+from typing import Any
+
 from ansys.fluent.core.fluent_connection import _FluentConnection
+from ansys.fluent.core.session_base_meshing import _BaseMeshing
 from ansys.fluent.core.session_pure_meshing import PureMeshing
 from ansys.fluent.core.session_solver import Solver
 
@@ -10,25 +13,20 @@ from ansys.fluent.core.session_solver import Solver
 class Meshing(PureMeshing):
     """Encapsulates a Fluent - Meshing session connection.
     Meshing(PureMeshing) holds the top-level objects
-    for meshing TUI and various meshing datamodel API calls."""
-
-    """
-    _alive = []
-
-    def __new__(cls, *args, **kwargs):
-        self = super().__new__(cls)
-        Meshing._alive.append(self)
-        return weakref.proxy(self)
-    """
+    for meshing TUI and various meshing datamodel API calls.
+    In this general meshing mode, switch to solver is available,
+    after which"""
 
     def __init__(
         self,
         fluent_connection: _FluentConnection,
     ):
         super(Meshing, self).__init__(fluent_connection=fluent_connection)
+        self.switch_to_solver = lambda: self._switch_to_solver()
 
-    def switch_to_solver(self):
+    def _switch_to_solver(self) -> Any:
         self.tui.switch_to_solution_mode("yes")
         solver_session = Solver(fluent_connection=self.fluent_connection)
-        # self._alive.remove(self)
+        for attr in _BaseMeshing.meshing_attrs + ("switch_to_solver",):
+            delattr(self, attr)
         return solver_session

--- a/src/ansys/fluent/core/session_meshing.py
+++ b/src/ansys/fluent/core/session_meshing.py
@@ -1,5 +1,6 @@
 """Module containing class encapsulating Fluent connection."""
-import weakref
+# import weakref
+
 
 from ansys.fluent.core.fluent_connection import _FluentConnection
 from ansys.fluent.core.session_pure_meshing import PureMeshing
@@ -11,12 +12,14 @@ class Meshing(PureMeshing):
     Meshing(PureMeshing) holds the top-level objects
     for meshing TUI and various meshing datamodel API calls."""
 
+    """
     _alive = []
 
     def __new__(cls, *args, **kwargs):
         self = super().__new__(cls)
         Meshing._alive.append(self)
         return weakref.proxy(self)
+    """
 
     def __init__(
         self,
@@ -27,5 +30,5 @@ class Meshing(PureMeshing):
     def switch_to_solver(self):
         self.tui.switch_to_solution_mode("yes")
         solver_session = Solver(fluent_connection=self.fluent_connection)
-        self._alive.remove(self)
+        # self._alive.remove(self)
         return solver_session

--- a/src/ansys/fluent/core/session_meshing.py
+++ b/src/ansys/fluent/core/session_meshing.py
@@ -1,6 +1,5 @@
 """Module containing class encapsulating Fluent connection."""
-# import weakref
-
+import weakref
 
 from ansys.fluent.core.fluent_connection import _FluentConnection
 from ansys.fluent.core.session_pure_meshing import PureMeshing
@@ -12,14 +11,12 @@ class Meshing(PureMeshing):
     Meshing(PureMeshing) holds the top-level objects
     for meshing TUI and various meshing datamodel API calls."""
 
-    """
     _alive = []
 
     def __new__(cls, *args, **kwargs):
         self = super().__new__(cls)
         Meshing._alive.append(self)
         return weakref.proxy(self)
-    """
 
     def __init__(
         self,
@@ -30,5 +27,5 @@ class Meshing(PureMeshing):
     def switch_to_solver(self):
         self.tui.switch_to_solution_mode("yes")
         solver_session = Solver(fluent_connection=self.fluent_connection)
-        # self._alive.remove(self)
+        self._alive.remove(self)
         return solver_session

--- a/src/ansys/fluent/core/session_meshing.py
+++ b/src/ansys/fluent/core/session_meshing.py
@@ -1,5 +1,6 @@
 """Module containing class encapsulating Fluent connection."""
-import grpc
+# import weakref
+
 
 from ansys.fluent.core.session_pure_meshing import PureMeshing
 from ansys.fluent.core.session_solver import Solver
@@ -10,83 +11,17 @@ class Meshing(PureMeshing):
     Meshing(PureMeshing) holds the top-level objects
     for meshing TUI and various meshing datamodel API calls."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        port: int = None,
-        password: str = None,
-        channel: grpc.Channel = None,
-        cleanup_on_exit: bool = True,
-        start_transcript: bool = True,
-        remote_instance=None,
-        fluent_connection=None,
-    ):
-        super().__init__(
-            ip=ip,
-            port=port,
-            password=password,
-            channel=channel,
-            cleanup_on_exit=cleanup_on_exit,
-            start_transcript=start_transcript,
-            remote_instance=remote_instance,
-            fluent_connection=fluent_connection,
-        )
+    """
+    _alive = []
 
-        self.solver_switch = False
-
-    @property
-    def tui(self):
-        """Instance of ``main_menu`` on which Fluent's SolverTUI methods can be
-        executed."""
-        if self.solver_switch:
-            raise AttributeError(
-                "Mesh-Session-specific attributes are not available in Solver-Session"
-            )
-        return super().tui
-
-    @property
-    def meshing(self):
-        """meshing datamodel root."""
-        if self.solver_switch:
-            raise AttributeError(
-                "Mesh-Session-specific attributes are not available in Solver-Session"
-            )
-        return super().meshing
-
-    @property
-    def workflow(self):
-        """workflow datamodel root."""
-        if self.solver_switch:
-            raise AttributeError(
-                "Mesh-Session-specific attributes are not available in Solver-Session"
-            )
-        return super().workflow
-
-    @property
-    def PartManagement(self):
-        """PartManagement datamodel root."""
-        if self.solver_switch:
-            raise AttributeError(
-                "Mesh-Session-specific attributes are not available in Solver-Session"
-            )
-        return super().PartManagement
-
-    @property
-    def PMFileManagement(self):
-        """PMFileManagement datamodel root."""
-        if self.solver_switch:
-            raise AttributeError(
-                "Mesh-Session-specific attributes are not available in Solver-Session"
-            )
-        return super().PMFileManagement
+    def __new__(cls, *args, **kwargs):
+        self = super().__new__(cls)
+        Meshing._alive.append(self)
+        return weakref.proxy(self)
+    """
 
     def switch_to_solver(self):
-        """A switch to move to the solver session from meshing."""
-        if self.solver_switch:
-            raise AttributeError(
-                "Mesh-Session-specific attributes are not available in Solver-Session"
-            )
         self.tui.switch_to_solution_mode("yes")
-        self.solver_switch = True
         solver_session = Solver(fluent_connection=self.fluent_connection)
+        # self._alive.remove(self)
         return solver_session

--- a/src/ansys/fluent/core/session_pure_meshing.py
+++ b/src/ansys/fluent/core/session_pure_meshing.py
@@ -2,13 +2,10 @@
 
 **********PRESENTLY SAME AS MESHING WITHOUT THE SWITCH TO SOLVER***********
 """
-import grpc
 
-from ansys.fluent.core.services.datamodel_se import PyMenuGeneric
-from ansys.fluent.core.services.datamodel_tui import TUIMenuGeneric
+from ansys.fluent.core.fluent_connection import _FluentConnection
 from ansys.fluent.core.session import BaseSession
-from ansys.fluent.core.session_shared import _CODEGEN_MSG_DATAMODEL, _CODEGEN_MSG_TUI
-from ansys.fluent.core.utils.logging import LOG
+from ansys.fluent.core.session_base_meshing import BaseMeshing
 
 
 class PureMeshing(BaseSession):
@@ -16,109 +13,10 @@ class PureMeshing(BaseSession):
     PureMeshing(BaseSession) holds the top-level objects
     for meshing TUI and various meshing datamodel API calls."""
 
-    def __init__(
-        self,
-        ip: str = None,
-        port: int = None,
-        password: str = None,
-        channel: grpc.Channel = None,
-        cleanup_on_exit: bool = True,
-        start_transcript: bool = True,
-        remote_instance=None,
-        fluent_connection=None,
-    ):
-        super().__init__(
-            ip=ip,
-            port=port,
-            password=password,
-            channel=channel,
-            cleanup_on_exit=cleanup_on_exit,
-            start_transcript=start_transcript,
-            remote_instance=remote_instance,
-            fluent_connection=fluent_connection,
-        )
-        self._tui_service = self.fluent_connection.datamodel_service_tui
-        self._se_service = self.fluent_connection.datamodel_service_se
-        self._tui = None
-        self._meshing = None
-        self._workflow = None
-        self._part_management = None
-        self._pm_file_management = None
+    def __init__(self, fluent_connection: _FluentConnection):
+        super(PureMeshing, self).__init__(fluent_connection=fluent_connection)
 
-    @property
-    def tui(self):
-        """Instance of ``main_menu`` on which Fluent's SolverTUI methods can be
-        executed."""
-        if self._tui is None:
-            try:
-                from ansys.fluent.core.meshing.tui import main_menu as MeshingMainMenu
+        self._base_meshing = BaseMeshing(fluent_connection)
 
-                self._tui = MeshingMainMenu([], self._tui_service)
-            except (ImportError, ModuleNotFoundError):
-                LOG.warning(_CODEGEN_MSG_TUI)
-                self._tui = TUIMenuGeneric([], self._tui_service)
-        return self._tui
-
-    @property
-    def meshing(self):
-        """meshing datamodel root."""
-        if self._meshing is None:
-            try:
-                from ansys.fluent.core.datamodel.meshing import Root as meshing_root
-
-                self._meshing = meshing_root(self._se_service, "meshing", [])
-            except (ImportError, ModuleNotFoundError):
-                LOG.warning(_CODEGEN_MSG_DATAMODEL)
-                self._meshing = PyMenuGeneric(self._se_service, "meshing")
-        return self._meshing
-
-    @property
-    def workflow(self):
-        """workflow datamodel root."""
-        if self._workflow is None:
-            try:
-                from ansys.fluent.core.datamodel.workflow import Root as workflow_root
-
-                self._workflow = workflow_root(self._se_service, "workflow", [])
-            except (ImportError, ModuleNotFoundError):
-                LOG.warning(_CODEGEN_MSG_DATAMODEL)
-                self._workflow = PyMenuGeneric(self._se_service, "workflow")
-        return self._workflow
-
-    @property
-    def PartManagement(self):
-        """PartManagement datamodel root."""
-        if self._part_management is None:
-            try:
-                from ansys.fluent.core.datamodel.PartManagement import (
-                    Root as PartManagement_root,
-                )
-
-                self._part_management = PartManagement_root(
-                    self._se_service, "PartManagement", []
-                )
-            except (ImportError, ModuleNotFoundError):
-                LOG.warning(_CODEGEN_MSG_DATAMODEL)
-                self._part_management = PyMenuGeneric(
-                    self._se_service, "PartManagement"
-                )
-        return self._part_management
-
-    @property
-    def PMFileManagement(self):
-        """PMFileManagement datamodel root."""
-        if self._pm_file_management is None:
-            try:
-                from ansys.fluent.core.datamodel.PMFileManagement import (
-                    Root as PMFileManagement_root,
-                )
-
-                self._pm_file_management = PMFileManagement_root(
-                    self._se_service, "PMFileManagement", []
-                )
-            except (ImportError, ModuleNotFoundError):
-                LOG.warning(_CODEGEN_MSG_DATAMODEL)
-                self._pm_file_management = PyMenuGeneric(
-                    self._se_service, "PMFileManagement"
-                )
-        return self._pm_file_management
+    def __getattr__(self, attr):
+        return getattr(self._base_meshing, attr)

--- a/src/ansys/fluent/core/session_pure_meshing.py
+++ b/src/ansys/fluent/core/session_pure_meshing.py
@@ -4,19 +4,22 @@
 """
 
 from ansys.fluent.core.fluent_connection import _FluentConnection
-from ansys.fluent.core.session import BaseSession
-from ansys.fluent.core.session_base_meshing import BaseMeshing
+from ansys.fluent.core.session import _BaseSession
+from ansys.fluent.core.session_base_meshing import _BaseMeshing
 
 
-class PureMeshing(BaseSession):
+class PureMeshing(_BaseSession):
     """Encapsulates a Fluent - Pure Meshing session connection.
-    PureMeshing(BaseSession) holds the top-level objects
-    for meshing TUI and various meshing datamodel API calls."""
+    PureMeshing(_BaseSession) holds the top-level objects
+    for meshing TUI and various meshing datamodel API calls.
+    In pure-meshing mode, switch to solver is not available.
+    Public attributes of this class or extracted from the _BaseMeshing
+    class"""
 
     def __init__(self, fluent_connection: _FluentConnection):
         super(PureMeshing, self).__init__(fluent_connection=fluent_connection)
 
-        self._base_meshing = BaseMeshing(fluent_connection)
+        self._base_meshing = _BaseMeshing(fluent_connection)
 
-    def __getattr__(self, attr):
-        return getattr(self._base_meshing, attr)
+        for attr in _BaseMeshing.meshing_attrs:
+            setattr(self, attr, getattr(self._base_meshing, attr))

--- a/src/ansys/fluent/core/session_shared.py
+++ b/src/ansys/fluent/core/session_shared.py
@@ -1,0 +1,11 @@
+_CODEGEN_MSG_DATAMODEL = (
+    "Currently calling the datamodel API in a generic manner. "
+    "Please run `python codegen/allapigen.py` from the top-level pyfluent "
+    "directory to generate the local datamodel API classes."
+)
+
+_CODEGEN_MSG_TUI = (
+    "Currently calling the TUI commands in a generic manner. "
+    "Please run `python codegen/allapigen.py` from the top-level pyfluent "
+    "directory to generate the local TUI commands classes."
+)

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -1,5 +1,4 @@
 """Module containing class encapsulating Fluent connection."""
-import grpc
 
 from ansys.fluent.core.services.datamodel_tui import TUIMenuGeneric
 from ansys.fluent.core.session import _CODEGEN_MSG_TUI, BaseSession
@@ -14,25 +13,9 @@ class Solver(BaseSession):
 
     def __init__(
         self,
-        ip: str = None,
-        port: int = None,
-        password: str = None,
-        channel: grpc.Channel = None,
-        cleanup_on_exit: bool = True,
-        start_transcript: bool = True,
-        remote_instance=None,
-        fluent_connection=None,
+        fluent_connection,
     ):
-        super().__init__(
-            ip=ip,
-            port=port,
-            password=password,
-            channel=channel,
-            cleanup_on_exit=cleanup_on_exit,
-            start_transcript=start_transcript,
-            remote_instance=remote_instance,
-            fluent_connection=fluent_connection,
-        )
+        super(Solver, self).__init__(fluent_connection=fluent_connection)
         self._tui_service = self.fluent_connection.datamodel_service_tui
         self._settings_service = self.fluent_connection.settings_service
         self._tui = None

--- a/src/ansys/fluent/core/session_solver.py
+++ b/src/ansys/fluent/core/session_solver.py
@@ -1,12 +1,12 @@
 """Module containing class encapsulating Fluent connection."""
 
 from ansys.fluent.core.services.datamodel_tui import TUIMenuGeneric
-from ansys.fluent.core.session import _CODEGEN_MSG_TUI, BaseSession
+from ansys.fluent.core.session import _CODEGEN_MSG_TUI, _BaseSession
 from ansys.fluent.core.solver.flobject import get_root as settings_get_root
 from ansys.fluent.core.utils.logging import LOG
 
 
-class Solver(BaseSession):
+class Solver(_BaseSession):
     """Encapsulates a Fluent - Solver session connection.
     Solver(Session) holds the top-level objects
     for solver TUI and settings objects calls."""

--- a/tests/test_pure_mesh_vs_mesh_workflow.py
+++ b/tests/test_pure_mesh_vs_mesh_workflow.py
@@ -38,5 +38,5 @@ def test_meshing_mode_post_switching_to_solver(load_mixing_elbow_meshing):
     meshing_session = load_mixing_elbow_meshing
     meshing_session.switch_to_solver()
     # Post switching to solver session, meshing session specific attributes are unavailable
-    with pytest.raises(AttributeError):
-        meshing_session.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")
+    # with pytest.raises(AttributeError):
+    #    meshing_session.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")

--- a/tests/test_pure_mesh_vs_mesh_workflow.py
+++ b/tests/test_pure_mesh_vs_mesh_workflow.py
@@ -38,5 +38,5 @@ def test_meshing_mode_post_switching_to_solver(load_mixing_elbow_meshing):
     meshing_session = load_mixing_elbow_meshing
     meshing_session.switch_to_solver()
     # Post switching to solver session, meshing session specific attributes are unavailable
-    # with pytest.raises(AttributeError):
-    #    meshing_session.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")
+    with pytest.raises(AttributeError):
+        meshing_session.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")

--- a/tests/test_pure_mesh_vs_mesh_workflow.py
+++ b/tests/test_pure_mesh_vs_mesh_workflow.py
@@ -6,7 +6,21 @@ import pytest
 @pytest.mark.setup
 def test_pure_meshing_mode(load_mixing_elbow_pure_meshing):
     pure_meshing_session = load_mixing_elbow_pure_meshing
-    assert pure_meshing_session.workflow.TaskObject["Import Geometry"].Execute()
+    # check a few dir elements
+    # n.b. 'field_data', 'field_info' need to
+    # be eliminated from meshing sessions
+    session_dir = dir(pure_meshing_session)
+    for attr in ("field_data", "field_info", "meshing", "workflow"):
+        assert attr in session_dir
+    workflow = pure_meshing_session.workflow
+    workflow_dir = dir(workflow)
+    for attr in ("TaskObject", "InsertNewTask", "Workflow", "setState"):
+        assert attr in workflow_dir
+    import_geometry = workflow.TaskObject["Import Geometry"]
+    import_geometry_dir = dir(import_geometry)
+    for attr in ("AddChildToTask", "Arguments", "Execute", "setState"):
+        assert attr in import_geometry_dir
+    assert import_geometry.Execute()
     with pytest.raises(AttributeError):
         pure_meshing_session.switch_to_solver()
 
@@ -16,6 +30,12 @@ def test_pure_meshing_mode(load_mixing_elbow_pure_meshing):
 @pytest.mark.setup
 def test_meshing_mode(load_mixing_elbow_meshing):
     meshing_session = load_mixing_elbow_meshing
+    # check a few dir elements
+    # n.b. 'field_data', 'field_info' need to
+    # be eliminated from meshing sessions
+    session_dir = dir(meshing_session)
+    for attr in ("field_data", "field_info", "meshing", "workflow"):
+        assert attr in session_dir
     assert meshing_session.workflow.TaskObject["Import Geometry"].Execute()
     assert meshing_session.switch_to_solver()
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -130,6 +130,10 @@ def test_create_session_from_launch_fluent_by_passing_ip_and_port(
     session = launch_fluent(
         start_instance=False, ip=ip, port=port, cleanup_on_exit=False, mode="solver"
     )
+    # check a few dir elements
+    session_dir = dir(session)
+    for attr in ("field_data", "field_info", "setup", "solution"):
+        assert attr in session_dir
     assert session.check_health() == HealthCheckService.Status.SERVING.name
     server.stop(None)
     session.exit()
@@ -149,6 +153,10 @@ def test_create_session_from_launch_fluent_by_setting_ip_and_port_env_var(
     monkeypatch.setenv("PYFLUENT_FLUENT_IP", ip)
     monkeypatch.setenv("PYFLUENT_FLUENT_PORT", str(port))
     session = launch_fluent(start_instance=False, cleanup_on_exit=False, mode="solver")
+    # check a few dir elements
+    session_dir = dir(session)
+    for attr in ("field_data", "field_info"):
+        assert attr in session_dir
     assert session.check_health() == HealthCheckService.Status.SERVING.name
     server.stop(None)
     session.exit()


### PR DESCRIPTION
Current meshing workflow exposure requires improvement as outlined: https://github.com/pyansys/pyfluent/issues/622.

In this change, the actual workflow and workflow.task objects are extended with the required functionality.

e.g.,
```
>>> import ansys.fluent.core as pf
>>> session = pf.launch_fluent(mode="meshing")
>>> w=session.workflow
>>> w.InitializeWorkflow(WorkflowType="Watertight Geometry")
True
>>> igt=w.task('Import Geometry')
>>> igt.CommandArguments.CadImportOptions
<ansys.fluent.core.services.datamodel_se.PyCommandArgumentsSubItem object at 0x0000021FFE1C6D00>
>>> igt.CommandArguments.CadImportOptions.OneZonePer
<ansys.fluent.core.services.datamodel_se.PyCommandArgumentsSubItem object at 0x0000021FFE1C6BB0>
>>> igt.CommandArguments.CadImportOptions.OneZonePer()
'Body'
>>> igt.CommandArguments.CadImportOptions.OneZonePer.getAttribValue("default")
'Body'
```

EDIT:  This is also fixes https://github.com/pyansys/pyfluent/issues/722.  So I have commented out some of the new code to get this in. `field_data` will be a significant loss for some users.

**I still need to add doc comments**