### PR TITLE
Address field data access error handling

### DIFF
--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -190,12 +190,16 @@ class _FluentConnection:
         self.datamodel_service_se = DatamodelService_SE(self._channel, self._metadata)
         self.settings_service = SettingsService(self._channel, self._metadata)
 
-        self._field_data_service = FieldDataService(self._channel, self._metadata)
-        self.field_info = FieldInfo(self._field_data_service)
-        self.field_data = FieldData(self._field_data_service, self.field_info)
-
         self._scheme_eval_service = SchemeEvalService(self._channel, self._metadata)
         self.scheme_eval = SchemeEval(self._scheme_eval_service)
+
+        self._field_data_service = FieldDataService(self._channel, self._metadata)
+        self.field_info = FieldInfo(self._field_data_service)
+        self.field_data = FieldData(
+            self._field_data_service,
+            self.field_info,
+            lambda: self.scheme_eval.scheme_eval("(data-valid?)"),
+        )
 
         self.journal = Journal(self.scheme_eval)
 

--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -190,9 +190,6 @@ class _FluentConnection:
         self.datamodel_service_se = DatamodelService_SE(self._channel, self._metadata)
         self.settings_service = SettingsService(self._channel, self._metadata)
 
-        self._scheme_eval_service = SchemeEvalService(self._channel, self._metadata)
-        self.scheme_eval = SchemeEval(self._scheme_eval_service)
-
         self._field_data_service = FieldDataService(self._channel, self._metadata)
         self.field_info = FieldInfo(self._field_data_service)
         self.field_data = FieldData(
@@ -200,6 +197,9 @@ class _FluentConnection:
             self.field_info,
             lambda: self.scheme_eval.scheme_eval("(data-valid?)"),
         )
+
+        self._scheme_eval_service = SchemeEvalService(self._channel, self._metadata)
+        self.scheme_eval = SchemeEval(self._scheme_eval_service)
 
         self.journal = Journal(self.scheme_eval)
 

--- a/src/ansys/fluent/core/services/field_data.py
+++ b/src/ansys/fluent/core/services/field_data.py
@@ -58,6 +58,15 @@ class SurfaceNameError(ValueError):
         )
 
 
