### PR TITLE
resets the global version variable after test

### DIFF
--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -19,6 +19,10 @@ def test_manual_fluent_version_setting():
     with pytest.raises(RuntimeError):
         pyfluent.set_ansys_version(22.1)
 
+    # Resets the global variable to its original state
+    pyfluent.set_ansys_version(version=pyfluent.FluentVersion.version_22R2)
+    assert FLUENT_VERSION[0] == "22.2"
+
 
 def test_manual_fluent_path_setting():
     """Test case for setting up the path to fluent.exe via program"""

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -6,6 +6,9 @@ from ansys.fluent.core.launcher.launcher import FLUENT_VERSION
 
 def test_manual_fluent_version_setting():
     """Test case for setting up the Ansys / Fluent version via program"""
+
+    initial_version_info = FLUENT_VERSION[0]
+
     pyfluent.set_ansys_version("23.1")
     assert FLUENT_VERSION[0] == "23.1"
 
@@ -20,8 +23,7 @@ def test_manual_fluent_version_setting():
         pyfluent.set_ansys_version(22.1)
 
     # Resets the global variable to its original state
-    pyfluent.set_ansys_version(version=pyfluent.FluentVersion.version_22R2)
-    assert FLUENT_VERSION[0] == "22.2"
+    pyfluent.set_ansys_version(initial_version_info)
 
 
 def test_manual_fluent_path_setting():


### PR DESCRIPTION
Fix the "test_manual_fluent_version_setting()" to reset the version of fluent after the test.