### PR TITLE
Add nightly CI to compare flobject

### DIFF
--- a/.ci/compare_flobject.py
+++ b/.ci/compare_flobject.py
@@ -1,0 +1,31 @@
+import platform
+import subprocess
+import uuid
+
+
+def compare_flobject():
+    image_name = f"ghcr.io/pyansys/pyfluent:v23.1.0"
+    container_name = uuid.uuid4().hex
+    is_linux = platform.system() == "Linux"
+    subprocess.run(
+        f"docker container create --name {container_name} {image_name}",
+        shell=is_linux,
+    )
+    xml_source = f"/ansys_inc/v231/fluent/fluent23.1.0/cortex/pylib/flapi/flobject.py"
+    subprocess.run(
+        f"docker cp {container_name}:{xml_source} fluent_flobject.py", shell=is_linux
+    )
+    subprocess.run(f"docker container rm {container_name}", shell=is_linux)
+    p = subprocess.run(
+        f"diff -u fluent_flobject.py src/ansys/fluent/core/solver/flobject.py",
+        shell=is_linux,
+        capture_output=True,
+        text=True,
+    )
+    print(p.stdout)
+    if p.returncode != 0:
+        raise RuntimeError("flobject.py is different in Fluent and PyFLuent.")
+
+
+if __name__ == "__main__":
+    compare_flobject()

--- a/.github/workflows/compare-flobject.yml
+++ b/.github/workflows/compare-flobject.yml
@@ -1,0 +1,33 @@
+name: Compare flobject between Fluent and PyFluent
+
+on:
+  schedule:  # UTC at 0400
+    - cron:  '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  compare_flobject:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.REPO_DOWNLOAD_PAT }}
+
+      - name: Pull Fluent docker image
+        run: make docker-pull
+        env:
+          FLUENT_IMAGE_TAG: v23.1.0
+
+      - name: Compare flobject
+        run: make compare-flobject

--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,6 @@ build-doc:
 	@xvfb-run make -C doc html
 	@touch doc/_build/html/.nojekyll
 	@echo "$(DOCS_CNAME)" >> doc/_build/html/CNAME
+
+compare-flobject:
+	@python .ci/compare_flobject.py


### PR DESCRIPTION
Sample output ([from a test CI run](https://github.com/pyansys/pyfluent/actions/runs/3103707183/jobs/5027335865#step:6:42)):
```
--- fluent_flobject.py	2022-09-13 17:00:29.000000000 +0000
+++ src/ansys/fluent/core/solver/flobject.py	2022-09-22 07:50:55.709520981 +0000
@@ -[14](https://github.com/pyansys/pyfluent/actions/runs/3103707183/jobs/5027335865#step:6:15)5,7 +145,7 @@
         """Get the requested attribute for the object."""
         attrs = self.get_attrs([attr])
         attrs = attrs.get("attrs", attrs)
Traceback (most recent call last):
-        if attr != "active?" and attrs.get("active?", True) is False:
+        if attr != "active?" and attrs and attrs.get("active?", True) is False:
             raise RuntimeError("Object is not active")
         return attrs[attr] if attrs else None
 
  File "/home/runner/work/pyfluent/pyfluent/.ci/compare_flobject.py", line 31, in <module>
@@ -864,7 +864,7 @@
    compare_flobject()
                     dct["__doc__"] = f"'{pname.strip('_')}' child."
 
         include_child_named_objects = info.get("include_child_named_objects", False)
-        user_creatable = info.get("user_creatable", False)
+        user_creatable = info.get("user_creatable", True)
 
         bases = (base,)
         if include_child_named_objects:

  File "/home/runner/work/pyfluent/pyfluent/.ci/compare_flobject.py", line [27](https://github.com/pyansys/pyfluent/actions/runs/3103707183/jobs/5027335865#step:6:28), in compare_flobject
    raise RuntimeError("flobject.py is different in Fluent and PyFLuent.")
RuntimeError: flobject.py is different in Fluent and PyFLuent.
make: *** [Makefile:58: compare-flobject] Error 1
Error: Process completed with exit code 2.
```