### PR TITLE
Add an icon in the doc for the pyfluent discussions.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -163,6 +163,13 @@ html_theme_options = {
     "additional_breadcrumbs": [
         ("PyAnsys", "https://docs.pyansys.com/"),
     ],
+    "icon_links": [
+        {
+            "name": "Support",
+            "url": "https://github.com/pyansys/pyfluent/discussions",
+            "icon": "fa fa-comment fa-fw",
+        },
+    ],
     "switcher": {
         "json_url": f"{cname}/release/versions.json",
         "version_match": get_version_match(__version__),


### PR DESCRIPTION
This should had an icon in the [documentation](https://fluent.docs.pyansys.com/) on the top right corner.

![image](https://user-images.githubusercontent.com/87315832/210534099-ffa53ac7-bc30-4dfe-9f07-7c8b5449b0bc.png)

When clicking on this icon, users should be directed to the [discussions](https://github.com/pyansys/pyfluent/discussions).