### PR TITLE
Fix root access with old-style session

### DIFF
--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -433,7 +433,7 @@ def launch_fluent(
                 pyfluent.EXAMPLES_PATH, pyfluent.EXAMPLES_PATH, args
             )
             return new_session(
-                _FluentConnection(
+                fluent_connection=_FluentConnection(
                     port=port,
                     cleanup_on_exit=cleanup_on_exit,
                     start_transcript=start_transcript,

--- a/src/ansys/fluent/core/session.py
+++ b/src/ansys/fluent/core/session.py
@@ -8,11 +8,7 @@ import warnings
 import grpc
 
 from ansys.fluent.core.fluent_connection import _FluentConnection
-from ansys.fluent.core.services.datamodel_tui import (
-    DatamodelService as DatamodelService_TUI,
-)
 from ansys.fluent.core.services.datamodel_tui import TUIMenuGeneric
-from ansys.fluent.core.services.settings import SettingsService
 from ansys.fluent.core.session_base_meshing import _BaseMeshing
 from ansys.fluent.core.session_shared import _CODEGEN_MSG_TUI
 from ansys.fluent.core.solver.flobject import get_root as settings_get_root
@@ -235,9 +231,7 @@ class Session:
         self._datamodel_service_tui = self.fluent_connection.datamodel_service_tui
         self._settings_service = self.fluent_connection.settings_service
 
-        self.solver = Session.Solver(
-            self._datamodel_service_tui, self._settings_service
-        )
+        self.solver = Session.Solver(self.fluent_connection)
 
     @classmethod
     def create_from_server_info_file(
@@ -320,14 +314,17 @@ class Session:
         )
 
     class Solver:
-        def __init__(
-            self, tui_service: DatamodelService_TUI, settings_service: SettingsService
-        ):
-            self._tui_service = tui_service
-            self._settings_service = settings_service
+        def __init__(self, fluent_connection: _FluentConnection):
+            self._fluent_connection = fluent_connection
+            self._tui_service = fluent_connection.datamodel_service_tui
+            self._settings_service = fluent_connection.settings_service
             self._tui = None
             self._settings_root = None
             self._version = None
+
+        def get_fluent_version(self):
+            """Gets and returns the fluent version."""
+            return self._fluent_connection.get_fluent_version()
 
         @property
         def version(self):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -9,6 +9,7 @@ from util.meshing_workflow import new_mesh_session  # noqa: F401
 from ansys.api.fluent.v0 import health_pb2, health_pb2_grpc
 import ansys.fluent.core as pyfluent
 from ansys.fluent.core import launch_fluent
+from ansys.fluent.core.examples import download_file
 from ansys.fluent.core.fluent_connection import _FluentConnection
 from ansys.fluent.core.services.health_check import HealthCheckService
 from ansys.fluent.core.session import _BaseSession
@@ -184,3 +185,11 @@ def test_execute_tui_commands(new_mesh_session, tmp_path=pyfluent.EXAMPLES_PATH)
         os.remove(file_path)
 
     assert returned
+
+
+def test_old_style_session(with_launching_container):
+    session = pyfluent.launch_fluent()
+    case_path = download_file("mixing_elbow.cas.h5", "pyfluent/mixing_elbow")
+    session.solver.root.file.read(file_type="case", file_name=case_path)
+    session.solver.tui.report.system.sys_stats()
+    session.exit()


### PR DESCRIPTION
The following code was failing:
```
import ansys.fluent.core as pyfluent
session = pyfluent.launch_fluent()
session.solver.root
```

This seems to be broken after merging the segregration of generated code.