### PR TITLE
Ignore all the generated API files from all fluent versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,13 +135,9 @@ dmypy.json
 .vscode
 
 # generated API files
-src/ansys/fluent/core/fluent_version_222.py
-src/ansys/fluent/core/meshing/tui_222.py
-src/ansys/fluent/core/solver/tui_222.py
-src/ansys/fluent/core/datamodel_222/
-src/ansys/fluent/core/solver/settings_222/
-src/ansys/fluent/core/fluent_version_231.py
-src/ansys/fluent/core/meshing/tui_231.py
-src/ansys/fluent/core/solver/tui_231.py
-src/ansys/fluent/core/datamodel_222/
-src/ansys/fluent/core/solver/settings_222/
+src/ansys/fluent/core/fluent_version_*.py
+src/ansys/fluent/core/meshing/tui_*.py
+src/ansys/fluent/core/solver/tui_*.py
+src/ansys/fluent/core/datamodel_*/
+src/ansys/fluent/core/solver/settings_*/
+


### PR DESCRIPTION
Make it more generic so all the versions are captured.