### PR TITLE
Bump version v0.12.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,16 +183,11 @@ jobs:
           PYFLUENT_START_INSTANCE: 0
           FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
 
-      - name: Zip HTML Documentation before upload
-        run: |
-          sudo apt install zip -y
-          zip -r doc.zip doc/_build/html
-
       - name: Upload HTML Documentation
         uses: actions/upload-artifact@v3
         with:
           name: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
-          path: doc.zip
+          path: doc/_build/html 
           retention-days: 7
 
       - name: Deploy stable documentation

--- a/src/ansys/fluent/core/_version.py
+++ b/src/ansys/fluent/core/_version.py
@@ -6,7 +6,7 @@ version_info = 0, 1, 'dev0'
 """
 
 # major, minor, patch
-version_info = 0, 12, 1
+version_info = 0, 12, 3
 
 # Nice string for the version
 __version__ = ".".join(map(str, version_info))


### PR DESCRIPTION
Merging @alikasim72's PR #1273 changes to fix the release documentation. 

I accidentally pushed the v0.12.2 tag before updating the version in code, so I've incremented once more.