### PR TITLE
FIX: deploy dev docs using desired image

### DIFF
--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -80,6 +80,7 @@ jobs:
       - name: "Deploy development documentation"
         if: matrix.image-tag == env.DOC_DEPLOYMENT_IMAGE_TAG
         uses: pyansys/actions/doc-deploy-dev@v2
+        if: matrix.image-tag == 'v23.1.0'
         with:
             cname: ${{ env.DOCUMENTATION_CNAME }}
             token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull-request adds a conditional to deploy development documentation when using a particular image in the nighly-build, since HTML doc artifacts are generated only for v23.1.0.