### PR TITLE
DOC: enable multi-version documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ env:
   # It applies 7 days retention policy by default.
   RESET_EXAMPLES_CACHE: 6
   API_CODE_CACHE: 3
+  DOCUMENTATION_CNAME: 'fluent.docs.pyansys.com'
 
 jobs:
   stylecheck:
@@ -116,15 +117,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # used for documentation deployment
-      - name: Get Bot Application Token
-        if: github.event_name == 'push' && contains(github.ref, 'refs/tags') && matrix.image-tag == 'v23.1.0'
-        id: get_workflow_token
-        uses: peter-murray/workflow-application-token-action@v2
-        with:
-          application_id: ${{ secrets.BOT_APPLICATION_ID }}
-          application_private_key: ${{ secrets.BOT_APPLICATION_PRIVATE_KEY }}
-
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -206,16 +198,11 @@ jobs:
             Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}
 
       - name: Build Documentation
-        run: make build-doc DOCS_CNAME=fluent.docs.pyansys.com
+        run: make build-doc
         env:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
           FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
-
-      - name: Zip HTML Documentation before upload
-        run: |
-          sudo apt install zip -y
-          zip -r doc.zip doc/_build/html
 
       - name: Upload HTML Documentation
         if: matrix.image-tag == 'v23.1.0'
@@ -225,15 +212,14 @@ jobs:
           path: doc.zip
           retention-days: 7
 
-      - name: Deploy
+      - name: Deploy stable documentation
+        uses: pyansys/actions/doc-deploy-stable@v2
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev') && matrix.image-tag == 'v23.1.0'
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
-          repository-name: pyansys/pyfluent-docs
-          token: ${{ secrets.DOC_DEPLOYMENT_PAT }}
-          BRANCH: gh-pages
-          FOLDER: doc/_build/html
-          CLEAN: true
+            doc-artifact-name: 'HTML-Documentation-tag-${{ matrix.image-tag }}'
+            cname: ${{ env.DOCUMENTATION_CNAME }}
+            token: ${{ secrets.GITHUB_TOKEN }}
+
 
   build:
     name: Build

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -5,6 +5,9 @@ on:
     - cron:  '0 4 * * *'
   workflow_dispatch:
 
+env:
+  DOCUMENTATION_CNAME: 'fluent.docs.pyansys.com'
+
 jobs:
   nightly_docs_build:
     runs-on: [self-hosted, pyfluent]
@@ -58,18 +61,22 @@ jobs:
           FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
 
       - name: Build Documentation
-        run: make build-doc DOCS_CNAME=dev.fluent.docs.pyansys.com
+        run: make build-doc
         env:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
           FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
 
-      - name: Deploy
+      - name: Upload HTML documentation
         if: matrix.image-tag == 'v23.1.0'
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: actions/upload-artifact@v3
         with:
-          repository-name: pyansys/pyfluent-dev-docs
-          token: ${{ secrets.DOC_DEPLOYMENT_PAT }}
-          BRANCH: gh-pages
-          FOLDER: doc/_build/html
-          CLEAN: true
+          name: documentation-html
+          path: doc/_build/html
+          retention-days: 7
+
+      - name: "Deploy development documentation"
+        uses: pyansys/actions/doc-deploy-dev@v2
+        with:
+            cname: ${{ env.DOCUMENTATION_CNAME }}
+            token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,6 @@ build-doc:
 	@sudo rm -rf /home/ansys/.local/share/ansys_fluent_core/examples/*
 	@pip install -r requirements/requirements_doc.txt
 	@xvfb-run make -C doc html
-	@touch doc/_build/html/.nojekyll
-	@echo "$(DOCS_CNAME)" >> doc/_build/html/CNAME
 
 compare-flobject:
 	@python .ci/compare_flobject.py

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,9 +1,10 @@
 """Sphinx documentation configuration file."""
 from datetime import datetime
+import os
 import platform
 import subprocess
 
-from ansys_sphinx_theme import ansys_favicon, pyansys_logo_black
+from ansys_sphinx_theme import ansys_favicon, get_version_match, pyansys_logo_black
 from sphinx_gallery.sorting import FileNameSortKey
 
 import ansys.fluent.core as pyfluent
@@ -16,6 +17,7 @@ pyfluent.BUILDING_GALLERY = True
 project = "ansys.fluent.core"
 copyright = f"(c) {datetime.now().year} ANSYS, Inc. All rights reserved"
 author = "ANSYS Inc."
+cname = os.getenv("DOCUMENTATION_CNAME", "nocname.com")
 
 # The short X.Y version
 release = version = __version__
@@ -161,6 +163,11 @@ html_theme_options = {
     "additional_breadcrumbs": [
         ("PyAnsys", "https://docs.pyansys.com/"),
     ],
+    "switcher": {
+        "json_url": f"{cname}/release/versions.json",
+        "version_match": get_version_match(__version__),
+    },
+    "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],
     "navigation_depth": -1,
 }
 

--- a/requirements/requirements_doc.txt
+++ b/requirements/requirements_doc.txt
@@ -2,7 +2,7 @@ Sphinx==5.3.0
 jupyter_sphinx==0.4.0
 numpydoc==1.5.0
 matplotlib==3.6.2
-ansys-sphinx-theme==0.7.2
+ansys-sphinx-theme==0.8.0
 pypandoc==1.10
 pytest-sphinx==0.5.0
 sphinx-autobuild==2021.3.14


### PR DESCRIPTION
Fix #1132 by:

* Updating to ansys-sphinx-theme==0.8.0
* Enabling version switcher in `doc/source/conf.py` file
* Updating development and stable doc deployment jobs in CI
* The CNAME and .nojekyll file injection through Makefile got removed as this is already being done in pyansys/actions/doc-deploy-*