### PR TITLE
Some doc cleanups based on feedback from ACE team

### DIFF
--- a/doc/source/api/core/meshing/index.rst
+++ b/doc/source/api/core/meshing/index.rst
@@ -11,91 +11,91 @@ Workflow example
 .. code:: python
 
     import ansys.fluent.core as pyfluent
+
     meshing = pyfluent.launch_fluent(mode="meshing")
     meshing.start_transcript()
-    meshing.workflow.InitializeWorkflow(WorkflowType='Watertight Geometry')
-    meshing.workflow.TaskObject['Import Geometry'].Arguments = dict(FileName='cylinder.agdb')
-    meshing.workflow.TaskObject['Import Geometry'].Execute()
+    meshing.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")
+    meshing.workflow.TaskObject["Import Geometry"].Arguments = {"FileName": "cylinder.agdb"}
+    meshing.workflow.TaskObject["Import Geometry"].Execute()
     meshing.tui.mesh.check_mesh()
     exit()
-	
-You can manually convert existing Fluent meshing workflow
-journals to session-based PyFluent scripts. Examples follow of a Fluent journal
-and the equivalent PyFluent script.
+
+You can manually convert existing Fluent meshing workflow journals to
+session-based PyFluent scripts. Examples follow of a Fluent journal and the
+equivalent PyFluent script.
 
 **Fluent journal**
 
-.. code-block::
+.. code:: scheme
 
-  (%py-exec "workflow.InitializeWorkflow(WorkflowType=r'Watertight Geometry')")
-  (%py-exec "workflow.TaskObject['Import Geometry'].Arguments.setState({r'FileName': r'file.pmdb',r'LengthUnit': r'in',})")
-  (%py-exec "workflow.TaskObject['Import Geometry'].Execute()")
-  (%py-exec "workflow.TaskObject['Add Local Sizing'].AddChildToTask()")
-  (%py-exec "workflow.TaskObject['Add Local Sizing'].Execute()")
-  (%py-exec "workflow.TaskObject['Generate the Surface Mesh'].Arguments.setState({r'CFDSurfaceMeshControls': {r'MaxSize': 0.3,},})")
-  (%py-exec "workflow.TaskObject['Generate the Surface Mesh'].Execute()")
-  (%py-exec "workflow.TaskObject['Describe Geometry'].UpdateChildTasks(SetupTypeChanged=False)")
-  (%py-exec "workflow.TaskObject['Describe Geometry'].Arguments.setState({r'SetupType': r'The geometry consists of only fluid regions with no voids',})")
-  (%py-exec "workflow.TaskObject['Describe Geometry'].UpdateChildTasks(SetupTypeChanged=True)")
-  (%py-exec "workflow.TaskObject['Describe Geometry'].Execute()")
-  (%py-exec "workflow.TaskObject['Update Boundaries'].Arguments.setState({r'BoundaryLabelList': [r'wall-inlet'],r'BoundaryLabelTypeList': [r'wall'],r'OldBoundaryLabelList': [r'wall-inlet'],r'OldBoundaryLabelTypeList': [r'velocity-inlet'],})")
-  (%py-exec "workflow.TaskObject['Update Boundaries'].Execute()")
-  (%py-exec "workflow.TaskObject['Update Regions'].Execute()")
-  (%py-exec "workflow.TaskObject['Add Boundary Layers'].AddChildToTask()")
-  (%py-exec "workflow.TaskObject['Add Boundary Layers'].InsertCompoundChildTask()")
-  (%py-exec "workflow.TaskObject['smooth-transition_1'].Arguments.setState({r'BLControlName': r'smooth-transition_1',})")
-  (%py-exec "workflow.TaskObject['Add Boundary Layers'].Arguments.setState({})")
-  (%py-exec "workflow.TaskObject['smooth-transition_1'].Execute()")
-  (%py-exec "workflow.TaskObject['Generate the Volume Mesh'].Arguments.setState({r'VolumeFill': r'poly-hexcore',r'VolumeFillControls': {r'HexMaxCellLength': 0.3,},})")
-  (%py-exec "workflow.TaskObject['Generate the Volume Mesh'].Execute()")
+    (%py-exec "workflow.InitializeWorkflow(WorkflowType=r'Watertight Geometry')")
+    (%py-exec "workflow.TaskObject['Import Geometry'].Arguments.set_state({r'FileName': r'file.pmdb',r'LengthUnit': r'in',})")
+    (%py-exec "workflow.TaskObject['Import Geometry'].Execute()")
+    (%py-exec "workflow.TaskObject['Add Local Sizing'].AddChildToTask()")
+    (%py-exec "workflow.TaskObject['Add Local Sizing'].Execute()")
+    (%py-exec "workflow.TaskObject['Generate the Surface Mesh'].Arguments.set_state({r'CFDSurfaceMeshControls': {r'MaxSize': 0.3,},})")
+    (%py-exec "workflow.TaskObject['Generate the Surface Mesh'].Execute()")
+    (%py-exec "workflow.TaskObject['Describe Geometry'].UpdateChildTasks(SetupTypeChanged=False)")
+    (%py-exec "workflow.TaskObject['Describe Geometry'].Arguments.set_state({r'SetupType': r'The geometry consists of only fluid regions with no voids',})")
+    (%py-exec "workflow.TaskObject['Describe Geometry'].UpdateChildTasks(SetupTypeChanged=True)")
+    (%py-exec "workflow.TaskObject['Describe Geometry'].Execute()")
+    (%py-exec "workflow.TaskObject['Update Boundaries'].Arguments.set_state({r'BoundaryLabelList': [r'wall-inlet'],r'BoundaryLabelTypeList': [r'wall'],r'OldBoundaryLabelList': [r'wall-inlet'],r'OldBoundaryLabelTypeList': [r'velocity-inlet'],})")
+    (%py-exec "workflow.TaskObject['Update Boundaries'].Execute()")
+    (%py-exec "workflow.TaskObject['Update Regions'].Execute()")
+    (%py-exec "workflow.TaskObject['Add Boundary Layers'].AddChildToTask()")
+    (%py-exec "workflow.TaskObject['Add Boundary Layers'].InsertCompoundChildTask()")
+    (%py-exec "workflow.TaskObject['smooth-transition_1'].Arguments.set_state({r'BLControlName': r'smooth-transition_1',})")
+    (%py-exec "workflow.TaskObject['Add Boundary Layers'].Arguments.set_state({})")
+    (%py-exec "workflow.TaskObject['smooth-transition_1'].Execute()")
+    (%py-exec "workflow.TaskObject['Generate the Volume Mesh'].Arguments.set_state({r'VolumeFill': r'poly-hexcore',r'VolumeFillControls': {r'HexMaxCellLength': 0.3,},})")
+    (%py-exec "workflow.TaskObject['Generate the Volume Mesh'].Execute()")
 
 **PyFluent script**
 
 .. code:: python
 
-  meshing.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")
-  meshing.workflow.TaskObject["Import Geometry"].Arguments = dict(
-      FileName=import_filename, LengthUnit="in"
-  )
-  meshing.workflow.TaskObject["Import Geometry"].Execute()
-  meshing.workflow.TaskObject["Add Local Sizing"].AddChildToTask()
-  meshing.workflow.TaskObject["Add Local Sizing"].Execute()
-  meshing.workflow.TaskObject["Generate the Surface Mesh"].Arguments = {
-      "CFDSurfaceMeshControls": {"MaxSize": 0.3}
-  }
-  meshing.workflow.TaskObject["Generate the Surface Mesh"].Execute()
-  meshing.workflow.TaskObject["Describe Geometry"].UpdateChildTasks(
-      SetupTypeChanged=False
-  )
-  meshing.workflow.TaskObject["Describe Geometry"].Arguments = dict(
-      SetupType="The geometry consists of only fluid regions with no voids"
-  )
-  meshing.workflow.TaskObject["Describe Geometry"].UpdateChildTasks(
-      SetupTypeChanged=True
-  )
-  meshing.workflow.TaskObject["Describe Geometry"].Execute()
-  meshing.workflow.TaskObject["Update Boundaries"].Arguments = {
-      "BoundaryLabelList": ["wall-inlet"],
-      "BoundaryLabelTypeList": ["wall"],
-      "OldBoundaryLabelList": ["wall-inlet"],
-      "OldBoundaryLabelTypeList": ["velocity-inlet"],
-  }
-  meshing.workflow.TaskObject["Update Boundaries"].Execute()
-  meshing.workflow.TaskObject["Update Regions"].Execute()
-  meshing.workflow.TaskObject["Add Boundary Layers"].AddChildToTask()
-  meshing.workflow.TaskObject["Add Boundary Layers"].InsertCompoundChildTask()
-  meshing.workflow.TaskObject["smooth-transition_1"].Arguments = {
-      "BLControlName": "smooth-transition_1",
-  }
-  meshing.workflow.TaskObject["Add Boundary Layers"].Arguments = {}
-  meshing.workflow.TaskObject["smooth-transition_1"].Execute()
-  meshing.workflow.TaskObject["Generate the Volume Mesh"].Arguments = {
-      "VolumeFill": "poly-hexcore",
-      "VolumeFillControls": {
-          "HexMaxCellLength": 0.3,
-      },
-  }
-  meshing.workflow.TaskObject["Generate the Volume Mesh"].Execute()
+    meshing.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")
+    meshing.workflow.TaskObject["Import Geometry"].Arguments = {
+        "FileName": import_filename,
+        "LengthUnit": "in",
+    }
+    meshing.workflow.TaskObject["Import Geometry"].Execute()
+    meshing.workflow.TaskObject["Add Local Sizing"].AddChildToTask()
+    meshing.workflow.TaskObject["Add Local Sizing"].Execute()
+    meshing.workflow.TaskObject["Generate the Surface Mesh"].Arguments = {
+        "CFDSurfaceMeshControls": {"MaxSize": 0.3}
+    }
+    meshing.workflow.TaskObject["Generate the Surface Mesh"].Execute()
+    meshing.workflow.TaskObject["Describe Geometry"].UpdateChildTasks(
+        SetupTypeChanged=False
+    )
+    meshing.workflow.TaskObject["Describe Geometry"].Arguments = {
+        SetupType: "The geometry consists of only fluid regions with no voids"
+    }
+    meshing.workflow.TaskObject["Describe Geometry"].UpdateChildTasks(SetupTypeChanged=True)
+    meshing.workflow.TaskObject["Describe Geometry"].Execute()
+    meshing.workflow.TaskObject["Update Boundaries"].Arguments = {
+        "BoundaryLabelList": ["wall-inlet"],
+        "BoundaryLabelTypeList": ["wall"],
+        "OldBoundaryLabelList": ["wall-inlet"],
+        "OldBoundaryLabelTypeList": ["velocity-inlet"],
+    }
+    meshing.workflow.TaskObject["Update Boundaries"].Execute()
+    meshing.workflow.TaskObject["Update Regions"].Execute()
+    meshing.workflow.TaskObject["Add Boundary Layers"].AddChildToTask()
+    meshing.workflow.TaskObject["Add Boundary Layers"].InsertCompoundChildTask()
+    meshing.workflow.TaskObject["smooth-transition_1"].Arguments = {
+        "BLControlName": "smooth-transition_1",
+    }
+    meshing.workflow.TaskObject["Add Boundary Layers"].Arguments = {}
+    meshing.workflow.TaskObject["smooth-transition_1"].Execute()
+    meshing.workflow.TaskObject["Generate the Volume Mesh"].Arguments = {
+        "VolumeFill": "poly-hexcore",
+        "VolumeFillControls": {
+            "HexMaxCellLength": 0.3,
+        },
+    }
+    meshing.workflow.TaskObject["Generate the Volume Mesh"].Execute()
 
 TUI commands example
 --------------------
