### PR TITLE
Not needed since protobuf files were refactored out

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,8 +1,0 @@
-BasedOnStyle: Google
-IndentWidth: 2
-ColumnLimit: 0
----
-Language: Proto
-AllowShortBlocksOnASingleLine: Empty
----
-Language: Cpp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,13 +9,6 @@ repos:
       src/ansys, codegen, doc, examples, tests
     ]
 
-- repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v14.0.1
-  hooks:
-  - id: clang-format
-    files: ^.+.proto$
-    args: [ -i, -style=file ]
-
 - repo: https://github.com/pycqa/isort
   rev: 5.10.1
   hooks:


### PR DESCRIPTION
Since we moved the grpc protobuf files out of the core repo we don't need the clang-format stuff running.