### PR TITLE
Deploy doc for 22.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,9 +110,8 @@ jobs:
     name: Build Documentation
     needs: [docs-style]
     runs-on: [self-hosted, pyfluent]
-    strategy:
-      matrix:
-        image-tag: [v23.1.0]
+    env:
+      DOC_DEPLOYMENT_IMAGE_TAG: v22.2.0
 
     steps:
       - uses: actions/checkout@v3
@@ -149,17 +148,17 @@ jobs:
         id: cache-api-code
         with:
           path: |
-            src/ansys/fluent/core/datamodel_231
-            src/ansys/fluent/core/fluent_version_231.py
-            src/ansys/fluent/core/meshing/tui_231.py
-            src/ansys/fluent/core/solver/settings_231
-            src/ansys/fluent/core/solver/tui_231.py
+            src/ansys/fluent/core/datamodel_222
+            src/ansys/fluent/core/fluent_version_222.py
+            src/ansys/fluent/core/meshing/tui_222.py
+            src/ansys/fluent/core/solver/settings_222
+            src/ansys/fluent/core/solver/tui_222.py
             doc/source/api/meshing/tui
             doc/source/api/meshing/datamodel
             doc/source/api/solver/tui
             doc/source/api/solver/datamodel
-          key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}-${{ hashFiles('codegen/**') }}
-          restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}
+          key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}-${{ hashFiles('codegen/**') }}
+          restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
 
       - name: Login to GitHub Container Registry
         if: steps.cache-api-code.outputs.cache-hit != 'true'
@@ -173,7 +172,7 @@ jobs:
         if: steps.cache-api-code.outputs.cache-hit != 'true'
         run: make docker-pull
         env:
-          FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
+          FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
 
       - name: Run API codegen
         if: steps.cache-api-code.outputs.cache-hit != 'true'
@@ -182,7 +181,7 @@ jobs:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
           PYFLUENT_LAUNCH_CONTAINER: 1
-          FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
+          FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
 
       - name: Install again after codegen
         run: |
@@ -193,30 +192,29 @@ jobs:
         uses: actions/cache@v3
         with:
           path: doc/source/examples
-          key: Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}-${{ hashFiles('examples/**') }}
+          key: Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}-${{ hashFiles('examples/**') }}
           restore-keys: |
-            Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ matrix.image-tag }}
+            Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
 
       - name: Build Documentation
         run: make build-doc
         env:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
-          FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
+          FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
 
       - name: Upload HTML Documentation
-        if: matrix.image-tag == 'v23.1.0'
         uses: actions/upload-artifact@v3
         with:
-          name: HTML-Documentation-tag-${{ matrix.image-tag }}
+          name: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
           path: doc.zip
           retention-days: 7
 
       - name: Deploy stable documentation
         uses: pyansys/actions/doc-deploy-stable@v2
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev') && matrix.image-tag == 'v23.1.0'
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
         with:
-            doc-artifact-name: 'HTML-Documentation-tag-${{ matrix.image-tag }}'
+            doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
             cname: ${{ env.DOCUMENTATION_CNAME }}
             token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -15,6 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         image-tag: [v22.2.0, v23.1.0, v23.2.0]
+      env:
+        DOC_DEPLOYMENT_IMAGE_TAG: v22.2.0
 
     steps:
       - uses: actions/checkout@v3
@@ -68,7 +70,7 @@ jobs:
           FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
 
       - name: Upload HTML documentation
-        if: matrix.image-tag == 'v23.1.0'
+        if: matrix.image-tag == env.DOC_DEPLOYMENT_IMAGE_TAG
         uses: actions/upload-artifact@v3
         with:
           name: documentation-html
@@ -76,6 +78,7 @@ jobs:
           retention-days: 7
 
       - name: "Deploy development documentation"
+        if: matrix.image-tag == env.DOC_DEPLOYMENT_IMAGE_TAG
         uses: pyansys/actions/doc-deploy-dev@v2
         with:
             cname: ${{ env.DOCUMENTATION_CNAME }}

--- a/src/ansys/fluent/core/services/scheme_eval.py
+++ b/src/ansys/fluent/core/services/scheme_eval.py
@@ -99,7 +99,7 @@ def _convert_py_value_to_scheme_pointer(val: Any, p: SchemePointer, version):
         _convert_py_value_to_scheme_pointer(val[0], p.pair.car, version)
         _convert_py_value_to_scheme_pointer(val[1], p.pair.cdr, version)
     elif isinstance(val, list) or isinstance(val, tuple):
