### PR TITLE
Mark tests between nightly CI and PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
   test:
     name: Unit Testing
     needs: test-import
-    runs-on: [self-hosted, pyfluent]
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
   test:
     name: Unit Testing
     needs: test-import
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, pyfluent]
     strategy:
       fail-fast: false
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test-import:
 unittest:
 	@echo "Running unittests"
 	@pip install -r requirements/requirements_tests.txt
-	@pytest -v -m "unmarked or integration" --cov=ansys.fluent --cov-report html:cov_html --cov-config=.coveragerc
+	@pytest -v -m "unmarked" --cov=ansys.fluent --cov-report html:cov_html --cov-config=.coveragerc
 
 unittest-all:
 	@echo "Running all unittests"

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,4 @@ markers =
     mesh:Tests covering meshing scenarios
     optislang:Test Optislang integration scenarios
     unmarked:All unmarked tests, marked automatically
+    nightly:Run under nightly CI

--- a/tests/test_cad_to_post_ftm.py
+++ b/tests/test_cad_to_post_ftm.py
@@ -14,7 +14,7 @@ This test queries the following using PyTest:
 
 from functools import partial
 
-from pytest import approx
+import pytest
 from util.meshing_workflow import (  # noqa: F401
     assign_task_arguments,
     execute_task_with_pre_and_postcondition_checks,
@@ -26,6 +26,7 @@ from util.meshing_workflow import (  # noqa: F401
 from util.solver import check_report_definition_result
 
 
+@pytest.mark.nightly
 def test_exhaust_system(new_fault_tolerant_workflow_session, exhaust_system_geometry):
 
     meshing_session = new_fault_tolerant_workflow_session
@@ -498,7 +499,7 @@ def test_exhaust_system(new_fault_tolerant_workflow_session, exhaust_system_geom
 
         check_report_definition(
             report_definition_name="mass_flow_rate",
-            expected_result=approx(-6.036667e-07, abs=1e-3),
+            expected_result=pytest.approx(-6.036667e-07, abs=1e-3),
         )
 
         ###############################################################################
@@ -524,7 +525,7 @@ def test_exhaust_system(new_fault_tolerant_workflow_session, exhaust_system_geom
 
         check_report_definition(
             report_definition_name="velocity_magnitude_outlet",
-            expected_result=approx(3.7988207, rel=1e-3),
+            expected_result=pytest.approx(3.7988207, rel=1e-3),
         )
 
         ###############################################################################

--- a/tests/test_cad_to_post_wtm.py
+++ b/tests/test_cad_to_post_wtm.py
@@ -16,7 +16,7 @@ This test queries the following using PyTest:
 
 from functools import partial
 
-from pytest import approx
+import pytest
 from util.meshing_workflow import (  # noqa: F401
     assign_task_arguments,
     execute_task_with_pre_and_postcondition_checks,
@@ -28,6 +28,7 @@ from util.meshing_workflow import (  # noqa: F401
 from util.solver import check_report_definition_result
 
 
+@pytest.mark.nightly
 def test_mixing_elbow(new_watertight_workflow_session, mixing_elbow_geometry):
 
     meshing_session = new_watertight_workflow_session
@@ -249,7 +250,7 @@ def test_mixing_elbow(new_watertight_workflow_session, mixing_elbow_geometry):
 
         check_report_definition(
             report_definition_name="mass_flow_rate",
-            expected_result=approx(-2.985690364942784e-06, abs=1e-3),
+            expected_result=pytest.approx(-2.985690364942784e-06, abs=1e-3),
         )
 
         ###############################################################################
@@ -267,7 +268,7 @@ def test_mixing_elbow(new_watertight_workflow_session, mixing_elbow_geometry):
 
         check_report_definition(
             report_definition_name="temperature_outlet",
-            expected_result=approx(296.229, rel=1e-3),
+            expected_result=pytest.approx(296.229, rel=1e-3),
         )
 
         ###############################################################################

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -21,6 +21,7 @@ from util.meshing_workflow import (  # noqa: F401; model_object_throws_on_invali
 import ansys.fluent.core as pyfluent
 
 
+@pytest.mark.nightly
 def test_mixing_elbow_meshing_workflow(
     shared_watertight_workflow_session,
     mixing_elbow_geometry,

--- a/tests/test_pure_mesh_vs_mesh_workflow.py
+++ b/tests/test_pure_mesh_vs_mesh_workflow.py
@@ -1,9 +1,6 @@
 import pytest
 
 
-@pytest.mark.integration
-@pytest.mark.quick
-@pytest.mark.setup
 def test_pure_meshing_mode(load_mixing_elbow_pure_meshing):
     pure_meshing_session = load_mixing_elbow_pure_meshing
     # check a few dir elements
@@ -25,9 +22,6 @@ def test_pure_meshing_mode(load_mixing_elbow_pure_meshing):
         pure_meshing_session.switch_to_solver()
 
 
-@pytest.mark.integration
-@pytest.mark.quick
-@pytest.mark.setup
 def test_meshing_mode(load_mixing_elbow_meshing):
     meshing_session = load_mixing_elbow_meshing
     # check a few dir elements
@@ -40,9 +34,6 @@ def test_meshing_mode(load_mixing_elbow_meshing):
     assert meshing_session.switch_to_solver()
 
 
-@pytest.mark.integration
-@pytest.mark.quick
-@pytest.mark.setup
 def test_meshing_and_solver_mode_exit(load_mixing_elbow_meshing):
     meshing_session = load_mixing_elbow_meshing
     solver_session = meshing_session.switch_to_solver()
@@ -51,9 +42,6 @@ def test_meshing_and_solver_mode_exit(load_mixing_elbow_meshing):
     solver_session.exit()
 
 
-@pytest.mark.integration
-@pytest.mark.quick
-@pytest.mark.setup
 def test_meshing_mode_post_switching_to_solver(load_mixing_elbow_meshing):
     meshing_session = load_mixing_elbow_meshing
     meshing_session.switch_to_solver()


### PR DESCRIPTION
Moving the tests which are running meshing or solver workflows under nightly CI