### PR TITLE
Turn machine lists into Fluent parallel options

### DIFF
--- a/src/ansys/fluent/core/scheduler/__init__.py
+++ b/src/ansys/fluent/core/scheduler/__init__.py
@@ -9,6 +9,13 @@ _machineSep = ","
 
 
 def build_parallel_options(machine_list: MachineList) -> str:
+    """Constructs Fluent's parallel arguments given a list of machines.
+
+    Parameters
+    ----------
+    machine_list : MachineList
+        List of machines obtained by calling `load_machines`.
+    """
     parOpt = _fluentOpt.replace("%n%", str(machine_list.number_of_cores))
     cnfList = (
         machine_list[0].host_name + _procSep + str(machine_list[0].number_of_cores)

--- a/src/ansys/fluent/core/scheduler/__init__.py
+++ b/src/ansys/fluent/core/scheduler/__init__.py
@@ -1,3 +1,24 @@
 """A package providing job scheduler support."""
 
-from .load_machines import load_machines  # noqa: F401
+from ansys.fluent.core.scheduler.load_machines import load_machines  # noqa: F401
+from ansys.fluent.core.scheduler.machine_list import MachineList
+
+_fluentOpt = "-t%n% -cnf=%machineList%"
+_procSep = ":"
+_machineSep = ","
+
+
+def build_parallel_options(machine_list: MachineList) -> str:
+    parOpt = _fluentOpt.replace("%n%", str(machine_list.number_of_cores))
+    cnfList = (
+        machine_list[0].host_name + _procSep + str(machine_list[0].number_of_cores)
+    )
+    for m in range(1, len(machine_list)):
+        cnfList += (
+            _machineSep
+            + machine_list[m].host_name
+            + _procSep
+            + str(machine_list[m].number_of_cores)
+        )
+    parOpt = parOpt.replace("%machineList%", cnfList)
+    return parOpt

--- a/src/ansys/fluent/core/scheduler/machine_list.py
+++ b/src/ansys/fluent/core/scheduler/machine_list.py
@@ -87,8 +87,14 @@ class MachineList(object):
         for machine in machinesIn:
             self._machines.append(machine)
 
+    def __len__(self):
+        return self.num_machines
+
     def __iter__(self):
         return self._machines.__iter__()
+
+    def __getitem__(self, index):
+        return self._machines[index]
 
     def __deepcopy__(self, memo):
         machineList = []

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -6,6 +6,7 @@ from builtins import range
 import os
 import unittest
 
+from ansys.fluent.core.scheduler import build_parallel_options
 from ansys.fluent.core.scheduler.load_machines import (
     _construct_machine_list_slurm,
     _parse_host_info,
@@ -162,6 +163,8 @@ class TestLoadMachines(unittest.TestCase):
             self.assertEqual(machine.number_of_cores, expectedValue[machine.host_name])
         # Ensure that the order is preserved
         self.assertEqual(machineList.machines[0].host_name, "M0")
+        fluentOpts = build_parallel_options(machineList)
+        self.assertEqual(fluentOpts, "-t4 -cnf=M0:1,M1:2,M2:1")
 
     def test_constrain_machines2(self):
         machineList = load_machines(host_info="M0:2,M1:3,M2:2", ncores=3)
@@ -171,6 +174,8 @@ class TestLoadMachines(unittest.TestCase):
             self.assertEqual(machine.number_of_cores, expectedValue[machine.host_name])
         # Ensure that the order is preserved
         self.assertEqual(machineList.machines[0].host_name, "M0")
+        fluentOpts = build_parallel_options(machineList)
+        self.assertEqual(fluentOpts, "-t3 -cnf=M0:1,M1:1,M2:1")
 
     def test_overload_machines1(self):
         machineList = load_machines(host_info="M0:2,M1:1", ncores=10)
@@ -180,6 +185,8 @@ class TestLoadMachines(unittest.TestCase):
             self.assertEqual(machine.number_of_cores, expectedValue[machine.host_name])
         # Ensure that the order is preserved
         self.assertEqual(machineList.machines[0].host_name, "M0")
+        fluentOpts = build_parallel_options(machineList)
+        self.assertEqual(fluentOpts, "-t3 -cnf=M0:2,M1:1")
 
     def test_overload_machines2(self):
         machineList = load_machines(host_info="M0,M0,M1", ncores=10)
@@ -189,6 +196,8 @@ class TestLoadMachines(unittest.TestCase):
             self.assertEqual(machine.number_of_cores, expectedValue[machine.host_name])
         # Ensure that the order is preserved
         self.assertEqual(machineList.machines[0].host_name, "M0")
+        fluentOpts = build_parallel_options(machineList)
+        self.assertEqual(fluentOpts, "-t3 -cnf=M0:2,M1:1")
 
     def test_winhpc(self):
         os.environ["CCP_NODES"] = "3 M0 8 M1 8 M2 16"
@@ -198,6 +207,8 @@ class TestLoadMachines(unittest.TestCase):
         self.assertEqual(machineList.machines[0].host_name, "M0")
         self.assertEqual(machineList.machines[1].host_name, "M1")
         self.assertEqual(machineList.machines[2].host_name, "M2")
+        fluentOpts = build_parallel_options(machineList)
+        self.assertEqual(fluentOpts, "-t32 -cnf=M0:8,M1:8,M2:16")
 
     def test_slurm_no_brackets(self):
         os.environ["SLURM_JOB_NODELIST"] = "M0,M1,M2"
@@ -209,6 +220,8 @@ class TestLoadMachines(unittest.TestCase):
         self.assertEqual(machineList.machines[0].host_name, "M0")
         self.assertEqual(machineList.machines[1].host_name, "M1")
         self.assertEqual(machineList.machines[2].host_name, "M2")
+        fluentOpts = build_parallel_options(machineList)
+        self.assertEqual(fluentOpts, "-t24 -cnf=M0:8,M1:8,M2:8")
         del os.environ["SLURM_JOB_NODELIST"]
         del os.environ["SLURM_NTASKS_PER_NODE"]
 
@@ -222,6 +235,8 @@ class TestLoadMachines(unittest.TestCase):
         self.assertEqual(machineList.machines[0].host_name, "M0")
         self.assertEqual(machineList.machines[1].host_name, "M1")
         self.assertEqual(machineList.machines[2].host_name, "M2")
+        fluentOpts = build_parallel_options(machineList)
+        self.assertEqual(fluentOpts, "-t36 -cnf=M0:12,M1:12,M2:12")
         del os.environ["SLURM_JOB_NODELIST"]
         del os.environ["SLURM_NTASKS_PER_NODE"]
 


### PR DESCRIPTION
Testing this on SLURM, these small changes to MachineList make the arguments construction a bit more straightforward.  I've added support for `len()` and indexing operation.  The function to build the parallel arguments is added to the main package and is tested.

From here one would need to call these functions in launch_fluent.  I'll try this next.
