### PR TITLE
Add markers for 22.2 or 23.1 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
           CLEAN: true
 
   build-test:
-    name: Unit Testing
+    name: Build and Unit Testing
     needs: test-import
     runs-on: ubuntu-latest
 
@@ -340,7 +340,7 @@ jobs:
           make install > /dev/null
 
       - name: 22.2 Unit Testing
-        run: make unittest
+        run: make unittest-dev-222
         env:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
@@ -354,7 +354,7 @@ jobs:
           retention-days: 7
 
       - name: 23.1 Unit Testing
-        run: make unittest
+        run: make unittest-dev-231
         env:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0

--- a/.github/workflows/nightly-test-run.yml
+++ b/.github/workflows/nightly-test-run.yml
@@ -9,10 +9,6 @@ jobs:
   test:
     name: Unit Testing
     runs-on: [self-hosted, pyfluent]
-    strategy:
-      fail-fast: false
-      matrix:
-        image-tag: [v22.2.0, v23.1.0]
 
     steps:
       - uses: actions/checkout@v3
@@ -52,7 +48,7 @@ jobs:
       - name: Pull Fluent docker image
         run: make docker-pull
         env:
-          FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
+          FLUENT_IMAGE_TAG: v22.2.0
 
       - name: Run API codegen
         run: make api-codegen
@@ -60,7 +56,20 @@ jobs:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
           PYFLUENT_LAUNCH_CONTAINER: 1
-          FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
+          FLUENT_IMAGE_TAG: v22.2.0
+
+      - name: Pull Fluent docker image
+        run: make docker-pull
+        env:
+          FLUENT_IMAGE_TAG: v23.1.0
+
+      - name: Run API codegen
+        run: make api-codegen
+        env:
+          ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
+          PYFLUENT_START_INSTANCE: 0
+          PYFLUENT_LAUNCH_CONTAINER: 1
+          FLUENT_IMAGE_TAG: v23.1.0
 
       - name: Install again after codegen
         run: |
@@ -68,16 +77,22 @@ jobs:
           make install > /dev/null
 
       - name: Unit Testing
-        run: make unittest-all
+        run: make unittest-all-222
         env:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
-          FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
+          FLUENT_IMAGE_TAG: v22.2.0
 
       - name: Upload Coverage Results
-        if: matrix.image-tag == 'v22.2.0'
         uses: actions/upload-artifact@v3
         with:
-          name: HTML-Coverage-tag-${{ matrix.image-tag }}
+          name: HTML-Coverage-tag-222
           path: cov_html
           retention-days: 7
+
+      - name: Unit Testing
+        run: make unittest-all-231
+        env:
+          ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
+          PYFLUENT_START_INSTANCE: 0
+          FLUENT_IMAGE_TAG: v23.1.0

--- a/Makefile
+++ b/Makefile
@@ -17,15 +17,27 @@ docker-pull:
 test-import:
 	@python -c "import ansys.fluent.core as pyfluent"
 
-unittest:
+unittest: unittest-dev-222
+
+unittest-dev-222:
 	@echo "Running unittests"
 	@pip install -r requirements/requirements_tests.txt
-	@pytest -v -m "unmarked" --cov=ansys.fluent --cov-report html:cov_html --cov-config=.coveragerc
+	@pytest -v -m "dev and not fluent_231" --cov=ansys.fluent --cov-report html:cov_html --cov-config=.coveragerc
 
-unittest-all:
+unittest-dev-231:
+	@echo "Running unittests"
+	@pip install -r requirements/requirements_tests.txt
+	@pytest -v -m "dev and not fluent_222" --cov=ansys.fluent --cov-report html:cov_html --cov-config=.coveragerc
+
+unittest-all-222:
 	@echo "Running all unittests"
 	@pip install -r requirements/requirements_tests.txt
-	@pytest -v --cov=ansys.fluent --cov-report html:cov_html --cov-config=.coveragerc
+	@pytest -v -m "not fluent_231" --cov=ansys.fluent --cov-report html:cov_html --cov-config=.coveragerc
+
+unittest-all-231:
+	@echo "Running all unittests"
+	@pip install -r requirements/requirements_tests.txt
+	@pytest -v -m "not fluent_222" --cov=ansys.fluent --cov-report html:cov_html --cov-config=.coveragerc
 
 api-codegen:
 	@echo "Running API codegen"

--- a/codegen/tuigen.py
+++ b/codegen/tuigen.py
@@ -80,7 +80,7 @@ _XML_HELPSTRINGS = {}
 
 def _copy_tui_help_xml_file(version: str):
     if os.getenv("PYFLUENT_LAUNCH_CONTAINER") == "1":
-        image_tag = os.getenv("FLUENT_IMAGE_TAG", "v23.1.0")
+        image_tag = os.getenv("FLUENT_IMAGE_TAG", "v22.2.0")
         image_name = f"ghcr.io/pyansys/pyfluent:{image_tag}"
         container_name = uuid.uuid4().hex
         is_linux = platform.system() == "Linux"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+addopts = -m "dev and not fluent_231"
 markers =
     integration:Short-running tests which read a simple input file and check the exposure and values of various setting objects
     quick:Run the quick tests
@@ -6,5 +7,7 @@ markers =
     solve:Long-running tests that continue until convergence
     mesh:Tests covering meshing scenarios
     optislang:Test Optislang integration scenarios
-    unmarked:All unmarked tests, marked automatically
-    nightly:Run under nightly CI
+    dev:Tests that must be successful before PR merge, includes unmarked tests
+    nightly:Tests that run under nightly CI
+    fluent_222:Tests that run only with Fluent 22.2
+    fluent_231:Tests that run only with Fluent 23.1

