### PR TITLE
fix for meshingworkflow class

### DIFF
--- a/src/ansys/fluent/core/meshing/workflow.py
+++ b/src/ansys/fluent/core/meshing/workflow.py
@@ -16,6 +16,28 @@ def _new_command_for_task(task, meshing):
 
 
 class MeshingWorkflow:
+    class TaskContainer(PyCallableStateObject):
+        def __init__(self, meshing):
+            self._meshing_container = meshing
+            self._workflow = meshing._workflow
+            self._meshing = meshing._meshing
+            self._task_container = self._workflow.TaskObject
+
+        def __getitem__(self, name):
+            return MeshingWorkflow.Task(self._meshing_container, name)
+
+        def __getattr__(self, attr):
+            return getattr(self._task_container, attr)
+
+        def __dir__(self):
+            return sorted(
+                set(
+                    list(self.__dict__.keys())
+                    + dir(type(self))
+                    + dir(self._task_container)
+                )
+            )
+
     class Task(PyCallableStateObject):
         def __init__(self, meshing, name):
             self._workflow = meshing._workflow
@@ -52,6 +74,10 @@ class MeshingWorkflow:
 
     def task(self, name):
         return MeshingWorkflow.Task(self, name)
+
+    @property
+    def TaskObject(self):
+        return MeshingWorkflow.TaskContainer(self)
 
     def __getattr__(self, attr):
         return getattr(self._workflow, attr)

--- a/src/ansys/fluent/core/meshing/workflow.py
+++ b/src/ansys/fluent/core/meshing/workflow.py
@@ -19,9 +19,7 @@ class MeshingWorkflow:
     class TaskContainer(PyCallableStateObject):
         def __init__(self, meshing):
             self._meshing_container = meshing
-            self._workflow = meshing._workflow
-            self._meshing = meshing._meshing
-            self._task_container = self._workflow.TaskObject
+            self._task_container = meshing._workflow.TaskObject
 
         def __getitem__(self, name):
             return MeshingWorkflow.Task(self._meshing_container, name)

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -200,6 +200,18 @@ def test_command_args_datamodel_se(new_mesh_session):
 
 
 @pytest.mark.skipif(os.getenv("FLUENT_IMAGE_TAG") == "v22.2.0", reason="Skip on 22.2")
+def test_command_args_including_task_object_datamodel_se(new_mesh_session):
+    session_new = new_mesh_session
+    w = session_new.workflow
+    w.InitializeWorkflow(WorkflowType="Watertight Geometry")
+    igt = w.TaskObject["Import Geometry"]
+    assert igt.Arguments == {}
+    assert igt.CommandArguments.CadImportOptions()
+    assert igt.CommandArguments.CadImportOptions.OneZonePer()
+    assert igt.CommandArguments.CadImportOptions.OneZonePer.getAttribValue("default")
+
+
+@pytest.mark.skipif(os.getenv("FLUENT_IMAGE_TAG") == "v22.2.0", reason="Skip on 22.2")
 def test_meshing_object_commands(new_mesh_session, tmp_path=pyfluent.EXAMPLES_PATH):
     session_new = new_mesh_session
     file_path = os.path.join(tmp_path, "sample_py_journal.txt")

--- a/tests/test_pure_mesh_vs_mesh_workflow.py
+++ b/tests/test_pure_mesh_vs_mesh_workflow.py
@@ -17,7 +17,6 @@ def test_pure_meshing_mode(load_mixing_elbow_pure_meshing):
     import_geometry_dir = dir(import_geometry)
     for attr in ("AddChildToTask", "Arguments", "Execute", "setState"):
         assert attr in import_geometry_dir
-    assert import_geometry.Execute()
     with pytest.raises(AttributeError):
         pure_meshing_session.switch_to_solver()
 

--- a/tests/test_pure_mesh_vs_mesh_workflow.py
+++ b/tests/test_pure_mesh_vs_mesh_workflow.py
@@ -30,7 +30,9 @@ def test_meshing_mode(load_mixing_elbow_meshing):
     session_dir = dir(meshing_session)
     for attr in ("field_data", "field_info", "meshing", "workflow"):
         assert attr in session_dir
-    assert meshing_session.workflow.TaskObject["Import Geometry"].Execute()
+    assert meshing_session.workflow.InitializeWorkflow(
+        WorkflowType="Watertight Geometry"
+    )
     assert meshing_session.switch_to_solver()
 
 

--- a/tests/util/meshing_workflow.py
+++ b/tests/util/meshing_workflow.py
@@ -11,7 +11,7 @@ def assign_task_arguments(
     task.Arguments = kwargs
     if check_state:
         # the state that we have set must be a subset of the total state
-        assert kwargs.items() <= task.Arguments().items()
+        assert kwargs.items() <= task.Arguments.items()
 
 
 def check_task_execute_preconditions(task) -> None:


### PR DESCRIPTION
If not properly wrapping TaskObject type itself in the new workflow wrapper then we can get the new CommandArguments functionality via that route as opposed to calling the new task method.