@@ -103,6 +103,7 @@ TUI commands example
 .. code:: python
 
     import ansys.fluent.core as pyfluent
+
     meshing_session = pyfluent.launch_fluent(mode="meshing")
     meshing_session.tui.file.read_case("elbow.cas.gz")
     solver = meshing_session.switch_to_solver()

--- a/doc/source/user_guide/boundary_conditions.rst
+++ b/doc/source/user_guide/boundary_conditions.rst
@@ -28,53 +28,29 @@ Python code for defining velocity boundary conditions at inlets.
 .. code:: python
 
     import ansys.fluent.core as pyfluent
-    solver = pyfluent.launch_fluent(precision='double', processor_count=2, mode="solver")
-    solver.tui.file.read_case('file.cas.h5')
+
+    solver = pyfluent.launch_fluent(precision="double", processor_count=2, mode="solver")
+    solver.tui.file.read_case("file.cas.h5")
     solver.tui.define.boundary_conditions.set.velocity_inlet(
-        'cold-inlet',
-        (),
-        'vmag',
-        'no',
-        0.4,
-        'quit'
+        "cold-inlet", (), "vmag", "no", 0.4, "quit"
     )
     solver.tui.define.boundary_conditions.set.velocity_inlet(
-        'cold-inlet',
-        (),
-        'ke-spec',
-        'no',
-        'no',
-        'no',
-        'yes',
-        'quit'
+        "cold-inlet", (), "ke-spec", "no", "no", "no", "yes", "quit"
     )
     solver.tui.define.boundary_conditions.set.velocity_inlet(
-        'cold-inlet',
-        (),
-        'turb-intensity',
-        5,
-        'quit'
+        "cold-inlet", (), "turb-intensity", 5, "quit"
     )
     solver.tui.define.boundary_conditions.set.velocity_inlet(
-        'cold-inlet',
-        (),
-        'turb-hydraulic-diam',
-        4,
-        'quit'
+        "cold-inlet", (), "turb-hydraulic-diam", 4, "quit"
     )
     solver.tui.define.boundary_conditions.set.velocity_inlet(
-        'cold-inlet',
-        (),
-        'temperature',
-        'no',
-        293.15,
-        'quit'
+        "cold-inlet", (), "temperature", "no", 293.15, "quit"
     )
 
 Copying boundary conditions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-This example shows a comparison between the TUI command and the
-Python code for copying boundary conditions to other zones.
+This example shows a comparison between the TUI command and the Python code for
+copying boundary conditions to other zones.
 
 **TUI command**
 
@@ -90,8 +66,8 @@ Python code for copying boundary conditions to other zones.
 
 Listing zones
 ~~~~~~~~~~~~~
-This example shows a comparison between the TUI command and the
-Python code for printing to the Fluent console the types and IDs of all zones.
+This example shows a comparison between the TUI command and the Python code for
+printing to the Fluent console the types and IDs of all zones.
 
 **TUI command**
 
@@ -107,8 +83,8 @@ Python code for printing to the Fluent console the types and IDs of all zones.
 
 Modifying cell zone conditions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-This example shows a comparison between the TUI command and the
-Python code for modifying cell zone conditions.
+This example shows a comparison between the TUI command and the Python code for
+modifying cell zone conditions.
 
 **TUI command**
 
@@ -120,31 +96,31 @@ Python code for modifying cell zone conditions.
 
 .. code:: python
 
-    #Enabling Laminar Zone
+    # Enabling Laminar Zone
     solver.tui.define.boundary_conditions.fluid(
-        'elbow-fluid',
-        'no',
-        'no',
-        'no',
-        'no',
-        'no',
+        "elbow-fluid",
+        "no",
+        "no",
+        "no",
+        "no",
+        "no",
         0,
-        'no',
+        "no",
         0,
-        'no',
+        "no",
         0,
-        'no',
+        "no",
         0,
-        'no',
+        "no",
         0,
-        'no',
+        "no",
         1,
-        'no',
-        'yes',
-        'yes',
-        'no',
-        'no',
-        'no'
+        "no",
+        "yes",
+        "yes",
+        "no",
+        "no",
+        "no",
     )
 
 Using settings objects
@@ -159,22 +135,20 @@ Define boundary conditions
 
 .. code:: python
 
-    solver.setup.boundary_conditions.velocity_inlet['cold-inlet'].vmag = {
-        'option': 'constant or expression',
-        'constant': 0.4,
+    solver.setup.boundary_conditions.velocity_inlet["cold-inlet"].vmag = {
+        "option": "constant or expression",
+        "constant": 0.4,
     }
     solver.setup.boundary_conditions.velocity_inlet[
-        'cold-inlet'
-    ].ke_spec = 'Intensity and Hydraulic Diameter'
+        "cold-inlet"
+    ].ke_spec = "Intensity and Hydraulic Diameter"
+    solver.setup.boundary_conditions.velocity_inlet["cold-inlet"].turb_intensity = 5
     solver.setup.boundary_conditions.velocity_inlet[
-        'cold-inlet'
-    ].turb_intensity = 5
-    solver.setup.boundary_conditions.velocity_inlet[
-        'cold-inlet'
-    ].turb_hydraulic_diam = '4 [in]'
-    solver.setup.boundary_conditions.velocity_inlet['cold-inlet'].t = {
-        'option': 'constant or expression',
-        'constant': 293.15,
+        "cold-inlet"
+    ].turb_hydraulic_diam = "4 [in]"
+    solver.setup.boundary_conditions.velocity_inlet["cold-inlet"].t = {
+        "option": "constant or expression",
+        "constant": 293.15,
     }
 
 Modify cell zone conditions
@@ -184,5 +158,5 @@ Modify cell zone conditions
 
 .. code:: python
 
-    #Enabling Laminar Zone
-    solver.setup.cell_zone_conditions.fluid['elbow-fluid'] = {'laminar' : True}
+    # Enabling Laminar Zone
+    solver.setup.cell_zone_conditions.fluid["elbow-fluid"] = {"laminar": True}

--- a/doc/source/user_guide/general_settings.rst
+++ b/doc/source/user_guide/general_settings.rst
@@ -8,12 +8,11 @@ to run solver meshing commands and set up units.
 
 Check the mesh
 --------------
-This example shows a comparison between the TUI command and the
-Python code for performing mesh consistency checks and displaying a
-report in the console. This report lists domain extents, volume statistics,
-face area statistics, any warnings, and information about failures.
-The level of information shown depends on the setting specified for
-the verbosity (level 0 to 3).
+This example shows a comparison between the TUI command and the Python code for
+performing mesh consistency checks and displaying a report in the console. This
+report lists domain extents, volume statistics, face area statistics, any
+warnings, and information about failures. The level of information shown depends
+on the setting specified for the verbosity (level 0 to 3).
 
 **TUI command**
 
@@ -33,9 +32,9 @@ the verbosity (level 0 to 3).
 
 Report mesh quality
 -------------------
-This example shows a comparison between the TUI command and the
-Python code for displaying information about the quality of the mesh in the
-console, including the minimum orthogonal quality and maximum aspect ratio.
+This example shows a comparison between the TUI command and the Python code for
+displaying information about the quality of the mesh in the console, including
+the minimum orthogonal quality and maximum aspect ratio.
 
 **TUI command**
 
@@ -51,9 +50,8 @@ console, including the minimum orthogonal quality and maximum aspect ratio.
 
 Scale mesh
 ------------
-This example shows a comparison between the TUI command and the
-Python code for scaling the mesh in each of the active Cartesian
-coordinate directions.
+This example shows a comparison between the TUI command and the Python code for
+scaling the mesh in each of the active Cartesian coordinate directions.
 
 **TUI command**
 
@@ -69,8 +67,8 @@ coordinate directions.
 
 Define units
 --------------
-The following example shows a comparison between the TUI command and the
-Python code for setting the unit conversion factors.
+The following example shows a comparison between the TUI command and the Python
+code for setting the unit conversion factors.
 
 **TUI command**
 
@@ -82,4 +80,4 @@ Python code for setting the unit conversion factors.
 
 .. code:: python
 
-    solver.tui.define.units('length', 'in')
+    solver.tui.define.units("length", "in")

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -50,25 +50,27 @@ You can launch Fluent in meshing mode with:
 For more information, see :ref:`ref_user_guide_launch` 
 and :ref:`ref_launcher_launcher`.
 
-You can use PyFluent to create and initialize multiple, independent session objects.
-Each session object provides full access to the Fluent components relevant to the
-session's current mode (solution or meshing).
+You can use PyFluent to create and initialize multiple, independent session
+objects. Each session object provides full access to the Fluent components
+relevant to the session's current mode (solution or meshing).
 
 Solution mode session
 ---------------------
-A solution mode session has an active ``solver`` object that provides two distinct
-interfaces to the solver:
+A solution mode session has an active ``solver`` object that provides two
+distinct interfaces to the solver:
 
 - ``tui`` object
 - ``root`` object
 
-For general guidance on using these two objects, see :ref:`ref_user_guide_solver_settings`.
+For general guidance on using these two objects, see
+:ref:`ref_user_guide_solver_settings`.
 
 Solver ``tui`` object
 ~~~~~~~~~~~~~~~~~~~~~
-The solver ``tui`` object is a complete Python exposure of the Fluent solver TUI (text 
-user interface). This object allows straightforward execution of solver commands and 
-modification of solve settings in a manner that is familiar to existing Fluent users:
+The solver ``tui`` object is a complete Python exposure of the Fluent solver TUI
+(text user interface). This object allows straightforward execution of solver
+commands and modification of solve settings in a manner that is familiar to
+existing Fluent users:
 
 .. code:: python
 