+def valid_surface_name(surface_name, field_info):
+    if validate_inputs and surface_name not in field_info.get_surfaces_info():
+        raise SurfaceNameError(
+            surface_name=surface_name,
+            allowed_values=field_info.get_surfaces_info(),
+        )
+    return surface_name
+
+
 def valid_scalar_field_name(field_name, field_info):
     if validate_inputs and field_name not in field_info.get_fields_info():
         raise ScalarFieldNameError(
@@ -487,12 +496,9 @@ def _get_surface_ids(
                     field_info.get_surfaces_info()[surface_name]["surface_id"]
                 )
         elif surface_name:
-            if validate_inputs and surface_name not in field_info.get_surfaces_info():
-                raise SurfaceNameError(
-                    surface_name=surface_name,
-                    allowed_values=field_info.get_surfaces_info(),
-                )
-            surface_ids = field_info.get_surfaces_info()[surface_name]["surface_id"]
+            surface_ids = field_info.get_surfaces_info()[
+                valid_surface_name(surface_name, field_info)
+            ]["surface_id"]
         else:
             raise RuntimeError("Please provide either surface names or surface ids.")
     return surface_ids

--- a/src/ansys/fluent/core/services/field_data.py
+++ b/src/ansys/fluent/core/services/field_data.py
@@ -12,8 +12,8 @@ from ansys.api.fluent.v0 import field_data_pb2_grpc as FieldGrpcModule
 from ansys.fluent.core.services.error_handler import catch_grpc_error
 from ansys.fluent.core.services.interceptors import TracingInterceptor
 
-# this can be switched to False where the field_data request inputs are
-# fed by results of field_info queries
+# this can be switched to False in scenarios where the field_data request inputs are
+# fed by results of field_info queries, which might be true in GUI code.
 validate_inputs = True
 
 

--- a/src/ansys/fluent/core/services/field_data.py
+++ b/src/ansys/fluent/core/services/field_data.py
@@ -11,25 +11,34 @@ from ansys.api.fluent.v0 import field_data_pb2_grpc as FieldGrpcModule
 from ansys.fluent.core.services.error_handler import catch_grpc_error
 from ansys.fluent.core.services.interceptors import TracingInterceptor
 
+# this can be switched to False where the field_data request inputs are
+# fed by results of field_info queries
 validate_inputs = True
 
 
 class FieldNameError(ValueError):
-    def __init__(self, field_name):
-        self.field_name = field_name
+    pass
 
 
 class ScalarFieldNameError(FieldNameError):
-    pass
+    def __init__(self, field_name):
+        self.field_name = field_name
+        message = f"{field_name} is not an allowed scalar field name."
+        super().__init__(message)
 
 
 class VectorFieldNameError(FieldNameError):
-    pass
+    def __init__(self, field_name):
+        self.field_name = field_name
+        message = f"{field_name} is not an allowed vector field name."
+        super().__init__(message)
 
 
 class SurfaceNameError(ValueError):
     def __init__(self, surface_name):
         self.surface_name = surface_name
+        message = f"{surface_name} is not an allowed surface name."
+        super().__init__(message)
 
 
 def valid_scalar_field_name(field_name, field_info):

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -573,7 +573,9 @@ class NamedObject(SettingsBase[DictStateType], Generic[ChildTypeT]):
 
     def get_object_names(self):
         """Object names."""
-        return list(self.flproxy.get_object_names(self.path))
+        obj_names = self.flproxy.get_object_names(self.path)
+        obj_names_list = obj_names if isinstance(obj_names, list) else list(obj_names)
+        return obj_names_list
 
     def __getitem__(self, name: str) -> ChildTypeT:
         if name not in self.get_object_names():

--- a/tests/test_field_data.py
+++ b/tests/test_field_data.py
@@ -1,6 +1,6 @@
 import os
 
-os.environ["PYFLUENT_FLUENT_ROOT"] = r"C:\ANSYSDev\ANSYSDev\vNNN\fluent"
+os.environ["PYFLUENT_FLUENT_ROOT"] = r"C:\ANSYSDev\ANSYSDev\vNNN\fluent"  # ???
 
 import numpy as np
 import pytest

--- a/tests/test_field_data_errors.py
+++ b/tests/test_field_data_errors.py
@@ -1,0 +1,29 @@
+import pytest
+from util.solver_workflow import new_solver_session  # noqa: F401
+
+from ansys.fluent.core import examples
+from ansys.fluent.core.services.field_data import FieldNameError, SurfaceNameError
+
+
+def test_field_data_errors(new_solver_session) -> None:
+    solver = new_solver_session
+    import_filename = examples.download_file(
+        "mixing_elbow.msh.h5", "pyfluent/mixing_elbow"
+    )
+    solver.file.read(file_type="case", file_name=import_filename)
+
+    # Initialize flow field
+    solver.solution.initialization.hybrid_initialize()
+
+    # Get field data object
+    field_data = solver.field_data
+
+    with pytest.raises(SurfaceNameError) as sne:
+        solver.field_data.get_scalar_field_data(
+            field_name="entropy", surface_name="bob"
+        )
+    assert sne.value.surface_name == "bob"
+
+    with pytest.raises(FieldNameError) as fne:
+        solver.field_data.get_scalar_field_data(field_name="bentropy", surface_ids=[0])
+    assert fne.value.field_name == "bentropy"

--- a/tests/test_field_data_errors.py
+++ b/tests/test_field_data_errors.py
@@ -2,7 +2,7 @@ import pytest
 from util.solver_workflow import new_solver_session  # noqa: F401
 
 from ansys.fluent.core import examples
-from ansys.fluent.core.services.field_data import FieldNameError, SurfaceNameError
+from ansys.fluent.core.services.field_data import ScalarFieldNameError, SurfaceNameError
 
 
 def test_field_data_errors(new_solver_session) -> None:
@@ -24,6 +24,6 @@ def test_field_data_errors(new_solver_session) -> None:
         )
     assert sne.value.surface_name == "bob"
 
