### PR TITLE
Bump version to v0.12.dev9

### DIFF
--- a/src/ansys/fluent/core/_version.py
+++ b/src/ansys/fluent/core/_version.py
@@ -6,7 +6,7 @@ version_info = 0, 1, 'dev0'
 """
 
 # major, minor, patch
-version_info = 0, 12, "dev8"
+version_info = 0, 12, "dev9"
 
 # Nice string for the version
 __version__ = ".".join(map(str, version_info))


### PR DESCRIPTION
This release is required to get the dependent changes in the UI repo to run seamlessly.