### PR TITLE
Remove installation instruction from git url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,13 +53,6 @@ Install the latest release from `PyPI
 
    pip install ansys-fluent-core
 
-Alternatively, install the latest release from `GitHub <https://github.com/pyansys/pyfluent>`_
-with:
-
-.. code:: console
-
-   pip install git+https://github.com/pyansys/pyfluent.git
-
 If you plan on doing local *development* of PyFluent with Git, install
 the latest release with:
 

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -23,14 +23,6 @@ Install the latest release from `PyPi
 
    pip install ansys-fluent-core
 
-Alternatively, install the latest release from `GitHub
-<https://github.com/pyansys/pyfluent/issues>`_ with:
-
-.. code::
-
-   pip install git+https://github.com/pyansys/pyfluent.git
-
-
 If you plan on doing local *development* of PyFluent with Git, install
 the latest release with:
 


### PR DESCRIPTION
Git url installation doesn't install the generated API files, nor user will have a way to generate those locally. PyFluent will still work without those generated files but intellisense won't be available in IDEs