-    with pytest.raises(FieldNameError) as fne:
+    with pytest.raises(ScalarFieldNameError) as fne:
         solver.field_data.get_scalar_field_data(field_name="bentropy", surface_ids=[0])
     assert fne.value.field_name == "bentropy"

--- a/tests/test_field_data_errors.py
+++ b/tests/test_field_data_errors.py
@@ -2,7 +2,11 @@ import pytest
 from util.solver_workflow import new_solver_session  # noqa: F401
 
 from ansys.fluent.core import examples
-from ansys.fluent.core.services.field_data import ScalarFieldNameError, SurfaceNameError
+from ansys.fluent.core.services.field_data import (
+    ScalarFieldNameError,
+    ScalarFieldUnavailable,
+    SurfaceNameError,
+)
 
 
 def test_field_data_errors(new_solver_session) -> None:
@@ -10,7 +14,34 @@ def test_field_data_errors(new_solver_session) -> None:
     import_filename = examples.download_file(
         "mixing_elbow.msh.h5", "pyfluent/mixing_elbow"
     )
+
+    with pytest.raises(ScalarFieldNameError) as fne:
+        solver.field_data.get_scalar_field_data(
+            field_name="y-face-area", surface_ids=[0]
+        )
+    assert fne.value.field_name == "y-face-area"
+
+    with pytest.raises(ScalarFieldNameError) as fne:
+        solver.field_data.get_scalar_field_data(
+            field_name="partition-neighbors", surface_ids=[0]
+        )
+    assert fne.value.field_name == "partition-neighbors"
+
     solver.file.read(file_type="case", file_name=import_filename)
+
+    with pytest.raises(ScalarFieldUnavailable) as fnu:
+        solver.field_data.get_scalar_field_data(field_name="density", surface_ids=[0])
+    assert fnu.value.field_name == "density"
+
+    y_face_area = solver.field_data.get_scalar_field_data(
+        field_name="y-face-area", surface_ids=[0]
+    )
+    assert y_face_area and isinstance(y_face_area, dict)
+
+    partition_neighbors = solver.field_data.get_scalar_field_data(
+        field_name="partition-neighbors", surface_ids=[0]
+    )
+    assert partition_neighbors and isinstance(partition_neighbors, dict)
 
     # Initialize flow field
     solver.solution.initialization.hybrid_initialize()
@@ -20,10 +51,10 @@ def test_field_data_errors(new_solver_session) -> None:
 
     with pytest.raises(SurfaceNameError) as sne:
         solver.field_data.get_scalar_field_data(
-            field_name="entropy", surface_name="bob"
+            field_name="density", surface_name="bob"
         )
     assert sne.value.surface_name == "bob"
 
     with pytest.raises(ScalarFieldNameError) as fne:
-        solver.field_data.get_scalar_field_data(field_name="bentropy", surface_ids=[0])
-    assert fne.value.field_name == "bentropy"
+        solver.field_data.get_scalar_field_data(field_name="xdensity", surface_ids=[0])
+    assert fne.value.field_name == "xdensity"

--- a/tests/test_fluent_session.py
+++ b/tests/test_fluent_session.py
@@ -69,7 +69,7 @@ def test_server_exits_when_session_goes_out_of_scope(with_launching_container) -
     if os.getenv("PYFLUENT_START_INSTANCE") == "0":
         containers_before = get_container_ids_set()
         f()
-        time.sleep(10)
+        time.sleep(20)
         containers_after = get_container_ids_set()
         new_containers = containers_after - containers_before
         assert not new_containers


### PR DESCRIPTION
Trying to add a bit of safety around field data calls. Up to now, invalid calls (invalid field name, location name) crash Fluent, so I am checking field_info for the validity of names up front, and cleanly raising exceptions in the client as appropriate. An extra feature is that the raised exception can contain hints for closely matching names, which should help many users - we get a lot of queries about what is the right field name to use.

Outstanding issues:
- the field names from field info are not necessarily all "active". If there is no data then non-mesh variable access will still tend to crash Fluent. Perhaps we can pass an extra argument to the field info queries to request active-only (can this be easily implemented?)
- alignment of field names with variable names across the API. Judging by the queries I receive, I suspect that there is some misalignment, which would be the cause for the misuse
- potential reuse of the introduced _close matches_ function across the APIs?