@@ -83,9 +85,9 @@ For general guidance on using TUI commands, see :ref:`ref_user_guide_tui_command
 
 Solver ``root`` object
 ~~~~~~~~~~~~~~~~~~~~~~
-The solver ``root`` object exposes most of the solver capabilities covered by the solver
-``tui`` object and provides significant additional interface features that are not possible
-via the ``tui`` object:
+The solver ``root`` object exposes most of the solver capabilities covered by
+the solver ``tui`` object and provides significant additional interface features
+that are not possible via the ``tui`` object:
 
 .. code:: python
 
@@ -109,10 +111,10 @@ distinct interfaces to the mesher:
 
 Meshing ``tui`` object
 ~~~~~~~~~~~~~~~~~~~~~~
-The meshing ``tui`` object is a complete Python exposure of the Fluent meshing TUI
-(text user interface). This object allows straightforward execution of meshing
-commands and modification of meshing settings in a manner that is familiar
-to existing Fluent users:
+The meshing ``tui`` object is a complete Python exposure of the Fluent meshing
+TUI (text user interface). This object allows straightforward execution of
+meshing commands and modification of meshing settings in a manner that is
+familiar to existing Fluent users:
 
 .. code:: python
 
@@ -122,15 +124,15 @@ to existing Fluent users:
 
     tui.file.write_case("pipe.cas.h5")
     
-For the full hierarchy under the meshing ``tui`` object, see :ref:`ref_meshing_tui`.
-For general guidance on using TUI commands, see :ref:`ref_user_guide_tui_commands`. 
+For the full hierarchy under the meshing ``tui`` object, see
+:ref:`ref_meshing_tui`. For general guidance on using TUI commands, see
+:ref:`ref_user_guide_tui_commands`. 
 
 ``Meshing`` and ``Workflow`` properties
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The ``meshing`` object has ``meshing`` and ``workflow`` properties that
-together provide access to Fluent's meshing workflows. This interface
-is consistent with the Python meshing workflow interface that Fluent meshing
-exposes directly:
+The ``meshing`` object has ``meshing`` and ``workflow`` properties that together
+provide access to Fluent's meshing workflows. This interface is consistent with
+the Python meshing workflow interface that Fluent meshing exposes directly:
 
 .. code:: python
 
@@ -146,25 +148,25 @@ exposes directly:
 
     meshing = meshing_session.meshing
 
-    meshing.GlobalSettings.LengthUnit.setState("mm")
+    meshing.GlobalSettings.LengthUnit.set_state("mm")
 
 For additional examples, see :ref:`ref_user_guide_meshing_workflows`.
 For information on the full interface, see :ref:`ref_meshing_datamodel`.
 
 Session object
 --------------
-In either a solution or meshing mode session, the ``session`` object provides
-a more direct interaction via its ``scheme_eval`` attribute:
+In either a solution or meshing mode session, the ``session`` object provides a
+more direct interaction via its ``scheme_eval`` attribute:
 
 .. code:: python
 
     unsteady = solver.scheme_eval.scheme_eval("(rp-unsteady?)")
 
-The argument to ``scheme_eval`` is a string that contains any scheme
-code that can be executed in Fluent for the current mode.
+The argument to ``scheme_eval`` is a string that contains any scheme code that
+can be executed in Fluent for the current mode.
 
-Surface field and mesh data services are available in solution mode only via
-the ``field_data`` object attribute of the session object:
+Surface field and mesh data services are available in solution mode only via the
+``field_data`` object attribute of the session object:
 
 .. code:: python
 
@@ -182,8 +184,8 @@ The connection status of any session can be verified with:
 
 Streaming
 ---------
-Streaming of a Fluent transcript is automatically started by default.
-You can stop and start the streaming of a transcript manually with:
+Streaming of a Fluent transcript is automatically started by default. You can
+stop and start the streaming of a transcript manually with:
  
 .. code:: python
 
@@ -191,8 +193,8 @@ You can stop and start the streaming of a transcript manually with:
 
     solver.start_transcript()
 
-You can enable and disable the streaming of events pertaining to various
-solver event types via the ``events_manager`` attribute of a solution mode session:
+You can enable and disable the streaming of events pertaining to various solver
+event types via the ``events_manager`` attribute of a solution mode session:
 
 .. code:: python
 
@@ -207,5 +209,5 @@ You can control the global logging level at any time with:
 .. code:: python
 
     import ansys.fluent.core as pyfluent
-    pyfluent.set_log_level('DEBUG') # by default, only errors are shown
+    pyfluent.set_log_level("DEBUG") # by default, only errors are shown
 

--- a/doc/source/user_guide/materials.rst
+++ b/doc/source/user_guide/materials.rst
@@ -19,33 +19,34 @@ Python code for defining the fluid material being modelled on a cell zone.
 .. code:: python
 
     import ansys.fluent.core as pyfluent
-    solver = pyfluent.launch_fluent(precision='double', processor_count=2, mode="solver")
-    solver.tui.file.read_case('file.cas.h5')
-    solver.tui.define.materials.copy('fluid', 'water-liquid')
+
+    solver = pyfluent.launch_fluent(precision="double", processor_count=2, mode="solver")
+    solver.tui.file.read_case("file.cas.h5")
+    solver.tui.define.materials.copy("fluid", "water-liquid")
     solver.tui.define.boundary_conditions.fluid(
-        'elbow-fluid',
-        'yes',
-        'water-liquid',
-        'no',
-        'no',
-        'no',
-        'no',
-        '0',
-        'no',
-        '0',
-        'no',
-        '0',
-        'no',
-        '0',
-        'no',
-        '0',
-        'no',
-        '1',
-        'no',
-        'no',
-        'no',
-        'no',
-        'no',
+        "elbow-fluid",
+        "yes",
+        "water-liquid",
+        "no",
+        "no",
+        "no",
+        "no",
+        "0",
+        "no",
+        "0",
+        "no",
+        "0",
+        "no",
+        "0",
+        "no",
+        "0",
+        "no",
+        "1",
+        "no",
+        "no",
+        "no",
+        "no",
+        "no",
     )
 
 Use settings objects
@@ -56,5 +57,5 @@ This example shows how you use :ref:`ref_settings` to define materials.
 
 .. code:: python
 
-    solver.setup.materials.copy_database_material_by_name(type='fluid', name='water-liquid')
-    solver.setup.cell_zone_conditions.fluid['elbow-fluid'].material = 'water-liquid'
+    solver.setup.materials.copy_database_material_by_name(type="fluid", name="water-liquid")
+    solver.setup.cell_zone_conditions.fluid["elbow-fluid"].material = "water-liquid"

--- a/doc/source/user_guide/meshing_workflows.rst
+++ b/doc/source/user_guide/meshing_workflows.rst
@@ -22,9 +22,9 @@ Import geometry
         mode="meshing", precision='double', processor_count=2
     )
     meshing.workflow.InitializeWorkflow(WorkflowType='Watertight Geometry')
-    meshing.workflow.TaskObject['Import Geometry'].Arguments = dict(
-        FileName=import_filename, LengthUnit='in'
-    )
+    meshing.workflow.TaskObject['Import Geometry'].Arguments = {
+        FileName: import_filename, LengthUnit: 'in'
+    }
     meshing.workflow.TaskObject['Import Geometry'].Execute()
 
 Add local sizing
@@ -50,62 +50,60 @@ Describe geometry
 
 .. code:: python
 
-    meshing.workflow.TaskObject['Describe Geometry'].UpdateChildTasks(
+    meshing.workflow.TaskObject["Describe Geometry"].UpdateChildTasks(
         SetupTypeChanged=False
     )
-    meshing.workflow.TaskObject['Describe Geometry'].Arguments = dict(
-        SetupType='The geometry consists of only fluid regions with no voids'
-    )
-    meshing.workflow.TaskObject['Describe Geometry'].UpdateChildTasks(
-        SetupTypeChanged=True
-    )
-    meshing.workflow.TaskObject['Describe Geometry'].Execute()
+    meshing.workflow.TaskObject["Describe Geometry"].Arguments = {
+        SetupType: "The geometry consists of only fluid regions with no voids"
+    }
+    meshing.workflow.TaskObject["Describe Geometry"].UpdateChildTasks(SetupTypeChanged=True)
+    meshing.workflow.TaskObject["Describe Geometry"].Execute()
 
 Update boundaries
 ~~~~~~~~~~~~~~~~~
 
 .. code:: python
 
-    meshing.workflow.TaskObject['Update Boundaries'].Arguments = {
-        'BoundaryLabelList': ['wall-inlet'],
-        'BoundaryLabelTypeList': ['wall'],
-        'OldBoundaryLabelList': ['wall-inlet'],
-        'OldBoundaryLabelTypeList': ['velocity-inlet'],
+    meshing.workflow.TaskObject["Update Boundaries"].Arguments = {
+        "BoundaryLabelList": ["wall-inlet"],
+        "BoundaryLabelTypeList": ["wall"],
+        "OldBoundaryLabelList": ["wall-inlet"],
+        "OldBoundaryLabelTypeList": ["velocity-inlet"],
     }
-    meshing.workflow.TaskObject['Update Boundaries'].Execute()
+    meshing.workflow.TaskObject["Update Boundaries"].Execute()
 
 Update regions
 ~~~~~~~~~~~~~~
 
 .. code:: python
 
-    meshing.workflow.TaskObject['Update Regions'].Execute()
+    meshing.workflow.TaskObject["Update Regions"].Execute()
 
 Add boundary layers
 ~~~~~~~~~~~~~~~~~~~
 
 .. code:: python
 
-    meshing.workflow.TaskObject['Add Boundary Layers'].AddChildToTask()
-    meshing.workflow.TaskObject['Add Boundary Layers'].InsertCompoundChildTask()
-    meshing.workflow.TaskObject['smooth-transition_1'].Arguments = {
-        'BLControlName': 'smooth-transition_1',
+    meshing.workflow.TaskObject["Add Boundary Layers"].AddChildToTask()
+    meshing.workflow.TaskObject["Add Boundary Layers"].InsertCompoundChildTask()
+    meshing.workflow.TaskObject["smooth-transition_1"].Arguments = {
+        "BLControlName": "smooth-transition_1",
     }
-    meshing.workflow.TaskObject['Add Boundary Layers'].Arguments = {}
-    meshing.workflow.TaskObject['smooth-transition_1'].Execute()
+    meshing.workflow.TaskObject["Add Boundary Layers"].Arguments = {}
+    meshing.workflow.TaskObject["smooth-transition_1"].Execute()
 
 Generate volume mesh
 ~~~~~~~~~~~~~~~~~~~~
 
 .. code:: python
 
-    meshing.workflow.TaskObject['Generate the Volume Mesh'].Arguments = {
-        'VolumeFill': 'poly-hexcore',
-        'VolumeFillControls': {
-            'HexMaxCellLength': 0.3,
+    meshing.workflow.TaskObject["Generate the Volume Mesh"].Arguments = {
+        "VolumeFill": "poly-hexcore",
+        "VolumeFillControls": {
+            "HexMaxCellLength": 0.3,
         },
     }
-    meshing.workflow.TaskObject['Generate the Volume Mesh'].Execute()
+    meshing.workflow.TaskObject["Generate the Volume Mesh"].Execute()
 
 Switch to solution mode
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -127,480 +125,440 @@ Import CAD and part management
     from ansys.fluent.core import examples
 
     import_filename = examples.download_file(
-        'exhaust_system.fmd', 'pyfluent/exhaust_system'
+        "exhaust_system.fmd", "pyfluent/exhaust_system"
     )
-    meshing = pyfluent.launch_fluent(
-        precision='double', processor_count=2, mode="meshing"
-    )
-    meshing.workflow.InitializeWorkflow(WorkflowType='Fault-tolerant Meshing')
+    meshing = pyfluent.launch_fluent(precision="double", processor_count=2, mode="meshing")
+    meshing.workflow.InitializeWorkflow(WorkflowType="Fault-tolerant Meshing")
     meshing.PartManagement.InputFileChanged(
         FilePath=import_filename, IgnoreSolidNames=False, PartPerBody=False
     )
     meshing.PMFileManagement.FileManager.LoadFiles()
-    meshing.PartManagement.Node['Meshing Model'].Copy(
+    meshing.PartManagement.Node["Meshing Model"].Copy(
         Paths=[
-            '/dirty_manifold-for-wrapper,' + '1/dirty_manifold-for-wrapper,1/main,1',
-            '/dirty_manifold-for-wrapper,' + '1/dirty_manifold-for-wrapper,1/flow-pipe,1',
-            '/dirty_manifold-for-wrapper,' + '1/dirty_manifold-for-wrapper,1/outpipe3,1',
-            '/dirty_manifold-for-wrapper,' + '1/dirty_manifold-for-wrapper,1/object2,1',
-            '/dirty_manifold-for-wrapper,' + '1/dirty_manifold-for-wrapper,1/object1,1',
+            "/dirty_manifold-for-wrapper," + "1/dirty_manifold-for-wrapper,1/main,1",
+            "/dirty_manifold-for-wrapper," + "1/dirty_manifold-for-wrapper,1/flow-pipe,1",
+            "/dirty_manifold-for-wrapper," + "1/dirty_manifold-for-wrapper,1/outpipe3,1",
+            "/dirty_manifold-for-wrapper," + "1/dirty_manifold-for-wrapper,1/object2,1",
+            "/dirty_manifold-for-wrapper," + "1/dirty_manifold-for-wrapper,1/object1,1",
         ]
     )
-    meshing.PartManagement.ObjectSetting[
-        'DefaultObjectSetting'
-    ].OneZonePer.setState('part')
-    meshing.workflow.TaskObject[
-        'Import CAD and Part Management'
-    ].Arguments.setState(
+    meshing.PartManagement.ObjectSetting["DefaultObjectSetting"].OneZonePer.set_state("part")
+    meshing.workflow.TaskObject["Import CAD and Part Management"].Arguments.set_state(
         {
-            'Context': 0,
-            'CreateObjectPer': 'Custom',
-            'FMDFileName': import_filename,
-            'FileLoaded': 'yes',
-            'ObjectSetting': 'DefaultObjectSetting',
-            'Options': {
-                'Line': False,
-                'Solid': False,
-                'Surface': False,
+            "Context": 0,
+            "CreateObjectPer": "Custom",
+            "FMDFileName": import_filename,
+            "FileLoaded": "yes",
+            "ObjectSetting": "DefaultObjectSetting",
+            "Options": {
+                "Line": False,
+                "Solid": False,
+                "Surface": False,
             },
         }
     )
-    meshing.workflow.TaskObject['Import CAD and Part Management'].Execute()
+    meshing.workflow.TaskObject["Import CAD and Part Management"].Execute()
 
 Describe geometry and flow
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: python
 
-    meshing.workflow.TaskObject['Describe Geometry and Flow'].Arguments.setState(
+    meshing.workflow.TaskObject["Describe Geometry and Flow"].Arguments.set_state(
         {
-            'AddEnclosure': 'No',
-            'CloseCaps': 'Yes',
-            'FlowType': 'Internal flow through the object',
+            "AddEnclosure": "No",
+            "CloseCaps": "Yes",
+            "FlowType": "Internal flow through the object",
         }
     )
-    meshing.workflow.TaskObject['Describe Geometry and Flow'].UpdateChildTasks(
+    meshing.workflow.TaskObject["Describe Geometry and Flow"].UpdateChildTasks(
         SetupTypeChanged=False
     )
-    meshing.workflow.TaskObject['Describe Geometry and Flow'].Arguments.setState(
+    meshing.workflow.TaskObject["Describe Geometry and Flow"].Arguments.set_state(
         {
-            'AddEnclosure': 'No',
-            'CloseCaps': 'Yes',
-            'DescribeGeometryAndFlowOptions': {
-                'AdvancedOptions': True,
-                'ExtractEdgeFeatures': 'Yes',
+            "AddEnclosure": "No",
+            "CloseCaps": "Yes",
+            "DescribeGeometryAndFlowOptions": {
+                "AdvancedOptions": True,
+                "ExtractEdgeFeatures": "Yes",
             },
-            'FlowType': 'Internal flow through the object',
+            "FlowType": "Internal flow through the object",
         }
     )
-    meshing.workflow.TaskObject['Describe Geometry and Flow'].UpdateChildTasks(
+    meshing.workflow.TaskObject["Describe Geometry and Flow"].UpdateChildTasks(
         SetupTypeChanged=False
     )
-    meshing.workflow.TaskObject['Describe Geometry and Flow'].Execute()
+    meshing.workflow.TaskObject["Describe Geometry and Flow"].Execute()
 
 Enclose fluid regions (capping)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: python
 
-    meshing.workflow.TaskObject[
-        'Enclose Fluid Regions (Capping)'
-    ].Arguments.setState(
+    meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state(
         {
-            'CreatePatchPreferences': {
-                'ShowCreatePatchPreferences': False,
+            "CreatePatchPreferences": {
+                "ShowCreatePatchPreferences": False,
             },
-            'PatchName': 'inlet-1',
-            'SelectionType': 'zone',
-            'ZoneSelectionList': ['inlet.1'],
+            "PatchName": "inlet-1",
+            "SelectionType": "zone",
+            "ZoneSelectionList": ["inlet.1"],
         }
     )
-    meshing.workflow.TaskObject[
-        'Enclose Fluid Regions (Capping)'
-    ].Arguments.setState(
+    meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state(
         {
-            'CreatePatchPreferences': {
-                'ShowCreatePatchPreferences': False,
+            "CreatePatchPreferences": {
+                "ShowCreatePatchPreferences": False,
             },
-            'PatchName': 'inlet-1',
-            'SelectionType': 'zone',
-            'ZoneLocation': [
-                '1',
-                '351.68205',
-                '-361.34322',
-                '-301.88668',
-                '396.96205',
-                '-332.84759',
-                '-266.69751',
-                'inlet.1',
+            "PatchName": "inlet-1",
+            "SelectionType": "zone",
+            "ZoneLocation": [
+                "1",
+                "351.68205",
+                "-361.34322",
+                "-301.88668",
+                "396.96205",
+                "-332.84759",
+                "-266.69751",
+                "inlet.1",
             ],
-            'ZoneSelectionList': ['inlet.1'],
+            "ZoneSelectionList": ["inlet.1"],
         }
     )
-    meshing.workflow.TaskObject['Enclose Fluid Regions (Capping)'].AddChildToTask()
+    meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].AddChildToTask()
 
-    meshing.workflow.TaskObject[
-        'Enclose Fluid Regions (Capping)'
-    ].InsertCompoundChildTask()
-    meshing.workflow.TaskObject[
-        'Enclose Fluid Regions (Capping)'
-    ].Arguments.setState({})
-    meshing.workflow.TaskObject['inlet-1'].Execute()
-    meshing.workflow.TaskObject[
-        'Enclose Fluid Regions (Capping)'
-    ].Arguments.setState(
+    meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].InsertCompoundChildTask()
+    meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state({})
+    meshing.workflow.TaskObject["inlet-1"].Execute()
+    meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state(
         {
-            'PatchName': 'inlet-2',
-            'SelectionType': 'zone',
-            'ZoneSelectionList': ['inlet.2'],
+            "PatchName": "inlet-2",
+            "SelectionType": "zone",
+            "ZoneSelectionList": ["inlet.2"],
         }
     )
-    meshing.workflow.TaskObject[
-        'Enclose Fluid Regions (Capping)'
-    ].Arguments.setState(
+    meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state(
         {
-            'PatchName': 'inlet-2',
-            'SelectionType': 'zone',
-            'ZoneLocation': [
-                '1',
-                '441.68205',
-                '-361.34322',
-                '-301.88668',
-                '486.96205',
-                '-332.84759',
-                '-266.69751',
-                'inlet.2',
+            "PatchName": "inlet-2",
+            "SelectionType": "zone",
+            "ZoneLocation": [
+                "1",
+                "441.68205",
+                "-361.34322",
+                "-301.88668",
+                "486.96205",
+                "-332.84759",
+                "-266.69751",
+                "inlet.2",
             ],
-            'ZoneSelectionList': ['inlet.2'],
+            "ZoneSelectionList": ["inlet.2"],
         }
     )
-    meshing.workflow.TaskObject['Enclose Fluid Regions (Capping)'].AddChildToTask()
+    meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].AddChildToTask()
 
-    meshing.workflow.TaskObject[
-        'Enclose Fluid Regions (Capping)'
-    ].InsertCompoundChildTask()
-    meshing.workflow.TaskObject[
-        'Enclose Fluid Regions (Capping)'
-    ].Arguments.setState({})
-    meshing.workflow.TaskObject['inlet-2'].Execute()
-    meshing.workflow.TaskObject[
-        'Enclose Fluid Regions (Capping)'
-    ].Arguments.setState(
+    meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].InsertCompoundChildTask()
+    meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state({})
+    meshing.workflow.TaskObject["inlet-2"].Execute()
+    meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state(
         {
-            'PatchName': 'inlet-3',
-            'SelectionType': 'zone',
-            'ZoneSelectionList': ['inlet'],
+            "PatchName": "inlet-3",
+            "SelectionType": "zone",
+            "ZoneSelectionList": ["inlet"],
         }
     )
-    meshing.workflow.TaskObject[
-        'Enclose Fluid Regions (Capping)'
-    ].Arguments.setState(
+    meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state(
         {
-            'PatchName': 'inlet-3',
-            'SelectionType': 'zone',
-            'ZoneLocation': [
-                '1',
-                '261.68205',
-                '-361.34322',
-                '-301.88668',
-                '306.96205',
-                '-332.84759',
-                '-266.69751',
-                'inlet',
+            "PatchName": "inlet-3",
+            "SelectionType": "zone",
+            "ZoneLocation": [
+                "1",
+                "261.68205",
+                "-361.34322",
+                "-301.88668",
+                "306.96205",
+                "-332.84759",
+                "-266.69751",
+                "inlet",
             ],
-            'ZoneSelectionList': ['inlet'],
+            "ZoneSelectionList": ["inlet"],
         }
     )
-    meshing.workflow.TaskObject['Enclose Fluid Regions (Capping)'].AddChildToTask()
+    meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].AddChildToTask()
 
-    meshing.workflow.TaskObject[
-        'Enclose Fluid Regions (Capping)'
-    ].InsertCompoundChildTask()
-    meshing.workflow.TaskObject[
-        'Enclose Fluid Regions (Capping)'
-    ].Arguments.setState({})
-    meshing.workflow.TaskObject['inlet-3'].Execute()
-    meshing.workflow.TaskObject[
-        'Enclose Fluid Regions (Capping)'
-    ].Arguments.setState(
+    meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].InsertCompoundChildTask()
+    meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state({})
+    meshing.workflow.TaskObject["inlet-3"].Execute()
+    meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state(
         {
-            'PatchName': 'outlet-1',
-            'SelectionType': 'zone',
-            'ZoneSelectionList': ['outlet'],
-            'ZoneType': 'pressure-outlet',
+            "PatchName": "outlet-1",
+            "SelectionType": "zone",
+            "ZoneSelectionList": ["outlet"],
+            "ZoneType": "pressure-outlet",
         }
     )
-    meshing.workflow.TaskObject[
-        'Enclose Fluid Regions (Capping)'
-    ].Arguments.setState(
+    meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state(
         {
-            'PatchName': 'outlet-1',
-            'SelectionType': 'zone',
-            'ZoneLocation': [
-                '1',
-                '352.22702',
-                '-197.8957',
-                '84.102381',
-                '394.41707',
-                '-155.70565',
-                '84.102381',
-                'outlet',
+            "PatchName": "outlet-1",
+            "SelectionType": "zone",
+            "ZoneLocation": [
+                "1",
+                "352.22702",
+                "-197.8957",
+                "84.102381",
+                "394.41707",
+                "-155.70565",
+                "84.102381",
+                "outlet",
             ],
-            'ZoneSelectionList': ['outlet'],
-            'ZoneType': 'pressure-outlet',
+            "ZoneSelectionList": ["outlet"],
+            "ZoneType": "pressure-outlet",
         }
     )
-    meshing.workflow.TaskObject['Enclose Fluid Regions (Capping)'].AddChildToTask()
+    meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].AddChildToTask()
 
-    meshing.workflow.TaskObject[
-        'Enclose Fluid Regions (Capping)'
-    ].InsertCompoundChildTask()
-    meshing.workflow.TaskObject[
-        'Enclose Fluid Regions (Capping)'
-    ].Arguments.setState({})
-    meshing.workflow.TaskObject['outlet-1'].Execute()
+    meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].InsertCompoundChildTask()
+    meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state({})
+    meshing.workflow.TaskObject["outlet-1"].Execute()
+
 
 Extract edge features
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: python
 
-    meshing.workflow.TaskObject['Extract Edge Features'].Arguments.setState(
+    meshing.workflow.TaskObject["Extract Edge Features"].Arguments.set_state(
         {
-            'ExtractMethodType': 'Intersection Loops',
-            'ObjectSelectionList': ['flow_pipe', 'main'],
+            "ExtractMethodType": "Intersection Loops",
+            "ObjectSelectionList": ["flow_pipe", "main"],
         }
     )
-    meshing.workflow.TaskObject['Extract Edge Features'].AddChildToTask()
+    meshing.workflow.TaskObject["Extract Edge Features"].AddChildToTask()
 
-    meshing.workflow.TaskObject['Extract Edge Features'].InsertCompoundChildTask()
+    meshing.workflow.TaskObject["Extract Edge Features"].InsertCompoundChildTask()
 
-    meshing.workflow.TaskObject['edge-group-1'].Arguments.setState(
+    meshing.workflow.TaskObject["edge-group-1"].Arguments.set_state(
         {
-            'ExtractEdgesName': 'edge-group-1',
-            'ExtractMethodType': 'Intersection Loops',
-            'ObjectSelectionList': ['flow_pipe', 'main'],
+            "ExtractEdgesName": "edge-group-1",
+            "ExtractMethodType": "Intersection Loops",
+            "ObjectSelectionList": ["flow_pipe", "main"],
         }
     )
-    meshing.workflow.TaskObject['Extract Edge Features'].Arguments.setState({})
+    meshing.workflow.TaskObject["Extract Edge Features"].Arguments.set_state({})
 
-    meshing.workflow.TaskObject['edge-group-1'].Execute()
+    meshing.workflow.TaskObject["edge-group-1"].Execute()
 
 Identify regions
 ~~~~~~~~~~~~~~~~
 
 .. code:: python
 
-    meshing.workflow.TaskObject['Identify Regions'].Arguments.setState(
+    meshing.workflow.TaskObject["Identify Regions"].Arguments.set_state(
         {
-            'SelectionType': 'zone',
-            'X': 377.322045740589,
-            'Y': -176.800676988458,
-            'Z': -37.0764628583475,
-            'ZoneSelectionList': ['main.1'],
+            "SelectionType": "zone",
+            "X": 377.322045740589,
+            "Y": -176.800676988458,
+            "Z": -37.0764628583475,
+            "ZoneSelectionList": ["main.1"],
         }
     )
-    meshing.workflow.TaskObject['Identify Regions'].Arguments.setState(
+    meshing.workflow.TaskObject["Identify Regions"].Arguments.set_state(
         {
-            'SelectionType': 'zone',
-            'X': 377.322045740589,
-                'Y': -176.800676988458,
-            'Z': -37.0764628583475,
-            'ZoneLocation': [
-                '1',
-                '213.32205',
-                '-225.28068',
-                '-158.25531',
-                '541.32205',
-                '-128.32068',
-                '84.102381',
-                'main.1',
+            "SelectionType": "zone",
+            "X": 377.322045740589,
+            "Y": -176.800676988458,
+            "Z": -37.0764628583475,
+            "ZoneLocation": [
+                "1",
+                "213.32205",
+                "-225.28068",
+                "-158.25531",
+                "541.32205",
+                "-128.32068",
+                "84.102381",
+                "main.1",
             ],
-            'ZoneSelectionList': ['main.1'],
+            "ZoneSelectionList": ["main.1"],
         }
     )
-    meshing.workflow.TaskObject['Identify Regions'].AddChildToTask()
+    meshing.workflow.TaskObject["Identify Regions"].AddChildToTask()
 
-    meshing.workflow.TaskObject['Identify Regions'].InsertCompoundChildTask()
+    meshing.workflow.TaskObject["Identify Regions"].InsertCompoundChildTask()
 
-    meshing.workflow.TaskObject['fluid-region-1'].Arguments.setState(
+    meshing.workflow.TaskObject["fluid-region-1"].Arguments.set_state(
         {
-            'MaterialPointsName': 'fluid-region-1',
-            'SelectionType': 'zone',
-            'X': 377.322045740589,
-            'Y': -176.800676988458,
-            'Z': -37.0764628583475,
-            'ZoneLocation': [
-                '1',
-                '213.32205',
-                '-225.28068',
-                '-158.25531',
-                '541.32205',
-                '-128.32068',
-                '84.102381',
-                'main.1',
+            "MaterialPointsName": "fluid-region-1",
+            "SelectionType": "zone",
+            "X": 377.322045740589,
+            "Y": -176.800676988458,
+            "Z": -37.0764628583475,
+            "ZoneLocation": [
+                "1",
+                "213.32205",
+                "-225.28068",
+                "-158.25531",
+                "541.32205",
+                "-128.32068",
+                "84.102381",
+                "main.1",
             ],
-            'ZoneSelectionList': ['main.1'],
+            "ZoneSelectionList": ["main.1"],
         }
     )
-    meshing.workflow.TaskObject['Identify Regions'].Arguments.setState({})
+    meshing.workflow.TaskObject["Identify Regions"].Arguments.set_state({})
 
-    meshing.workflow.TaskObject['fluid-region-1'].Execute()
-    meshing.workflow.TaskObject['Identify Regions'].Arguments.setState(
+    meshing.workflow.TaskObject["fluid-region-1"].Execute()
+    meshing.workflow.TaskObject["Identify Regions"].Arguments.set_state(
         {
-            'MaterialPointsName': 'void-region-1',
-            'NewRegionType': 'void',
-            'ObjectSelectionList': ['inlet-1', 'inlet-2', 'inlet-3', 'main'],
-            'X': 374.722045740589,
-            'Y': -278.9775145640143,
-            'Z': -161.1700719416913,
+            "MaterialPointsName": "void-region-1",
+            "NewRegionType": "void",
+            "ObjectSelectionList": ["inlet-1", "inlet-2", "inlet-3", "main"],
+            "X": 374.722045740589,
+            "Y": -278.9775145640143,
+            "Z": -161.1700719416913,
         }
     )
-    meshing.workflow.TaskObject['Identify Regions'].AddChildToTask()
+    meshing.workflow.TaskObject["Identify Regions"].AddChildToTask()
 
-    meshing.workflow.TaskObject['Identify Regions'].InsertCompoundChildTask()
+    meshing.workflow.TaskObject["Identify Regions"].InsertCompoundChildTask()
 
-    meshing.workflow.TaskObject['Identify Regions'].Arguments.setState({})
+    meshing.workflow.TaskObject["Identify Regions"].Arguments.set_state({})
 
-    meshing.workflow.TaskObject['void-region-1'].Execute()
+    meshing.workflow.TaskObject["void-region-1"].Execute()
 
 Define leakage threshold
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: python
 
-    meshing.workflow.TaskObject['Define Leakage Threshold'].Arguments.setState(
+    meshing.workflow.TaskObject["Define Leakage Threshold"].Arguments.set_state(
         {
-            'AddChild': 'yes',
-            'FlipDirection': True,
-            'PlaneDirection': 'X',
-            'RegionSelectionSingle': 'void-region-1',
+            "AddChild": "yes",
+            "FlipDirection": True,
+            "PlaneDirection": "X",
+            "RegionSelectionSingle": "void-region-1",
         }
     )
-    meshing.workflow.TaskObject['Define Leakage Threshold'].AddChildToTask()
+    meshing.workflow.TaskObject["Define Leakage Threshold"].AddChildToTask()
 
-    meshing.workflow.TaskObject[
-        'Define Leakage Threshold'
-    ].InsertCompoundChildTask()
-    meshing.workflow.TaskObject['leakage-1'].Arguments.setState(
+    meshing.workflow.TaskObject["Define Leakage Threshold"].InsertCompoundChildTask()
+    meshing.workflow.TaskObject["leakage-1"].Arguments.set_state(
         {
-            'AddChild': 'yes',
-            'FlipDirection': True,
-            'LeakageName': 'leakage-1',
-            'PlaneDirection': 'X',
-            'RegionSelectionSingle': 'void-region-1',
+            "AddChild": "yes",
+            "FlipDirection": True,
+            "LeakageName": "leakage-1",
+            "PlaneDirection": "X",
+            "RegionSelectionSingle": "void-region-1",
         }
     )
-    meshing.workflow.TaskObject['Define Leakage Threshold'].Arguments.setState(
+    meshing.workflow.TaskObject["Define Leakage Threshold"].Arguments.set_state(
         {
-            'AddChild': 'yes',
+            "AddChild": "yes",
         }
     )
-    meshing.workflow.TaskObject['leakage-1'].Execute()
+    meshing.workflow.TaskObject["leakage-1"].Execute()
 
 Update regions settings
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: python
 
-    meshing.workflow.TaskObject['Update Region Settings'].Arguments.setState(
+    meshing.workflow.TaskObject["Update Region Settings"].Arguments.set_state(
         {
-            'AllRegionFilterCategories': ['2'] * 5 + ['1'] * 2,
-            'AllRegionLeakageSizeList': ['none'] * 6 + ['6.4'],
-            'AllRegionLinkedConstructionSurfaceList': ['n/a'] * 6 + ['no'],
-            'AllRegionMeshMethodList': ['none'] * 6 + ['wrap'],
-            'AllRegionNameList': [
-                'main',
-                'flow_pipe',
-                'outpipe3',
-                'object2',
-                'object1',
-                'void-region-1',
-                'fluid-region-1',
+            "AllRegionFilterCategories": ["2"] * 5 + ["1"] * 2,
+            "AllRegionLeakageSizeList": ["none"] * 6 + ["6.4"],
+            "AllRegionLinkedConstructionSurfaceList": ["n/a"] * 6 + ["no"],
+            "AllRegionMeshMethodList": ["none"] * 6 + ["wrap"],
+            "AllRegionNameList": [
+                "main",
+                "flow_pipe",
+                "outpipe3",
+                "object2",
+                "object1",
+                "void-region-1",
+                "fluid-region-1",
             ],
-            'AllRegionOversetComponenList': ['no'] * 7,
-            'AllRegionSourceList': ['object'] * 5 + ['mpt'] * 2,
-            'AllRegionTypeList': ['void'] * 6 + ['fluid'],
-            'AllRegionVolumeFillList': ['none'] * 6 + ['tet'],
-            'FilterCategory': 'Identified Regions',
-            'OldRegionLeakageSizeList': [''],
-            'OldRegionMeshMethodList': ['wrap'],
-            'OldRegionNameList': ['fluid-region-1'],
-            'OldRegionOversetComponenList': ['no'],
-            'OldRegionTypeList': ['fluid'],
-            'OldRegionVolumeFillList': ['hexcore'],
-            'RegionLeakageSizeList': [''],
-            'RegionMeshMethodList': ['wrap'],
-            'RegionNameList': ['fluid-region-1'],
-            'RegionOversetComponenList': ['no'],
-            'RegionTypeList': ['fluid'],
-            'RegionVolumeFillList': ['tet'],
+            "AllRegionOversetComponenList": ["no"] * 7,
+            "AllRegionSourceList": ["object"] * 5 + ["mpt"] * 2,
+            "AllRegionTypeList": ["void"] * 6 + ["fluid"],
+            "AllRegionVolumeFillList": ["none"] * 6 + ["tet"],
+            "FilterCategory": "Identified Regions",
+            "OldRegionLeakageSizeList": [""],
+            "OldRegionMeshMethodList": ["wrap"],
+            "OldRegionNameList": ["fluid-region-1"],
+            "OldRegionOversetComponenList": ["no"],
+            "OldRegionTypeList": ["fluid"],
+            "OldRegionVolumeFillList": ["hexcore"],
+            "RegionLeakageSizeList": [""],
+            "RegionMeshMethodList": ["wrap"],
+            "RegionNameList": ["fluid-region-1"],
+            "RegionOversetComponenList": ["no"],
+            "RegionTypeList": ["fluid"],
+            "RegionVolumeFillList": ["tet"],
         }
     )
-    meshing.workflow.TaskObject['Update Region Settings'].Execute()
-
+    meshing.workflow.TaskObject["Update Region Settings"].Execute()
 
 Choose mesh control options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: python
 
-    meshing.workflow.TaskObject['Choose Mesh Control Options'].Execute()
+    meshing.workflow.TaskObject["Choose Mesh Control Options"].Execute()
 
 Generating surface mesh
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code:: python
 
-    meshing.workflow.TaskObject['Generate the Surface Mesh'].Execute()
+    meshing.workflow.TaskObject["Generate the Surface Mesh"].Execute()
 
 Update boundaries
 ~~~~~~~~~~~~~~~~~
 
 .. code:: python
 
-    meshing.workflow.TaskObject['Update Boundaries'].Execute()
+    meshing.workflow.TaskObject["Update Boundaries"].Execute()
 
 Add boundary layers
 ~~~~~~~~~~~~~~~~~~~
 
 .. code:: python
 
-    meshing.workflow.TaskObject['Add Boundary Layers'].AddChildToTask()
+    meshing.workflow.TaskObject["Add Boundary Layers"].AddChildToTask()
 
-    meshing.workflow.TaskObject['Add Boundary Layers'].InsertCompoundChildTask()
+    meshing.workflow.TaskObject["Add Boundary Layers"].InsertCompoundChildTask()
 
-    meshing.workflow.TaskObject['aspect-ratio_1'].Arguments.setState(
+    meshing.workflow.TaskObject["aspect-ratio_1"].Arguments.set_state(
         {
-            'BLControlName': 'aspect-ratio_1',
+            "BLControlName": "aspect-ratio_1",
         }
     )
-    meshing.workflow.TaskObject['Add Boundary Layers'].Arguments.setState({})
+    meshing.workflow.TaskObject["Add Boundary Layers"].Arguments.set_state({})
 
-    meshing.workflow.TaskObject['aspect-ratio_1'].Execute()
+    meshing.workflow.TaskObject["aspect-ratio_1"].Execute()
 
 Generate volume mesh
 ~~~~~~~~~~~~~~~~~~~~
 
 .. code:: python
 
-    meshing.workflow.TaskObject['Generate the Volume Mesh'].Arguments.setState(
+    meshing.workflow.TaskObject["Generate the Volume Mesh"].Arguments.set_state(
         {
-            'AllRegionNameList': [
-                'main',
-                'flow_pipe',
-                'outpipe3',
-                'object2',
-                'object1',
-                'void-region-1',
-                'fluid-region-1',
+            "AllRegionNameList": [
+                "main",
+                "flow_pipe",
+                "outpipe3",
+                "object2",
+                "object1",
+                "void-region-1",
+                "fluid-region-1",
             ],
-            'AllRegionSizeList': ['11.33375'] * 7,
-            'AllRegionVolumeFillList': ['none'] * 6 + ['tet'],
-            'EnableParallel': True,
+            "AllRegionSizeList": ["11.33375"] * 7,
+            "AllRegionVolumeFillList": ["none"] * 6 + ["tet"],
+            "EnableParallel": True,
         }
     )
-    meshing.workflow.TaskObject['Generate the Volume Mesh'].Execute()
+    meshing.workflow.TaskObject["Generate the Volume Mesh"].Execute()
 
 Switch to solution mode
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -620,10 +578,10 @@ Note: CommandArgument attributes are read-only.
     import ansys.fluent.core as pyfluent
     from ansys.fluent.core import examples
 
-    import_filename = examples.download_file('mixing_elbow.pmdb', 'pyfluent/mixing_elbow')
-    meshing = pyfluent.launch_fluent(mode="meshing", precision='double', processor_count=2)
+    import_filename = examples.download_file("mixing_elbow.pmdb", "pyfluent/mixing_elbow")
+    meshing = pyfluent.launch_fluent(mode="meshing", precision="double", processor_count=2)
     w = meshing.workflow
-    w.InitializeWorkflow(WorkflowType='Watertight Geometry')
+    w.InitializeWorkflow(WorkflowType="Watertight Geometry")
 
     w.task("Import Geometry").CommandArguments()
     w.task("Import Geometry").CommandArguments.FileName.is_read_only()
@@ -633,3 +591,4 @@ Note: CommandArgument attributes are read-only.
     w.task("Import Geometry").CommandArguments.LengthUnit()
     w.task("Import Geometry").CommandArguments.CadImportOptions.OneZonePer()
     w.task("Import Geometry").CommandArguments.CadImportOptions.FeatureAngle.min()
+

--- a/doc/source/user_guide/models.rst
+++ b/doc/source/user_guide/models.rst
@@ -23,9 +23,10 @@ Python code for enabling and disabling the energy model.
 .. code:: python
 
     import ansys.fluent.core as pyfluent
-    solver = pyfluent.launch_fluent(precision='double', processor_count=2, mode="solver")
-    solver.tui.file.read_case('file.cas.h5')
-    solver.tui.define.models.energy('yes', 'no', 'no', 'no', 'yes')
+
+    solver = pyfluent.launch_fluent(precision="double", processor_count=2, mode="solver")
+    solver.tui.file.read_case("file.cas.h5")
+    solver.tui.define.models.energy("yes", "no", "no", "no", "yes")
 
 Define the viscous model
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -44,9 +45,9 @@ Python code for enabling and disabling various viscous models.
 
 .. code:: python
 
-    solver.tui.define.models.viscous.laminar('yes')
-    solver.tui.define.models.viscous.kw_sst('yes')
-    solver.tui.define.models.viscous.ke_standard('yes')
+    solver.tui.define.models.viscous.laminar("yes")
+    solver.tui.define.models.viscous.kw_sst("yes")
+    solver.tui.define.models.viscous.ke_standard("yes")
 
 Define the radiation model
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -64,8 +65,8 @@ Python code for enabling and disabling various radiation models.
 
 .. code:: python
 
-    solver.tui.define.models.radiation.s2s('yes')
-    solver.tui.define.models.radiation.p1('yes')
+    solver.tui.define.models.radiation.s2s("yes")
+    solver.tui.define.models.radiation.p1("yes")
 
 Define the multiphase model
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -85,10 +86,10 @@ Python code for defining different multiphase models.
 
 .. code:: python
 
-    solver.tui.define.models.multiphase.model('vof')
-    solver.tui.define.models.multiphase.model('eulerian')
-    solver.tui.define.models.multiphase.model('mixture')
-    solver.tui.define.models.multiphase.model('wetsteam')
+    solver.tui.define.models.multiphase.model("vof")
+    solver.tui.define.models.multiphase.model("eulerian")
+    solver.tui.define.models.multiphase.model("mixture")
+    solver.tui.define.models.multiphase.model("wetsteam")
 
 Use settings objects
 --------------------

--- a/doc/source/user_guide/solution.rst
+++ b/doc/source/user_guide/solution.rst
@@ -6,15 +6,15 @@ PyFluent allows you to use :ref:`ref_solver_tui_commands` and
 
 Use solver TUI commands
 -----------------------
-The examples in this section show how you use :ref:`ref_solver_tui_commands`
-to apply solution settings.
+The examples in this section show how you use :ref:`ref_solver_tui_commands` to
+apply solution settings.
 
 Select solution method 
 ~~~~~~~~~~~~~~~~~~~~~~
-This example shows a comparison between the TUI command and the
-Python code for selecting the pressure velocity coupling scheme and setting
-the gradient options. Five solution methods (Index-Model) are available:
-20-SIMPLE, 21-SIMPLEC, 22-PISO, 24-Coupled, and 25-Fractional Step.
+This example shows a comparison between the TUI command and the Python code for
+selecting the pressure velocity coupling scheme and setting the gradient
+options. Five solution methods (Index-Model) are available: 20-SIMPLE,
+21-SIMPLEC, 22-PISO, 24-Coupled, and 25-Fractional Step.
 
 **TUI command**
 
@@ -29,16 +29,17 @@ the gradient options. Five solution methods (Index-Model) are available:
 .. code:: python
 
     import ansys.fluent.core as pyfluent
-    solver = pyfluent.launch_fluent(precision='double', processor_count=2, mode="solver")
-    solver.tui.file.read_case('file.cas.h5')
-    solver.tui.solve.set.p_v_coupling(24) # Coupled
-    solver.tui.solve.set.gradient_scheme('yes')    # Green-Gauss Node Based
-    solver.tui.solve.set.gradient_scheme('no','yes') # Least Squares Cell Based
+
+    solver = pyfluent.launch_fluent(precision="double", processor_count=2, mode="solver")
+    solver.tui.file.read_case("file.cas.h5")
+    solver.tui.solve.set.p_v_coupling(24)  # Coupled
+    solver.tui.solve.set.gradient_scheme("yes")  # Green-Gauss Node Based
+    solver.tui.solve.set.gradient_scheme("no", "yes")  # Least Squares Cell Based
     
 Select solution controls 
 ~~~~~~~~~~~~~~~~~~~~~~~~
-This example shows a comparison between the TUI command and the
-Python code for selecting the pressure velocity controls.
+This example shows a comparison between the TUI command and the Python code for
+selecting the pressure velocity controls.
 
 **TUI command**
 
@@ -54,8 +55,8 @@ Python code for selecting the pressure velocity controls.
 
 Create report definition
 ~~~~~~~~~~~~~~~~~~~~~~~~
-This example shows a comparison between the TUI command and the
-Python code for creating a report definition.
+This example shows a comparison between the TUI command and the Python code for
+creating a report definition.
 
 **TUI command**
 
@@ -68,20 +69,20 @@ Python code for creating a report definition.
 .. code:: python
 
     solver.tui.solve.report_definitions.add(
-        'outlet-temp-avg',
-        'surface-massavg',
-        'field',
-        'temperature',
-        'surface-names',
-        'outlet',
-        '()',
-        'quit',
+        "outlet-temp-avg",
+        "surface-massavg",
+        "field",
+        "temperature",
+        "surface-names",
+        "outlet",
+        "()",
+        "quit",
     )
 
 Initialize and solve 
 ~~~~~~~~~~~~~~~~~~~~
-This example shows a comparison between the TUI command and the
-Python code for initializing and performing a specified number of iterations.
+This example shows a comparison between the TUI command and the Python code for
+initializing and performing a specified number of iterations.
 
 **TUI command**
 
@@ -99,8 +100,7 @@ Python code for initializing and performing a specified number of iterations.
 
 Use settings objects
 --------------------
-This example shows how you use :ref:`ref_settings` to apply solution
-settings.
+This example shows how you use :ref:`ref_settings` to apply solution settings.
 
 **Python code**
 

--- a/doc/source/user_guide/solver_settings.rst
+++ b/doc/source/user_guide/solver_settings.rst
@@ -10,9 +10,8 @@ specify solver settings.
 
 Set steady or transient solution model
 --------------------------------------
-This example shows a comparison between the TUI commands and the
-Python code for enabling and disabling the steady and unsteady (transient)
-solution model.
+This example shows a comparison between the TUI commands and the Python code for
+enabling and disabling the steady and unsteady (transient) solution model.
 
 **TUI command**
 
@@ -26,16 +25,16 @@ solution model.
 .. code:: python
 
     import ansys.fluent.core as pyfluent
-    solver = pyfluent.launch_fluent(precision='double', processor_count=2, mode="solver")
-    solver.tui.file.read_case('file.cas.h5')
-    solver.tui.define.models.steady('yes')
-    solver.tui.define.models.unsteady_1st_order('yes')
+
+    solver = pyfluent.launch_fluent(precision="double", processor_count=2, mode="solver")
+    solver.tui.file.read_case("file.cas.h5")
+    solver.tui.define.models.steady("yes")
+    solver.tui.define.models.unsteady_1st_order("yes")
 
 Set a pressure-based or density-based solver
 --------------------------------------------
-This example shows a comparison between the TUI commands and the
-Python code for enabling and disabling the pressure-based and
-density-based solver models.
+This example shows a comparison between the TUI commands and the Python code for
+enabling and disabling the pressure-based and density-based solver models.
 
 **TUI command**
 
@@ -49,14 +48,14 @@ density-based solver models.
 
 .. code:: python
 
-    solver.tui.define.models.solver.density_based_explicit('yes')
-    solver.tui.define.models.solver.density_based_implicit('yes')
-    solver.tui.define.models.solver.pressure_based('yes')
+    solver.tui.define.models.solver.density_based_explicit("yes")
+    solver.tui.define.models.solver.density_based_implicit("yes")
+    solver.tui.define.models.solver.pressure_based("yes")
 
 Set gravitational acceleration
 ------------------------------
-This example shows a comparison between the TUI command and the
-Python code for setting the gravitational acceleration.
+This example shows a comparison between the TUI command and the Python code for
+setting the gravitational acceleration.
 
 **TUI command**
 
@@ -68,4 +67,4 @@ Python code for setting the gravitational acceleration.
 
 .. code:: python
 
-    solver.tui.define.operating_conditions.gravity('yes','0','-9.81','0')
+    solver.tui.define.operating_conditions.gravity("yes","0","-9.81","0")

--- a/doc/source/user_guide/tui_commands.rst
+++ b/doc/source/user_guide/tui_commands.rst
@@ -3,15 +3,15 @@
 Using TUI commands
 ==================
 
-TUI commands refer to a programming interface that mirrors the Fluent TUI (text user
-interface). There is a TUI command hierarchy defined for each of the two modes: meshing
-and solution. The hierarchy that is active depends on the current Fluent mode. The guidance
-in this topic applies to both modes.
+TUI commands refer to a programming interface that mirrors the Fluent TUI (text
+user interface). There is a TUI command hierarchy defined for each of the two
+modes: meshing and solution. The hierarchy that is active depends on the current
+Fluent mode. The guidance in this topic applies to both modes.
 
-The PyFluent TUI commands allow you to automate workflows. Everything
-that's in the Fluent TUI (which itself is a comprehensive automation interface)
-is exposed in PyFluent. The PyFluent TUI commands are Pythonic versions of the
-commands that are used in the Fluent console.
+The PyFluent TUI commands allow you to automate workflows. Everything that's in
+the Fluent TUI (which itself is a comprehensive automation interface) is exposed
+in PyFluent. The PyFluent TUI commands are Pythonic versions of the commands
+that are used in the Fluent console.
 
 The PyFluent TUI commands do not support TUI features such as aliases or
 command abbreviation. To make using PyFluent commands in an interactive
@@ -21,24 +21,25 @@ both command line completion and history. To inspect any PyFluent TUI object fur
 you can use the Python built-in`help <https://docs.python.org/3/library/functions.html#help>`_
 and `dir <https://docs.python.org/3/library/functions.html#dir>`_ functions.
 