-        if version < "23.1":
+        if version < "23.1.0":
             if val:
                 val = list(val)
                 _convert_py_value_to_scheme_pointer(val[0], p.pair.car, version)
@@ -108,7 +108,7 @@ def _convert_py_value_to_scheme_pointer(val: Any, p: SchemePointer, version):
             for item in val:
                 _convert_py_value_to_scheme_pointer(item, p.list.item.add(), version)
     elif isinstance(val, dict):
-        if version < "23.1":
+        if version < "23.1.0":
             as_list = list(val.items())
             if as_list:
                 _convert_pair_to_scheme_pointer(as_list[0], p.pair.car, version)
@@ -162,7 +162,7 @@ def _convert_scheme_pointer_to_py_value(p: SchemePointer, version):
     elif p.HasField("sym"):
         return Symbol(p.sym)
     elif p.HasField("pair"):
-        if version < "23.1":
+        if version < "23.1.0":
             if any(
                 p.pair.cdr.HasField(x)
                 for x in ["b", "fixednum", "flonum", "c", "str", "sym"]
@@ -217,9 +217,9 @@ class SchemeEval:
         self.service = service
         try:
             version = self.string_eval("(cx-version)")
-            self.version = ".".join(version.strip("()").split()[0:2])
+            self.version = ".".join(version.strip("()").split())
         except Exception:  # for pypim launch
-            self.version = "23.1"
+            self.version = "23.1.0"
 
     def eval(self, val: Any) -> Any:
         """Evaluates a scheme expression.
@@ -234,7 +234,7 @@ class SchemeEval:
         Any
             Output scheme value represented as Python datatype
         """
-        if self.version < "23.1":
+        if self.version < "23.1.0":
             request = SchemePointer()
             _convert_py_value_to_scheme_pointer(val, request, self.version)
             response = self.service.eval(request)

--- a/tests/test_scheme_eval_222.py
+++ b/tests/test_scheme_eval_222.py
@@ -108,7 +108,7 @@ def test_convert_py_value_to_scheme_pointer(
     py_value: Any, json_dict: Dict[str, Any]
 ) -> None:
     p = SchemePointer()
-    _convert_py_value_to_scheme_pointer(py_value, p, "22.2")
+    _convert_py_value_to_scheme_pointer(py_value, p, "22.2.0")
     assert MessageToDict(p) == json_dict
 
 
@@ -246,7 +246,7 @@ def test_convert_scheme_pointer_to_py_value(
 ) -> None:
     p = SchemePointer()
     ParseDict(json_dict, p)
-    val = _convert_scheme_pointer_to_py_value(p, "22.2")
+    val = _convert_scheme_pointer_to_py_value(p, "22.2.0")
     assert val == py_value
 
 
@@ -261,7 +261,7 @@ def test_convert_scheme_pointer_having_symbol_to_py_value() -> None:
         },
         p,
     )
-    val = _convert_scheme_pointer_to_py_value(p, "22.2")
+    val = _convert_scheme_pointer_to_py_value(p, "22.2.0")
     assert isinstance(val, tuple)
     assert len(val) == 2
     assert val[0] == "abc"
@@ -284,7 +284,7 @@ def test_convert_scheme_pointer_having_pair_to_py_value() -> None:
         },
         p,
     )
-    val = _convert_scheme_pointer_to_py_value(p, "22.2")
+    val = _convert_scheme_pointer_to_py_value(p, "22.2.0")
     assert isinstance(val, list)
     assert isinstance(val[0], Symbol)
     assert val[0].str == "+"
@@ -311,16 +311,16 @@ def test_convert_scheme_pointer_having_pair_to_py_value() -> None:
 )
 def test_two_way_conversion(py_value: Any) -> None:
     p = SchemePointer()
-    _convert_py_value_to_scheme_pointer(py_value, p, "22.2")
-    val = _convert_scheme_pointer_to_py_value(p, "22.2")
+    _convert_py_value_to_scheme_pointer(py_value, p, "22.2.0")
+    val = _convert_scheme_pointer_to_py_value(p, "22.2.0")
     assert val == py_value
 
 
 def test_two_way_conversion_for_symbol() -> None:
     py_value = [Symbol("+"), 2.0, 3.0]
     p = SchemePointer()