--- a/src/ansys/fluent/core/launcher/fluent_container.py
+++ b/src/ansys/fluent/core/launcher/fluent_container.py
@@ -38,7 +38,7 @@ def start_fluent_container(mounted_from: str, mounted_to: str, args: List[str]) 
     license_server = os.environ["ANSYSLMD_LICENSE_FILE"]
     port = _get_free_port()
     container_sifile = mounted_to + "/" + Path(sifile).name
-    image_tag = os.getenv("FLUENT_IMAGE_TAG", "latest")
+    image_tag = os.getenv("FLUENT_IMAGE_TAG", "v22.2.0")
 
     try:
         subprocess.run(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ pytest_plugins = [
 def pytest_collection_modifyitems(items, config):
     for item in items:
         if not any(item.iter_markers()):
-            item.add_marker("unmarked")
+            item.add_marker("dev")
 
 
 @pytest.fixture

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -1,9 +1,3 @@
-""".. _ref_mixing_elbow_tui_api:
-
-Fluid Flow and Heat Transfer in a Mixing Elbow
----------------------------------------------------
-This test covers generic meshing workflow behaviour
-"""
 from functools import partial
 import os
 
@@ -26,6 +20,9 @@ def test_mixing_elbow_meshing_workflow(
     shared_watertight_workflow_session,
     mixing_elbow_geometry,
 ):
+    """
+    This test covers generic meshing workflow behaviour
+    """
     meshing_session = shared_watertight_workflow_session
     workflow = meshing_session.workflow
 
@@ -188,7 +185,8 @@ def test_meshing_workflow_raises_exception_on_invalid_key_in_task_args_2(
 """
 
 
-@pytest.mark.skipif(os.getenv("FLUENT_IMAGE_TAG") == "v22.2.0", reason="Skip on 22.2")
+@pytest.mark.dev
+@pytest.mark.fluent_231
 def test_command_args_datamodel_se(new_mesh_session):
     session_new = new_mesh_session
     w = session_new.workflow
@@ -199,7 +197,8 @@ def test_command_args_datamodel_se(new_mesh_session):
     assert igt.CommandArguments.CadImportOptions.OneZonePer.getAttribValue("default")
 
 
-@pytest.mark.skipif(os.getenv("FLUENT_IMAGE_TAG") == "v22.2.0", reason="Skip on 22.2")
+@pytest.mark.dev
+@pytest.mark.fluent_231
 def test_command_args_including_task_object_datamodel_se(new_mesh_session):
     session_new = new_mesh_session
     w = session_new.workflow
@@ -211,7 +210,8 @@ def test_command_args_including_task_object_datamodel_se(new_mesh_session):
     assert igt.CommandArguments.CadImportOptions.OneZonePer.getAttribValue("default")
 
 
-@pytest.mark.skipif(os.getenv("FLUENT_IMAGE_TAG") == "v22.2.0", reason="Skip on 22.2")
+@pytest.mark.dev
+@pytest.mark.fluent_231
 def test_meshing_object_commands(new_mesh_session, tmp_path=pyfluent.EXAMPLES_PATH):
     session_new = new_mesh_session
     file_path = os.path.join(tmp_path, "sample_py_journal.txt")
@@ -230,7 +230,8 @@ def test_meshing_object_commands(new_mesh_session, tmp_path=pyfluent.EXAMPLES_PA
     assert returned
 
 
-@pytest.mark.skipif(os.getenv("FLUENT_IMAGE_TAG") == "v22.2.0", reason="Skip on 22.2")
+@pytest.mark.dev
+@pytest.mark.fluent_231
 def test_attribute_query_list_types(new_mesh_session):
     session_new = new_mesh_session
     w = session_new.workflow

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -204,7 +204,7 @@ def test_command_args_including_task_object_datamodel_se(new_mesh_session):
     w = session_new.workflow
     w.InitializeWorkflow(WorkflowType="Watertight Geometry")
     igt = w.TaskObject["Import Geometry"]
-    assert igt.Arguments == {}
+    assert igt.Arguments() == {}
     assert igt.CommandArguments.CadImportOptions()
     assert igt.CommandArguments.CadImportOptions.OneZonePer()
     assert igt.CommandArguments.CadImportOptions.OneZonePer.getAttribValue("default")

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -166,7 +166,8 @@ def test_create_session_from_launch_fluent_by_setting_ip_and_port_env_var(
     assert session.check_health() == HealthCheckService.Status.NOT_SERVING.name
 
 
-@pytest.mark.skipif(os.getenv("FLUENT_IMAGE_TAG") == "v22.2.0", reason="Skip on 22.2")
+@pytest.mark.dev
+@pytest.mark.fluent_231
 def test_execute_tui_commands(new_mesh_session, tmp_path=pyfluent.EXAMPLES_PATH):
     session = new_mesh_session
     file_path = os.path.join(tmp_path, "sample_py_journal.txt")

--- a/tests/test_solvermode/test_boundaries.py
+++ b/tests/test_solvermode/test_boundaries.py
@@ -81,7 +81,7 @@ def test_boundaries_elbow(load_mixing_elbow_mesh):
 
 @pytest.mark.integration
 @pytest.mark.setup
-@pytest.mark.skipif(os.getenv("FLUENT_IMAGE_TAG") == "v22.2.0", reason="Skip on 22.2")
+@pytest.mark.fluent_231
 def test_boundaries_periodic(load_periodic_rot_cas):
     solver_session = load_periodic_rot_cas
     print(__file__)


### PR DESCRIPTION
This will remove the usage of `FLUET_IMAGE_TAG` env. var. from pytest so that users can run them easily.