-The arguments to a TUI command are those that would be passed in direct interaction in the
-Fluent console, but they are in a Pythonic style. The most productive way to write Python commands
-is with reference to existing TUI commands. The following examples show how the Python usage
-mirrors the existing TUI usage.
+The arguments to a TUI command are those that would be passed in direct
+interaction in the Fluent console, but they are in a Pythonic style. The most
+productive way to write Python commands is with reference to existing TUI
+commands. The following examples show how the Python usage mirrors the existing
+TUI usage.
 
 TUI command construction
 -------------------------
-Assume that you are in the solution mode and type the following in the Fluent console to set
-velocity inlet properties:
+Assume that you are in the solution mode and type the following in the Fluent
+console to set velocity inlet properties:
 
-.. code:: lisp
+.. code:: scheme
 
     /define/boundary_conditions/set/velocity-inlet
 
 This command instigates a sequence of prompts in the console. Assume that you respond
 to each prompt in turn as follows:
 
-.. code:: lisp
+.. code:: scheme
 
     velocity-inlet-5 
     
@@ -54,7 +55,7 @@ to each prompt in turn as follows:
 
 The following code yields the same result but specifies all arguments in one call:
 
-.. code:: lisp
+.. code:: scheme
 
     /define/boundary-conditions/set/velocity-inlet velocity-inlet-5 () temperature no 293.15 quit
 