-    _convert_py_value_to_scheme_pointer(py_value, p, "22.2")
-    val = _convert_scheme_pointer_to_py_value(p, "22.2")
+    _convert_py_value_to_scheme_pointer(py_value, p, "22.2.0")
+    val = _convert_scheme_pointer_to_py_value(p, "22.2.0")
     assert isinstance(val, list)
     assert isinstance(val[0], Symbol)
     assert val[0].str == "+"
@@ -330,8 +330,8 @@ def test_two_way_conversion_for_symbol() -> None:
 def test_two_way_conversion_for_pairs() -> None:
     py_value = ("abc", 5.0)
     p = SchemePointer()
-    _convert_py_value_to_scheme_pointer(py_value, p, "22.2")
-    val = _convert_scheme_pointer_to_py_value(p, "22.2")
+    _convert_py_value_to_scheme_pointer(py_value, p, "22.2.0")
+    val = _convert_scheme_pointer_to_py_value(p, "22.2.0")
     assert isinstance(val, tuple)
     assert len(val) == 2
     assert val[0] == "abc"

--- a/tests/test_scheme_eval_231.py
+++ b/tests/test_scheme_eval_231.py
@@ -72,7 +72,7 @@ def test_convert_py_value_to_scheme_pointer(
     py_value: Any, json_dict: Dict[str, Any]
 ) -> None:
     p = SchemePointer()
-    _convert_py_value_to_scheme_pointer(py_value, p, "23.1")
+    _convert_py_value_to_scheme_pointer(py_value, p, "23.1.0")
     assert MessageToDict(p) == json_dict
 
 
@@ -164,7 +164,7 @@ def test_convert_scheme_pointer_to_py_value(
 ) -> None:
     p = SchemePointer()
     ParseDict(json_dict, p)
-    val = _convert_scheme_pointer_to_py_value(p, "23.1")
+    val = _convert_scheme_pointer_to_py_value(p, "23.1.0")
     assert val == py_value
 
 
@@ -179,7 +179,7 @@ def test_convert_scheme_pointer_having_symbol_to_py_value() -> None:
         },
         p,
     )
-    val = _convert_scheme_pointer_to_py_value(p, "23.1")
+    val = _convert_scheme_pointer_to_py_value(p, "23.1.0")
     assert isinstance(val, tuple)
     assert len(val) == 2
     assert val[0] == "abc"
@@ -206,16 +206,16 @@ def test_convert_scheme_pointer_having_symbol_to_py_value() -> None:
 )
 def test_two_way_conversion(py_value: Any) -> None:
     p = SchemePointer()
-    _convert_py_value_to_scheme_pointer(py_value, p, "23.1")
-    val = _convert_scheme_pointer_to_py_value(p, "23.1")
+    _convert_py_value_to_scheme_pointer(py_value, p, "23.1.0")
+    val = _convert_scheme_pointer_to_py_value(p, "23.1.0")
     assert val == py_value
 
 
 def test_two_way_conversion_for_symbol() -> None:
     py_value = [Symbol("+"), 2.0, 3.0]
     p = SchemePointer()
-    _convert_py_value_to_scheme_pointer(py_value, p, "23.1")
-    val = _convert_scheme_pointer_to_py_value(p, "23.1")
+    _convert_py_value_to_scheme_pointer(py_value, p, "23.1.0")
+    val = _convert_scheme_pointer_to_py_value(p, "23.1.0")
     assert isinstance(val, list)
     assert isinstance(val[0], Symbol)
     assert val[0].str == "+"
@@ -225,8 +225,8 @@ def test_two_way_conversion_for_symbol() -> None:
 def test_two_way_conversion_for_pairs() -> None:
     py_value = ("abc", 5.0)
     p = SchemePointer()
-    _convert_py_value_to_scheme_pointer(py_value, p, "23.1")
-    val = _convert_scheme_pointer_to_py_value(p, "23.1")
+    _convert_py_value_to_scheme_pointer(py_value, p, "23.1.0")
+    val = _convert_scheme_pointer_to_py_value(p, "23.1.0")
     assert isinstance(val, tuple)
     assert len(val) == 2
     assert val[0] == "abc"


### PR DESCRIPTION
We should deploy docs for Fluent 22.2 version as it is currently available to customers.  