### PR TITLE
CNAME changed for doc locations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
             Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}
 
       - name: Build Documentation
-        run: make build-doc DOCS_CNAME=fluentdocs.pyansys.com
+        run: make build-doc DOCS_CNAME=fluent.docs.pyansys.com
         env:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -58,7 +58,7 @@ jobs:
           FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
 
       - name: Build Documentation
-        run: make build-doc DOCS_CNAME=dev.fluentdocs.pyansys.com
+        run: make build-doc DOCS_CNAME=dev.fluent.docs.pyansys.com
         env:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,4 +8,4 @@ a community that can support user questions and develop new features to make
 this software a useful tool for all users. As such, we welcome and encourage
 any questions or submissions to this repository.
 
-For more information on contributing to PyFluent, see [Contributing](https://fluentdocs.pyansys.com/contributing.html).
+For more information on contributing to PyFluent, see [Contributing](https://fluent.docs.pyansys.com/contributing.html).

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ ability to:
 Documentation and issues
 ------------------------
 For comprehesive information on PyFluent, see the latest release
-`documentation <https://fluentdocs.pyansys.com>`_.
+`documentation <https://fluent.docs.pyansys.com>`_.
 
 On the `PyFluent Issues <https://github.com/pyansys/pyfluent/issues>`_ page, you can create
 issues to submit questions, report bugs, and request new features. To reach


### PR DESCRIPTION
After setting up the redirect repos for:
* https://fluentdocs.pyansys.com --> https://fluent.docs.pyansys.com
* https://dev.fluentdocs.pyansys.com --> https://dev.fluent.docs.pyansys.com

It was also necessary to adapt the workflows to the adequate CNAMEs. This should solve the issue.