@@ -73,8 +74,8 @@ code launches Fluent and makes the call to set velocity inlet properties:
     tui = solver.solver.tui
 
     tui.define.boundary_conditions.set.velocity_inlet(
-      "velocity-inlet-5", [], "temperature", "no", 293.15, "quit"
-      )
+        "velocity-inlet-5", [], "temperature", "no", 293.15, "quit"
+    )
 
 Here is another Fluent console interaction:
 
@@ -92,16 +93,17 @@ The corresponding Python call is:
 
     tui.define.units("pressure", '"Pa"')
 
-To preserve the double quotation marks around the TUI argument,
-you must wrap the string ``"Pa"`` in single quotation marks .
+To preserve the double quotation marks around the TUI argument, you must wrap
+the string ``"Pa"`` in single quotation marks.
 
 TUI command transformation rules
 --------------------------------
 The following rules are implied in the preceding examples:
 
-- Each forward slash separator between elements in TUI paths is transformed to Python dot notation.
-- Some characters in path elements are either removed or replaced because they are illegal inside Python names.
-  For example:
+- Each forward slash separator between elements in TUI paths is transformed to
+  Python dot notation.
+- Some characters in path elements are either removed or replaced because they
+  are illegal inside Python names. For example:
   
   - Each hyphen in a path element is transformed to an underscore.
   - Each question mark in a path element is removed.
