### PR TITLE
Ensure load_machines returns MachineList in all cases

### DIFF
--- a/src/ansys/fluent/core/scheduler/load_machines.py
+++ b/src/ansys/fluent/core/scheduler/load_machines.py
@@ -8,11 +8,14 @@ variables, respectively.
 import csv
 import os
 import subprocess
+from typing import Dict, List
 
 from ansys.fluent.core.scheduler.machine_list import Machine, MachineList
 
 
-def load_machines(machine_info=None, host_info=None, ncores=None):
+def load_machines(
+    machine_info: List[Dict[str, int]] = None, host_info: str = None, ncores: int = None
+) -> MachineList:
     """Provide a function to construct a machine list from allocated machines.
 
     Parameters
@@ -54,7 +57,7 @@ def load_machines(machine_info=None, host_info=None, ncores=None):
     names using scontrol.
     """
 
-    machine_list = []
+    machine_list = MachineList()
 
     if machine_info:
         machine_list = _construct_machine_list_manual(machine_info)
@@ -95,8 +98,10 @@ def load_machines(machine_info=None, host_info=None, ncores=None):
         machine_list = _construct_machine_list_ccs(hostList)
     elif ncores:
         machine_list = _get_local_machine(ncores)
+    elif ncores is None:
+        machine_list = _get_local_machine(1)
 
-    if machine_list and ncores:
+    if ncores is not None and machine_list.number_of_cores != ncores:
         # If both machine list and number of cores are provided, edit the
         # machine list to use exactly the number of cores indicated.
         machine_list = _restrict_machines_to_core_count(machine_list, ncores)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4,6 +4,7 @@ for machines to run on.
 """
 from builtins import range
 import os
+import socket
 import unittest
 
 from ansys.fluent.core.scheduler import build_parallel_options
@@ -155,6 +156,16 @@ class TestLoadMachines(unittest.TestCase):
     def tearDown(self):
         self._machineList.reset()
 
+    def test_no_environment(self):
+        machineList = load_machines()
+        self.assertEqual(machineList[0].host_name, socket.gethostname())
+        self.assertEqual(machineList.number_of_cores, 1)
+
+    def test_no_environment_cores(self):
+        machineList = load_machines(ncores=4)
+        self.assertEqual(machineList[0].host_name, socket.gethostname())
+        self.assertEqual(machineList.number_of_cores, 4)
+
     def test_constrain_machines1(self):
         machineList = load_machines(host_info="M0:2,M1:3,M2:2", ncores=4)
         expectedValue = {"M0": 1, "M1": 2, "M2": 1}
@@ -209,6 +220,7 @@ class TestLoadMachines(unittest.TestCase):
         self.assertEqual(machineList.machines[2].host_name, "M2")
         fluentOpts = build_parallel_options(machineList)
         self.assertEqual(fluentOpts, "-t32 -cnf=M0:8,M1:8,M2:16")
+        del os.environ["CCP_NODES"]
 
     def test_slurm_no_brackets(self):
         os.environ["SLURM_JOB_NODELIST"] = "M0,M1,M2"


### PR DESCRIPTION
The function will now assume that if no parallel environment is configured then you want to run on the current machine with a single core.