### PR TITLE
Improve CI run (include marker for 23.2 + zip coverage results).

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,9 +464,9 @@ jobs:
           FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
 
       - name: Zip 23.1 Coverage Results before upload
-          run: |
-            sudo apt install zip -y
-            zip -r cov.zip cov_html
+        run: |
+          sudo apt install zip -y
+          zip -r cov.zip cov_html
 
       - name: Upload 23.1 Coverage Results
         if: matrix.image-tag == 'v23.1.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,12 +463,17 @@ jobs:
           PYFLUENT_START_INSTANCE: 0
           FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
 
+      - name: Zip 23.1 Coverage Results before upload
+          run: |
+            sudo apt install zip -y
+            zip -r cov.zip cov_html
+
       - name: Upload 23.1 Coverage Results
         if: matrix.image-tag == 'v23.1.0'
         uses: actions/upload-artifact@v3
         with:
           name: HTML-Coverage-tag-231
-          path: cov_html
+          path: cov.zip
           retention-days: 7
 
   release:

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,12 @@ unittest: unittest-dev-231
 unittest-dev-222:
 	@echo "Running unittests"
 	@pip install -r requirements/requirements_tests.txt
-	@python -m pytest -v -m "dev and not fluent_231" --cov=ansys.fluent --cov-report html:cov_html --cov-config=.coveragerc
+	@python -m pytest -v -m "dev and not fluent_231 and not fluent_232" --cov=ansys.fluent --cov-report html:cov_html --cov-config=.coveragerc
 
 unittest-dev-231:
 	@echo "Running unittests"
 	@pip install -r requirements/requirements_tests.txt
-	@python -m pytest -v -m "dev and not fluent_222" --cov=ansys.fluent --cov-report html:cov_html --cov-config=.coveragerc
+	@python -m pytest -v -m "dev and not fluent_222  and not fluent_232" --cov=ansys.fluent --cov-report html:cov_html --cov-config=.coveragerc
 
 unittest-dev-232:
 	@echo "Running unittests"

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unittest-dev-222:
 unittest-dev-231:
 	@echo "Running unittests"
 	@pip install -r requirements/requirements_tests.txt
-	@python -m pytest -v -m "dev and not fluent_222  and not fluent_232" --cov=ansys.fluent --cov-report html:cov_html --cov-config=.coveragerc
+	@python -m pytest -v -m "dev and not fluent_222" --cov=ansys.fluent --cov-report html:cov_html --cov-config=.coveragerc
 
 unittest-dev-232:
 	@echo "Running unittests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ markers = [
     "nightly: Tests that run under nightly CI",
     "fluent_222: Tests that run only with Fluent 22.2",
     "fluent_231: Tests that run only with Fluent 23.1",
+    "fluent_232: Tests that run only with Fluent 23.2",
 ]
 
 


### PR DESCRIPTION
Test coverage html files have been zipped before uploading for the github CI run. This saves a lot of time by not requiring to upload large size files. Along with that a new marker for running tests in only 23.2 has been developed as well.
For now, if we mark a test with "fluent_222" -> it runs only in 22R2, "fluent_231" -> both in 23R1 and 23R2 and "fluent_232" -> only in 23R2.