@@ -109,8 +111,9 @@ The following rules are implied in the preceding examples:
 - Some are some rules about strings:
   
   - String-type arguments must be surrounded by quotation marks in Python.
-  - A target Fluent TUI argument that is surrounded by quotation marks (like ``"Pa"`` in the preceding
-    example) must be wrapped in single quotation marks so that the original quotation marks are preserved.
+  - A target Fluent TUI argument that is surrounded by quotation marks (like
+    ``"Pa"`` in the preceding example) must be wrapped in single quotation marks
+    so that the original quotation marks are preserved.
   - The contents of string arguments are preserved.
 
 For more examples of TUI command usage, see :ref:`ref_mixing_elbow_tui_api`.

--- a/examples/00-fluent/exhaust_system.py
+++ b/examples/00-fluent/exhaust_system.py
@@ -92,8 +92,10 @@ meshing.PartManagement.Node["Meshing Model"].Copy(
         "/dirty_manifold-for-wrapper," + "1/dirty_manifold-for-wrapper,1/object1,1",
     ]
 )
-meshing.PartManagement.ObjectSetting["DefaultObjectSetting"].OneZonePer.setState("part")
-meshing.workflow.TaskObject["Import CAD and Part Management"].Arguments.setState(
+meshing.PartManagement.ObjectSetting["DefaultObjectSetting"].OneZonePer.set_state(
+    "part"
+)
+meshing.workflow.TaskObject["Import CAD and Part Management"].Arguments.set_state(
     {
         "Context": 0,
         "CreateObjectPer": "Custom",
@@ -114,7 +116,7 @@ meshing.workflow.TaskObject["Import CAD and Part Management"].Execute()
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Describe the geometry and the flow characteristics.
 
-meshing.workflow.TaskObject["Describe Geometry and Flow"].Arguments.setState(
+meshing.workflow.TaskObject["Describe Geometry and Flow"].Arguments.set_state(
     {
         "AddEnclosure": "No",
         "CloseCaps": "Yes",
@@ -124,7 +126,7 @@ meshing.workflow.TaskObject["Describe Geometry and Flow"].Arguments.setState(
 meshing.workflow.TaskObject["Describe Geometry and Flow"].UpdateChildTasks(
     SetupTypeChanged=False
 )
-meshing.workflow.TaskObject["Describe Geometry and Flow"].Arguments.setState(
+meshing.workflow.TaskObject["Describe Geometry and Flow"].Arguments.set_state(
     {
         "AddEnclosure": "No",
         "CloseCaps": "Yes",
@@ -155,7 +157,7 @@ meshing.workflow.TaskObject["Describe Geometry and Flow"].Execute()
 #   :width: 400pt
 #   :align: center
 
-meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.setState(
+meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state(
     {
         "CreatePatchPreferences": {
             "ShowCreatePatchPreferences": False,
@@ -165,7 +167,7 @@ meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.setStat
         "ZoneSelectionList": ["inlet.1"],
     }
 )
-meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.setState(
+meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state(
     {
         "CreatePatchPreferences": {
             "ShowCreatePatchPreferences": False,
@@ -188,16 +190,16 @@ meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.setStat
 meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].AddChildToTask()
 
 meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].InsertCompoundChildTask()
-meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.setState({})
+meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state({})
 meshing.workflow.TaskObject["inlet-1"].Execute()
-meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.setState(
+meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state(
     {
         "PatchName": "inlet-2",
         "SelectionType": "zone",
         "ZoneSelectionList": ["inlet.2"],
     }
 )
-meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.setState(
+meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state(
     {
         "PatchName": "inlet-2",
         "SelectionType": "zone",
@@ -217,16 +219,16 @@ meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.setStat
 meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].AddChildToTask()
 
 meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].InsertCompoundChildTask()
-meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.setState({})
+meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state({})
 meshing.workflow.TaskObject["inlet-2"].Execute()
-meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.setState(
+meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state(
     {
         "PatchName": "inlet-3",
         "SelectionType": "zone",
         "ZoneSelectionList": ["inlet"],
     }
 )
-meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.setState(
+meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state(
     {
         "PatchName": "inlet-3",
         "SelectionType": "zone",
@@ -246,9 +248,9 @@ meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.setStat
 meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].AddChildToTask()
 
 meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].InsertCompoundChildTask()
-meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.setState({})
+meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state({})
 meshing.workflow.TaskObject["inlet-3"].Execute()
-meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.setState(
+meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state(
     {
         "PatchName": "outlet-1",
         "SelectionType": "zone",
@@ -256,7 +258,7 @@ meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.setStat
         "ZoneType": "pressure-outlet",
     }
 )
-meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.setState(
+meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state(
     {
         "PatchName": "outlet-1",
         "SelectionType": "zone",
@@ -277,7 +279,7 @@ meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.setStat
 meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].AddChildToTask()
 
 meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].InsertCompoundChildTask()
-meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.setState({})
+meshing.workflow.TaskObject["Enclose Fluid Regions (Capping)"].Arguments.set_state({})
 meshing.workflow.TaskObject["outlet-1"].Execute()
 
 ###############################################################################
@@ -285,7 +287,7 @@ meshing.workflow.TaskObject["outlet-1"].Execute()
 # ~~~~~~~~~~~~~~~~~~~~~
 # Extract edge features.
 
-meshing.workflow.TaskObject["Extract Edge Features"].Arguments.setState(
+meshing.workflow.TaskObject["Extract Edge Features"].Arguments.set_state(
     {
         "ExtractMethodType": "Intersection Loops",
         "ObjectSelectionList": ["flow_pipe", "main"],
@@ -295,14 +297,14 @@ meshing.workflow.TaskObject["Extract Edge Features"].AddChildToTask()
 
 meshing.workflow.TaskObject["Extract Edge Features"].InsertCompoundChildTask()
 
-meshing.workflow.TaskObject["edge-group-1"].Arguments.setState(
+meshing.workflow.TaskObject["edge-group-1"].Arguments.set_state(
     {
         "ExtractEdgesName": "edge-group-1",
         "ExtractMethodType": "Intersection Loops",
         "ObjectSelectionList": ["flow_pipe", "main"],
     }
 )
-meshing.workflow.TaskObject["Extract Edge Features"].Arguments.setState({})
+meshing.workflow.TaskObject["Extract Edge Features"].Arguments.set_state({})
 
 meshing.workflow.TaskObject["edge-group-1"].Execute()
 
@@ -311,7 +313,7 @@ meshing.workflow.TaskObject["edge-group-1"].Execute()
 # ~~~~~~~~~~~~~~~~
 # Identify regions.
 
-meshing.workflow.TaskObject["Identify Regions"].Arguments.setState(
+meshing.workflow.TaskObject["Identify Regions"].Arguments.set_state(
     {
         "SelectionType": "zone",
         "X": 377.322045740589,
@@ -320,7 +322,7 @@ meshing.workflow.TaskObject["Identify Regions"].Arguments.setState(
         "ZoneSelectionList": ["main.1"],
     }
 )
-meshing.workflow.TaskObject["Identify Regions"].Arguments.setState(
+meshing.workflow.TaskObject["Identify Regions"].Arguments.set_state(
     {
         "SelectionType": "zone",
         "X": 377.322045740589,
@@ -343,7 +345,7 @@ meshing.workflow.TaskObject["Identify Regions"].AddChildToTask()
 
 meshing.workflow.TaskObject["Identify Regions"].InsertCompoundChildTask()
 
-meshing.workflow.TaskObject["fluid-region-1"].Arguments.setState(
+meshing.workflow.TaskObject["fluid-region-1"].Arguments.set_state(
     {
         "MaterialPointsName": "fluid-region-1",
         "SelectionType": "zone",
@@ -363,10 +365,10 @@ meshing.workflow.TaskObject["fluid-region-1"].Arguments.setState(
         "ZoneSelectionList": ["main.1"],
     }
 )
-meshing.workflow.TaskObject["Identify Regions"].Arguments.setState({})
+meshing.workflow.TaskObject["Identify Regions"].Arguments.set_state({})
 
 meshing.workflow.TaskObject["fluid-region-1"].Execute()
-meshing.workflow.TaskObject["Identify Regions"].Arguments.setState(
+meshing.workflow.TaskObject["Identify Regions"].Arguments.set_state(
     {
         "MaterialPointsName": "void-region-1",
         "NewRegionType": "void",
@@ -380,7 +382,7 @@ meshing.workflow.TaskObject["Identify Regions"].AddChildToTask()
 
 meshing.workflow.TaskObject["Identify Regions"].InsertCompoundChildTask()
 
-meshing.workflow.TaskObject["Identify Regions"].Arguments.setState({})
+meshing.workflow.TaskObject["Identify Regions"].Arguments.set_state({})
 
 meshing.workflow.TaskObject["void-region-1"].Execute()
 
@@ -389,7 +391,7 @@ meshing.workflow.TaskObject["void-region-1"].Execute()
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Define thresholds for potential leakages.
 
-meshing.workflow.TaskObject["Define Leakage Threshold"].Arguments.setState(
+meshing.workflow.TaskObject["Define Leakage Threshold"].Arguments.set_state(
     {
         "AddChild": "yes",
         "FlipDirection": True,
@@ -400,7 +402,7 @@ meshing.workflow.TaskObject["Define Leakage Threshold"].Arguments.setState(
 meshing.workflow.TaskObject["Define Leakage Threshold"].AddChildToTask()
 
 meshing.workflow.TaskObject["Define Leakage Threshold"].InsertCompoundChildTask()
-meshing.workflow.TaskObject["leakage-1"].Arguments.setState(
+meshing.workflow.TaskObject["leakage-1"].Arguments.set_state(
     {
         "AddChild": "yes",
         "FlipDirection": True,
@@ -409,7 +411,7 @@ meshing.workflow.TaskObject["leakage-1"].Arguments.setState(
         "RegionSelectionSingle": "void-region-1",
     }
 )
-meshing.workflow.TaskObject["Define Leakage Threshold"].Arguments.setState(
+meshing.workflow.TaskObject["Define Leakage Threshold"].Arguments.set_state(
     {
         "AddChild": "yes",
     }
@@ -421,7 +423,7 @@ meshing.workflow.TaskObject["leakage-1"].Execute()
 # ~~~~~~~~~~~~~~~~~~~~~~
 # Review the region settings.
 
-meshing.workflow.TaskObject["Update Region Settings"].Arguments.setState(
+meshing.workflow.TaskObject["Update Region Settings"].Arguments.set_state(
     {
         "AllRegionFilterCategories": ["2"] * 5 + ["1"] * 2,
         "AllRegionLeakageSizeList": ["none"] * 6 + ["6.4"],
@@ -493,12 +495,12 @@ meshing.workflow.TaskObject["Add Boundary Layers"].AddChildToTask()
 
 meshing.workflow.TaskObject["Add Boundary Layers"].InsertCompoundChildTask()
 
-meshing.workflow.TaskObject["aspect-ratio_1"].Arguments.setState(
+meshing.workflow.TaskObject["aspect-ratio_1"].Arguments.set_state(
     {
         "BLControlName": "aspect-ratio_1",
     }
 )
-meshing.workflow.TaskObject["Add Boundary Layers"].Arguments.setState({})
+meshing.workflow.TaskObject["Add Boundary Layers"].Arguments.set_state({})
 
 meshing.workflow.TaskObject["aspect-ratio_1"].Execute()
 
@@ -512,7 +514,7 @@ meshing.workflow.TaskObject["aspect-ratio_1"].Execute()
 #   :width: 500pt
 #   :align: center
 
-meshing.workflow.TaskObject["Generate the Volume Mesh"].Arguments.setState(
+meshing.workflow.TaskObject["Generate the Volume Mesh"].Arguments.set_state(
     {
         "AllRegionNameList": [
             "main",

--- a/examples/00-fluent/mixing_elbow.py
+++ b/examples/00-fluent/mixing_elbow.py
@@ -75,9 +75,10 @@ meshing.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Import the CAD geometry and set the length units to inches.
 
-meshing.workflow.TaskObject["Import Geometry"].Arguments = dict(
-    FileName=import_filename, LengthUnit="in"
-)
+meshing.workflow.TaskObject["Import Geometry"].Arguments = {
+    "FileName": import_filename,
+    "LengthUnit": "in",
+}
 
 # Import geometry
 # ~~~~~~~~~~~~~~~
@@ -115,9 +116,9 @@ meshing.workflow.TaskObject["Generate the Surface Mesh"].Execute()
 meshing.workflow.TaskObject["Describe Geometry"].UpdateChildTasks(
     SetupTypeChanged=False
 )
-meshing.workflow.TaskObject["Describe Geometry"].Arguments = dict(
-    SetupType="The geometry consists of only fluid regions with no voids"
-)
+meshing.workflow.TaskObject["Describe Geometry"].Arguments = {
+    "SetupType": "The geometry consists of only fluid regions with no voids"
+}
 meshing.workflow.TaskObject["Describe Geometry"].UpdateChildTasks(SetupTypeChanged=True)
 meshing.workflow.TaskObject["Describe Geometry"].Execute()
 


### PR DESCRIPTION
- Switch from setState to set_state in the meshing workflows documentation
- Run many of the Python code examples through black so they are formatted like the library code
- Use `{}` consistently through the meshing workflow examples
- A little bit of rewrapping of certain paragraphs at 80 columns