### PR TITLE
Fixed links in the Contributing Page

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -4,10 +4,10 @@
 Contributing
 ============
 Overall guidance on contributing to a PyAnsys library appears in the
-`Contributing <https://dev.docs.pyansys.com/how-to/contributing.html>`_ topic
+`Contributing <https://dev.docs.pyansys.com/dev/how-to/contributing.html>`_ topic
 in the *PyAnsys Developer's Guide*. Ensure that you are thoroughly familiar with
 this guide, paying particular attention to the `Coding Style
-<https://dev.docs.pyansys.com/coding-style/index.html#coding-style>`_ topic, before
+<https://dev.docs.pyansys.com/dev/coding-style/index.html#coding-style>`_ topic, before
 attempting to contribute to PyFluent.
  
 The following contribution information is specific to PyFluent.


### PR DESCRIPTION
Fixed the broken links in the Contributing Page. Now, they redirect to their corresponding webpages.