### PR TITLE
Updated required methods to properties

### DIFF
--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -374,10 +374,12 @@ class PyParameter(PyBasicStateContainer):
     method.
     """
 
+    @property
     def default_value(self):
         """Get default value of the parameter."""
         return self.get_attrib_value(Attribute.DEFAULT.value)
 
+    @property
     def is_read_only(self):
         return true_if_none(self.get_attrib_value(Attribute.IS_READ_ONLY.value))
 
@@ -393,6 +395,7 @@ def true_if_none(val):
 class PyTextual(PyParameter):
     """Provides interface for textual parameters."""
 
+    @property
     def allowed_values(self):
         return self.get_attrib_value(Attribute.ALLOWED_VALUES.value)
 
@@ -400,9 +403,11 @@ class PyTextual(PyParameter):
 class PyNumerical(PyParameter):
     """Provides interface for numerical parameters."""
 
+    @property
     def min(self):
         return self.get_attrib_value(Attribute.MIN.value)
 
+    @property
     def max(self):
         return self.get_attrib_value(Attribute.MAX.value)
 

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -151,6 +151,7 @@ class Base:
         """Whether the object is active."""
         return self.get_attr("active?")
 
+    @property
     def is_read_only(self) -> bool:
         """Whether the object is read-only."""
         return self.get_attr("read-only?")
@@ -170,6 +171,7 @@ StateT = TypeVar("StateT")
 class Property(Base):
     """Exposes attribute accessor on settings object."""
 
+    @property
     def default_value(self):
         """Gets the default value of the object."""
         return self.get_attr("default")
@@ -178,10 +180,12 @@ class Property(Base):
 class Numerical(Property):
     """Exposes attribute accessor on settings object - specific to numerical objects."""
 
+    @property
     def min(self):
         """Get the minimum value of the object."""
         return self.get_attr("min")
 
+    @property
     def max(self):
         """Get the maximum value of the object."""
         return self.get_attr("max")
@@ -190,6 +194,7 @@ class Numerical(Property):
 class Textual(Property):
     """Exposes attribute accessor on settings object - specific to string objects."""
 
+    @property
     def allowed_values(self):
         """Get the allowed values of the object."""
         return self.get_attr("allowed-values")

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -635,9 +635,9 @@ class root(Group):
 
 def test_accessor_methods_on_settings_object(sample_solver_session):
     existing = sample_solver_session.file.read.file_type.get_attr("allowed-values")
-    modified = sample_solver_session.file.read.file_type.allowed_values()
+    modified = sample_solver_session.file.read.file_type.allowed_values
     assert existing == modified
 
     existing = sample_solver_session.file.read.file_type.get_attr("read-only?")
-    modified = sample_solver_session.file.read.file_type.is_read_only()
+    modified = sample_solver_session.file.read.file_type.is_read_only
     assert existing == modified


### PR DESCRIPTION
method() -> method

Example:
mesh1.surfaces_list.allowed_values() -> mesh1.surfaces_list.allowed_values

Consistent with PyFluent Visualization.