### PR TITLE
Edit learning subsection in FAQ section per Ryan's comment

### DIFF
--- a/doc/source/getting_started/faqs.rst
+++ b/doc/source/getting_started/faqs.rst
@@ -184,14 +184,14 @@ to learn how to use PyFluent:
   **Examples** sections in the `PyFluent-Parametric <https://fluentparametric.docs.pyansys.com/>`_ and
   `Pyfluent-Visusalization <https://fluentvisualization.docs.pyansys.com/>`_
   guides.
-- Record a journal of your actions in Fluent and review the corresponding script.
+- Record a journal of your actions in Fluent and review the corresponding Python script.
   
   .. note::
-     In Fluent 2022 R2, recording a journal of your Fluent meshing commands does not
-     produce a Python script that is in PyFluent syntax. However, there is a
-     one-to-one correspondence between the recorded Python command and the equivalent
-     PyFluent command. This means that you can manually translate the recorded Python
-     command to the PyFluent syntax.
+     In Fluent 2022 R2, you can only record a journal of your actions in Fluent
+     meshing to produce a Python script. This script is not in PyFluent syntax.
+     However, there is a one-to-one correspondence between the a recorded Python
+     command and the equivalent PyFluent command. This means that you can manually
+     translate the recorded Python command to the PyFluent syntax.
 
   
   Here is a Python command recorded in Fluent:


### PR DESCRIPTION
The doc suggestions made in this PR are based on this comment from Ryan:

Regarding "How do you learn how to use PyFluent," in 2022 R2 you can only record a journal of your actions in Fluent meshing to produce a Python script.