### PR TITLE
update dir, remove some redundant code

### DIFF
--- a/src/ansys/fluent/core/meshing/workflow.py
+++ b/src/ansys/fluent/core/meshing/workflow.py
@@ -17,20 +17,11 @@ def _new_command_for_task(task, meshing):
 
 class MeshingWorkflow:
     class Task(PyCallableStateObject):
-        class Args(PyCallableStateObject):
-            def __init__(self, task):
-                self._task = task
-                self._args = task.Arguments
-
-            def __getattr__(self, attr):
-                return getattr(self._args, attr)
-
         def __init__(self, meshing, name):
             self._workflow = meshing._workflow
             self._meshing = meshing._meshing
             self._task = self._workflow.TaskObject[name]
             self._cmd = None
-            self.Arguments = MeshingWorkflow.Task.Args(self)
 
         @property
         def CommandArguments(self):
@@ -50,6 +41,11 @@ class MeshingWorkflow:
         def __getattr__(self, attr):
             return getattr(self._task, attr)
 
+        def __dir__(self):
+            return sorted(
+                set(list(self.__dict__.keys()) + dir(type(self)) + dir(self._task))
+            )
+
     def __init__(self, workflow, meshing):
         self._workflow = workflow
         self._meshing = meshing
@@ -59,3 +55,8 @@ class MeshingWorkflow:
 
     def __getattr__(self, attr):
         return getattr(self._workflow, attr)
+
+    def __dir__(self):
+        return sorted(
+            set(list(self.__dict__.keys()) + dir(type(self)) + dir(self._workflow))
+        )

--- a/src/ansys/fluent/core/meshing/workflow.py
+++ b/src/ansys/fluent/core/meshing/workflow.py
@@ -60,3 +60,6 @@ class MeshingWorkflow:
         return sorted(
             set(list(self.__dict__.keys()) + dir(type(self)) + dir(self._workflow))
         )
+
+    def __call__(self):
+        return self._workflow()

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -583,8 +583,8 @@ class PyCommand:
         print(help_string)
 
     def _create_command_arguments(self):
-        # pending the proto changes
         pass
+        # pending the proto changes
         """
         request = DataModelProtoModule.CreateCommandArgumentsRequest()
         request.rules = self.rules

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -136,6 +136,15 @@ class _BaseSession:
     def __getattr__(self, attr):
         return getattr(self.fluent_connection, attr)
 
+    def __dir__(self):
+        return sorted(
+            set(
+                list(self.__dict__.keys())
+                + dir(type(self))
+                + dir(self.fluent_connection)
+            )
+        )
+
 
 class Session:
     """Instantiates a Fluent connection. This is a deprecated class. This has
@@ -274,6 +283,15 @@ class Session:
 
     def __getattr__(self, attr):
         return getattr(self.fluent_connection, attr)
+
+    def __dir__(self):
+        return sorted(
+            set(
+                list(self.__dict__.keys())
+                + dir(type(self))
+                + dir(self.fluent_connection)
+            )
+        )
 
     class Solver:
         def __init__(

--- a/tests/test_pure_mesh_vs_mesh_workflow.py
+++ b/tests/test_pure_mesh_vs_mesh_workflow.py
@@ -12,7 +12,15 @@ def test_pure_meshing_mode(load_mixing_elbow_pure_meshing):
     session_dir = dir(pure_meshing_session)
     for attr in ("field_data", "field_info", "meshing", "workflow"):
         assert attr in session_dir
-    assert pure_meshing_session.workflow.TaskObject["Import Geometry"].Execute()
+    workflow = pure_meshing_session.workflow
+    workflow_dir = dir(workflow)
+    for attr in ("TaskObject", "InsertNewTask", "Workflow", "setState"):
+        assert attr in workflow_dir
+    import_geometry = workflow.TaskObject["Import Geometry"]
+    import_geometry_dir = dir(import_geometry)
+    for attr in ("AddChildToTask", "Arguments", "Execute", "setState"):
+        assert attr in import_geometry_dir
+    assert import_geometry.Execute()
     with pytest.raises(AttributeError):
         pure_meshing_session.switch_to_solver()
 

--- a/tests/test_pure_mesh_vs_mesh_workflow.py
+++ b/tests/test_pure_mesh_vs_mesh_workflow.py
@@ -6,6 +6,12 @@ import pytest
 @pytest.mark.setup
 def test_pure_meshing_mode(load_mixing_elbow_pure_meshing):
     pure_meshing_session = load_mixing_elbow_pure_meshing
+    # check a few dir elements
+    # n.b. 'field_data', 'field_info' need to
+    # be eliminated from meshing sessions
+    session_dir = dir(pure_meshing_session)
+    for attr in ("field_data", "field_info", "meshing", "workflow"):
+        assert attr in session_dir
     assert pure_meshing_session.workflow.TaskObject["Import Geometry"].Execute()
     with pytest.raises(AttributeError):
         pure_meshing_session.switch_to_solver()
@@ -16,6 +22,12 @@ def test_pure_meshing_mode(load_mixing_elbow_pure_meshing):
 @pytest.mark.setup
 def test_meshing_mode(load_mixing_elbow_meshing):
     meshing_session = load_mixing_elbow_meshing
+    # check a few dir elements
+    # n.b. 'field_data', 'field_info' need to
+    # be eliminated from meshing sessions
+    session_dir = dir(meshing_session)
+    for attr in ("field_data", "field_info", "meshing", "workflow"):
+        assert attr in session_dir
     assert meshing_session.workflow.TaskObject["Import Geometry"].Execute()
     assert meshing_session.switch_to_solver()
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -130,6 +130,10 @@ def test_create_session_from_launch_fluent_by_passing_ip_and_port(
     session = launch_fluent(
         start_instance=False, ip=ip, port=port, cleanup_on_exit=False, mode="solver"
     )
+    # check a few dir elements
+    session_dir = dir(session)
+    for attr in ("field_data", "field_info", "setup", "solution"):
+        assert attr in session_dir
     assert session.check_health() == HealthCheckService.Status.SERVING.name
     server.stop(None)
     session.exit()
@@ -149,6 +153,10 @@ def test_create_session_from_launch_fluent_by_setting_ip_and_port_env_var(
     monkeypatch.setenv("PYFLUENT_FLUENT_IP", ip)
     monkeypatch.setenv("PYFLUENT_FLUENT_PORT", str(port))
     session = launch_fluent(start_instance=False, cleanup_on_exit=False, mode="solver")
+    # check a few dir elements
+    session_dir = dir(session)
+    for attr in ("field_data", "field_info", "meshing", "solver"):
+        assert attr in session_dir
     assert session.check_health() == HealthCheckService.Status.SERVING.name
     server.stop(None)
     session.exit()


### PR DESCRIPTION
- update `__dir__` in a few places because some elements are missing where they are attributes of other attributes. The original PR uses `__getattr__` in those places which leaves things missing from `dir()` results. 
- remove some redundant code in meshing/workflow.py
- - add \_\_call\_\_ in MeshingWorkflow class