### PR TITLE
Automated scm to py journal creation

### DIFF
--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -444,6 +444,7 @@ def launch_fluent(
     password: str = None,
     py: bool = None,
     cwd: str = None,
+    topy: Union[str, list] = None,
 ) -> Union[_BaseSession, Session]:
     """Launch Fluent locally in server mode or connect to a running Fluent
     server instance.
@@ -525,10 +526,11 @@ def launch_fluent(
     py : bool, optional
         Passes ``"-py"`` as an additional_argument to launch fluent in python mode.
         The default is ``None``.
-
     cwd: str, Optional
         Path to specify current working directory to launch fluent from the defined directory as
         current working directory.
+    topy: str or list, optional
+        Automates scheme to python journal creation.
 
     Returns
     -------
@@ -563,6 +565,20 @@ def launch_fluent(
             kwargs = _get_subprocess_kwargs_for_fluent(env)
             if cwd:
                 kwargs.update(cwd=cwd)
+            if topy:
+                if isinstance(topy, str):
+                    journal_name = topy.split(".")[0]
+                    journal_ext = topy.split(".")[1]
+                    launch_string += f' -i {journal_name}.{journal_ext} -command="(api-start-python-journal \\\"\\\"{journal_name}.py\\\"\\\")"'  # noqa: E501
+                if isinstance(topy, list):
+                    all_scm_journal_names = ""
+                    all_py_journal_names = ""
+                    for journals in topy:
+                        journal_name = journals.split(".")[0]
+                        journal_ext = journals.split(".")[1]
+                        all_scm_journal_names += f' -i {journal_name}.{journal_ext}'
+                        all_py_journal_names += f'{journal_name}_'
+                    launch_string += f'{all_scm_journal_names} -command="(api-start-python-journal \\\"\\\"{all_py_journal_names}journal.py\\\"\\\")"'  # noqa: E501
             subprocess.Popen(launch_string, **kwargs)
 
             _await_fluent_launch(server_info_filepath, start_timeout, sifile_last_mtime)

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -573,12 +573,14 @@ def launch_fluent(
                 if isinstance(topy, list):
                     all_scm_journal_names = ""
                     all_py_journal_names = ""
+                    name_list = []
                     for journals in topy:
-                        journal_name = journals.split(".")[0]
-                        journal_ext = journals.split(".")[1]
+                        journal_name = journals.rsplit(".")[0]
+                        journal_ext = journals.rsplit(".")[1]
+                        name_list.append(journal_name)
                         all_scm_journal_names += f' -i {journal_name}.{journal_ext}'
-                        all_py_journal_names += f'{journal_name}_'
-                    launch_string += f'{all_scm_journal_names} -command="(api-start-python-journal \\\"\\\"{all_py_journal_names}journal.py\\\"\\\")"'  # noqa: E501
+                    all_py_journal_names += '_'.join(name_list)
+                    launch_string += f'{all_scm_journal_names} -command="(api-start-python-journal \\\"\\\"{all_py_journal_names}.py\\\"\\\")"'  # noqa: E501
             subprocess.Popen(launch_string, **kwargs)
 
             _await_fluent_launch(server_info_filepath, start_timeout, sifile_last_mtime)


### PR DESCRIPTION
Automated scm to py journal creation.

`solver = pf.launch_fluent(mode="solver", topy="myjournal.jou", show_gui=True)`

output file = `myjournal.py`

![image](https://user-images.githubusercontent.com/106588300/207296910-f5a60ee9-a4cf-4706-89ca-89c7104f9ceb.png)

`---------------------------------------------------------------------------------------------------------------------------------------`

`solver = pf.launch_fluent(mode="solver", topy="myjournal.scm", show_gui=True)`

output file = `myjournal.py`

![image](https://user-images.githubusercontent.com/106588300/207299129-eade22a7-4511-46da-8488-520da5167bac.png)

`---------------------------------------------------------------------------------------------------------------------------------------`

`solver = pf.launch_fluent(mode="solver", topy=["my_jou_1.jou", "my_jou_2.jou"], show_gui=True)`

output file = `my_jou_1_my_jou_2.py`

![image](https://user-images.githubusercontent.com/106588300/207296491-735b087f-bc2c-469e-83a9-095b1ab43fea.png)

`---------------------------------------------------------------------------------------------------------------------------------------`

`solver = pf.launch_fluent(mode="solver", topy=["my_jou_1.scm", "my_jou_2.scm"], show_gui=True)`

output file = `my_jou_1_my_jou_2.py`

![image](https://user-images.githubusercontent.com/106588300/207297467-75667d99-65d3-42d9-be3d-47981333577f.png)

