### PR TITLE
_datamodel_service_se made available

### DIFF
--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -212,6 +212,7 @@ class Session:
 
         self.meshing = _BaseMeshing(self.fluent_connection)
 
+        self._datamodel_service_se = self.fluent_connection.datamodel_service_se
         self._datamodel_service_tui = self.fluent_connection.datamodel_service_tui
         self._settings_service = self.fluent_connection.settings_service
 


### PR DESCRIPTION
session._datamodel_service_se() should be available to support backward compatibility.