### PR TITLE
Remove set_ansys_version and set_fluent_exe_path methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,8 +102,7 @@ where ``<version>`` is the Fluent release that you would like to use.
 For example, ``v231`` uses release 2023 R1.
 
 For information on other ways of specifying the Fluent location for PyFluent,
-see `How does PyFluent infer the location to launch Fluent? <https://fluent.docs.pyansys.com/release/0.12/getting_started/faqs.html#how-does-pyfluent-infer-the-location-to-launch-fluent>`_
-in `Frequently asked questions <https://fluent.docs.pyansys.com/release/0.12/getting_started/faqs.html>`_.
+see `Frequently asked questions <https://fluent.docs.pyansys.com/release/0.12/getting_started/faqs.html>`_.
 
 Basic Usage
 ~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -89,17 +89,21 @@ To launch Fluent from Python, use the ``launch_fluent`` method:
   solver_session = pyfluent.launch_fluent(mode="solver")
   solver_session.health_check_service.is_serving
 
-On Windows systems the environment variable ``AWP_ROOT<ver>``, is configured
+On Windows systems the environment variable ``AWP_ROOT<ver>`` is configured
 when Fluent is installed, where ``<ver>`` is the Fluent release number such as
-``232`` for release 2022 R2.  PyFluent automatically uses this environment
-variable to locate the Fluent installation. On Linux systems configure
+``231`` for release 2023 R1.  PyFluent automatically uses this environment
+variable to locate the latest Fluent installation. On Linux systems configure
 ``AWP_ROOT<ver>`` to point to the absolute path of an Ansys installation such as
-``/apps/ansys_inc/v232``.
+``/apps/ansys_inc/v231``.
 
 To use a non-default installation location set ``AWP_ROOT<ver>`` or set the
-``PYFLUENT_FLUENT_ROOT`` environment variable to the ``<install
-location>/<version>/fluent`` directory, where ``<version>`` is the Fluent
-release that you would like to use. For example, ``v232`` uses release 2022 R2.
+``PYFLUENT_FLUENT_ROOT`` environment variable to the ``<install location>/<version>/fluent`` directory,
+where ``<version>`` is the Fluent release that you would like to use.
+For example, ``v231`` uses release 2023 R1.
+
+For information on other ways of specifying the Fluent location for PyFluent,
+see `How does PyFluent infer the location to launch Fluent? <https://fluent.docs.pyansys.com/release/0.12/getting_started/faqs.html#how-does-pyfluent-infer-the-location-to-launch-fluent>`_
+in `Frequently asked questions <https://fluent.docs.pyansys.com/release/0.12/getting_started/faqs.html>`_.
 
 Basic Usage
 ~~~~~~~~~~~

--- a/codegen/allapigen.py
+++ b/codegen/allapigen.py
@@ -1,12 +1,13 @@
 import argparse
 import os
+from pathlib import Path
 
 import datamodelgen
 import print_fluent_version
 import settingsgen
 import tuigen
 
-from ansys.fluent.core.launcher.launcher import get_ansys_version, set_ansys_version
+from ansys.fluent.core.launcher.launcher import FluentVersion, get_ansys_version
 
 if __name__ == "__main__":
     if not os.getenv("PYFLUENT_LAUNCH_CONTAINER"):
@@ -26,7 +27,8 @@ if __name__ == "__main__":
         args = parser.parse_args()
 
         if args.ansys_version:
-            set_ansys_version(args.ansys_version)
+            awp_root = os.environ["AWP_ROOT" + "".join(str(FluentVersion(args.ansys_version)).split("."))[:-1]]
+            os.environ["PYFLUENT_FLUENT_ROOT"] = Path(awp_root) / "fluent"
         if args.fluent_path:
             os.environ["PYFLUENT_FLUENT_ROOT"] = args.fluent_path
 

--- a/codegen/tuigen.py
+++ b/codegen/tuigen.py
@@ -94,7 +94,7 @@ def _copy_tui_help_xml_file(version: str):
         subprocess.run(f"docker container rm {container_name}", shell=is_linux)
 
     else:
-        ansys_version = get_ansys_version()
+        ansys_version = get_ansys_version()  # picking up the file from the latest install location
         awp_root = os.environ["AWP_ROOT" + "".join(str(ansys_version).split("."))[:-1]]
         xml_source = (
             Path(awp_root)

--- a/doc/source/api/launcher.rst
+++ b/doc/source/api/launcher.rst
@@ -3,9 +3,11 @@
 Launching Fluent
 ================
 
-.. currentmodule:: ansys.fluent.core.launcher
+.. currentmodule:: ansys.fluent.core
 
 .. autosummary::
    :toctree: _autosummary
-   
-   launcher.launch_fluent
+
+   set_ansys_version
+   set_fluent_exe_path
+   launch_fluent

--- a/doc/source/api/launcher.rst
+++ b/doc/source/api/launcher.rst
@@ -8,6 +8,4 @@ Launching Fluent
 .. autosummary::
    :toctree: _autosummary
 
-   set_ansys_version
-   set_fluent_exe_path
    launch_fluent

--- a/doc/source/getting_started/faqs.rst
+++ b/doc/source/getting_started/faqs.rst
@@ -174,6 +174,29 @@ processars and the Fluent GUI:
 For additional launch examples, see :ref:`ref_user_guide_launch`. For descriptions of all parameters,
 see the :func:`launch_fluent() <ansys.fluent.core.launcher.launcher.launch_fluent>` method.
 
+.. _faqs_fluentloc:
+
+How does PyFluent infer the location to launch Fluent?
+------------------------------------------------------
+PyFluent infers the Fluent location based on the following information, in increasing order of precedence:
+
+
+#. ``AWP_ROOT<ver>`` environment variable, which is configured on Windows system
+   when Fluent is installed, where ``<ver>`` is the Fluent release number such as
+   ``231`` for release 2023 R1.  PyFluent automatically uses this environment
+   variable to locate the latest Fluent installation. On Linux systems configure
+   ``AWP_ROOT<ver>`` to point to the absolute path of an Ansys installation such as
+   ``/apps/ansys_inc/v231``.
+
+#. Value set by :func:`set_ansys_version() <ansys.fluent.core.set_ansys_version>`.
+
+#. Value set by :func:`set_fluent_exe_path() <ansys.fluent.core.set_fluent_exe_path>`.
+
+#. Value of ``product_version`` parameter passed to :func:`launch_fluent() <ansys.fluent.core.launch_fluent>`.
+
+#. ``PYFLUENT_FLUENT_ROOT`` environment variable, set this to ``<install location>/<ver>/fluent`` directory.
+
+
 How do you learn how to use PyFluent?
 -------------------------------------
 Depending on how you prefer to learn, you can use any or all of these methods

--- a/doc/source/getting_started/faqs.rst
+++ b/doc/source/getting_started/faqs.rst
@@ -188,10 +188,6 @@ PyFluent infers the Fluent location based on the following information, in incre
    ``AWP_ROOT<ver>`` to point to the absolute path of an Ansys installation such as
    ``/apps/ansys_inc/v231``.
 
-#. Value set by :func:`set_ansys_version() <ansys.fluent.core.set_ansys_version>`.
-
-#. Value set by :func:`set_fluent_exe_path() <ansys.fluent.core.set_fluent_exe_path>`.
-
 #. Value of ``product_version`` parameter passed to :func:`launch_fluent() <ansys.fluent.core.launch_fluent>`.
 
 #. ``PYFLUENT_FLUENT_ROOT`` environment variable, set this to ``<install location>/<ver>/fluent`` directory.

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -49,16 +49,18 @@ method:
   solver = pyfluent.launch_fluent(precision="double", processor_count=2, mode="solver")
   solver.health_check_service.is_serving
 
-To locate the Fluent installation, PyFluent automatically uses the ``AWP_ROOT<ver>``
+To locate the latest Fluent installation, PyFluent automatically uses the ``AWP_ROOT<ver>``
 environment variable, where ``<ver>`` is the three-digit format for the release.
-For example, ``AWP_ROOT222`` is the environment variable for the 2022 R2 release. 
+For example, ``AWP_ROOT231`` is the environment variable for the 2023 R1 release. 
 
 On a Windows system, this environment variable is configured when a release is installed.
 
 On a Linux system, you must configure this environment variable to point to the absolute
-path of the installed release. For example, for the 2022 R2 release, you would set
-the ``AWP_ROOT222`` environment variable to point to an absolute location such as
-``C:\Program Files\ANSYS Inc\v222``.
+path of the installed release. For example, for the 2023 R1 release, you would set
+the ``AWP_ROOT231`` environment variable to point to an absolute location such as
+``/apps/ansys_inc/v231``.
+
+For information on other ways of specifying the Fluent location for PyFluent, see :ref:`faqs_fluentloc` in :ref:`faqs`.
 
 Once Fluent is active, you can use the ``solver_session.tui`` interface to send
 Fluent TUI commands to PyFluent. For example, this code reads a case file, updates a

--- a/src/ansys/fluent/core/__init__.py
+++ b/src/ansys/fluent/core/__init__.py
@@ -10,8 +10,6 @@ from ansys.fluent.core.launcher.launcher import (  # noqa: F401
     FluentVersion,
     LaunchModes,
     launch_fluent,
-    set_ansys_version,
-    set_fluent_exe_path,
 )
 from ansys.fluent.core.session import _BaseSession as Fluent  # noqa: F401
 from ansys.fluent.core.utils.logging import LOG

--- a/src/ansys/fluent/core/launcher/launcher.py
+++ b/src/ansys/fluent/core/launcher/launcher.py
@@ -28,9 +28,6 @@ import ansys.platform.instancemanagement as pypim
 _THIS_DIR = os.path.dirname(__file__)
 _OPTIONS_FILE = os.path.join(_THIS_DIR, "fluent_launcher_options.json")
 
-_FLUENT_EXE_PATH_SET = None  # set by set_fluent_path
-_ANSYS_VERSION_SET = None  # set by set_ansys_version
-
 
 def _is_windows():
     """Check if the current operating system is windows."""
@@ -60,38 +57,9 @@ class FluentVersion(Enum):
         return str(self.value)
 
 
-def set_fluent_exe_path(fluent_exe_path: Union[str, Path]) -> None:
-    """Set the Fluent executable path manually.
-
-    This supersedes the Fluent path set in the environment variable.
-    """
-    if Path(fluent_exe_path).exists():
-        global _FLUENT_EXE_PATH_SET
-        _FLUENT_EXE_PATH_SET = str(fluent_exe_path)
-    else:
-        raise RuntimeError(
-            f"The passed path '{fluent_exe_path}' does not contain a valid Fluent executable file."
-        )
-
-
-def set_ansys_version(version: Union[str, float, FluentVersion]) -> None:
-    """Set the Fluent version manually.
-
-    This method only works if the provided Fluent version is installed
-    and the environment variables are updated properly. This supersedes
-    the Fluent path set in the environment variable.
-    """
-    global _ANSYS_VERSION_SET
-    _ANSYS_VERSION_SET = str(FluentVersion(version))
-
-
 def get_ansys_version() -> str:
-    # Look for ANSYS version in the following order:
-    # 1. value set by set_ansys_version
-    if _ANSYS_VERSION_SET:
-        return _ANSYS_VERSION_SET
+    """Get the latest ANSYS version from AWP_ROOT environment variables."""
 
-    # 2. Search for the latest AWP_ROOT environment variable
     for v in FluentVersion:
         if "AWP_ROOT" + "".join(str(v).split("."))[:-1] in os.environ:
             return str(v)
@@ -121,11 +89,7 @@ def get_fluent_exe_path(**launch_argvals) -> Path:
     if product_version:
         return get_exe_path(get_fluent_root(FluentVersion(product_version)))
 
-    # 3. value set by set_fluent_exe_path
-    if _FLUENT_EXE_PATH_SET:
-        return Path(_FLUENT_EXE_PATH_SET)
-
-    # 4. value from get_ansys_version
+    # 3. the latest ANSYS version from AWP_ROOT environment variables
     ansys_version = get_ansys_version()
     return get_exe_path(get_fluent_root(FluentVersion(ansys_version)))
 

--- a/src/ansys/fluent/core/utils/setup_for_fluent.py
+++ b/src/ansys/fluent/core/utils/setup_for_fluent.py
@@ -1,22 +1,9 @@
-from ansys.fluent.core.launcher.launcher import (
-    FluentVersion,
-    launch_fluent,
-    set_ansys_version,
-)
+from ansys.fluent.core.launcher.launcher import launch_fluent
 from ansys.fluent.core.session_solver import Solver
 
 
 def setup_for_fluent(*args, **kwargs):
     """Returns global PyConsole objects."""
-
-    if kwargs["product_version"] == "22.2.0":
-        set_ansys_version(FluentVersion.version_22R2)
-    elif kwargs["product_version"] == "23.1.0":
-        set_ansys_version(FluentVersion.version_23R1)
-    elif kwargs["product_version"] == "23.2.0":
-        set_ansys_version(FluentVersion.version_23R2)
-
-    del kwargs["product_version"]
 
     session = launch_fluent(*args, **kwargs)
     globals = {}

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -8,37 +8,6 @@ from ansys.fluent.core.launcher import launcher
 from ansys.fluent.core.launcher.launcher import get_ansys_version, get_fluent_exe_path
 
 
-def test_manual_fluent_version_setting():
-    """Test case for setting up the Ansys / Fluent version via program"""
-
-    old_ansys_version = launcher._ANSYS_VERSION_SET
-
-    pyfluent.set_ansys_version("23.1.0")
-    assert get_ansys_version() == "23.1.0"
-
-    pyfluent.set_ansys_version(22.2)
-    assert get_ansys_version() == "22.2.0"
-
-    pyfluent.set_ansys_version(version=pyfluent.FluentVersion.version_23R1)
-    assert get_ansys_version() == "23.1.0"
-
-    # version does not exist
-    with pytest.raises(RuntimeError):
-        pyfluent.set_ansys_version(22.1)
-
-    # Resets the global variable to its original state
-    launcher._ANSYS_VERSION_SET = old_ansys_version
-
-
-def test_manual_fluent_path_setting():
-    """Test case for setting up the path to fluent.exe via program"""
-    with pytest.raises(RuntimeError):
-        pyfluent.set_fluent_exe_path("X:/dir_1/dir2/xxx.exe")
-
-    with pytest.raises(RuntimeError):
-        pyfluent.set_fluent_exe_path("X:/dir_1/dir2/fluent.bat")
-
-
 @pytest.mark.skip(reason="Can be used only locally.")
 def test_unsuccessful_fluent_connection(with_launching_container):
     # start-timeout is intentionally provided to be 2s for the connection to fail
@@ -120,55 +89,16 @@ def test_get_fluent_exe_path_from_awp_root_232(monkeypatch):
     assert get_fluent_exe_path() == expected_path
 
 
-def test_get_fluent_exe_path_from_set_ansys_version(monkeypatch):
-    monkeypatch.delenv("PYFLUENT_FLUENT_ROOT", raising=False)
-    monkeypatch.setenv("AWP_ROOT232", "ansys_inc/v232")
-    monkeypatch.setenv("AWP_ROOT231", "ansys_inc/v231")
-    monkeypatch.setenv("AWP_ROOT222", "ansys_inc/v222")
-    old_ansys_version = launcher._ANSYS_VERSION_SET
-    pyfluent.set_ansys_version("22.2.0")
-    if platform.system() == "Windows":
-        expected_path = Path("ansys_inc/v222/fluent") / "ntbin" / "win64" / "fluent.exe"
-    else:
-        expected_path = Path("ansys_inc/v222/fluent") / "bin" / "fluent"
-    assert get_ansys_version() == "22.2.0"
-    assert get_fluent_exe_path() == expected_path
-    launcher._ANSYS_VERSION_SET = old_ansys_version
-
-
-def test_get_fluent_exe_path_from_set_fluent_exe_path(monkeypatch):
-    monkeypatch.delenv("PYFLUENT_FLUENT_ROOT", raising=False)
-    monkeypatch.setenv("AWP_ROOT232", "ansys_inc/v232")
-    monkeypatch.setenv("AWP_ROOT231", "ansys_inc/v231")
-    monkeypatch.setenv("AWP_ROOT222", "ansys_inc/v222")
-    old_ansys_version = launcher._ANSYS_VERSION_SET
-    pyfluent.set_ansys_version("22.2.0")
-    old_fluent_exe_path = launcher._FLUENT_EXE_PATH_SET
-    monkeypatch.setattr(Path, "exists", lambda self: True)
-    pyfluent.set_fluent_exe_path("ansys_inc/vNNN/fluent/bin/fluent")
-    expected_path = Path("ansys_inc/vNNN/fluent/bin/fluent")
-    assert get_fluent_exe_path() == expected_path
-    launcher._FLUENT_EXE_PATH_SET = old_fluent_exe_path
-    launcher._ANSYS_VERSION_SET = old_ansys_version
-
-
 def test_get_fluent_exe_path_from_product_version_launcher_arg(monkeypatch):
     monkeypatch.delenv("PYFLUENT_FLUENT_ROOT", raising=False)
     monkeypatch.setenv("AWP_ROOT232", "ansys_inc/v232")
     monkeypatch.setenv("AWP_ROOT231", "ansys_inc/v231")
     monkeypatch.setenv("AWP_ROOT222", "ansys_inc/v222")
-    old_ansys_version = launcher._ANSYS_VERSION_SET
-    pyfluent.set_ansys_version("22.2.0")
-    old_fluent_exe_path = launcher._FLUENT_EXE_PATH_SET
-    monkeypatch.setattr(Path, "exists", lambda self: True)
-    pyfluent.set_fluent_exe_path("ansys_inc/vNNN/fluent/bin/fluent")
     if platform.system() == "Windows":
         expected_path = Path("ansys_inc/v231/fluent") / "ntbin" / "win64" / "fluent.exe"
     else:
         expected_path = Path("ansys_inc/v231/fluent") / "bin" / "fluent"
     assert get_fluent_exe_path(product_version="23.1.0") == expected_path
-    launcher._FLUENT_EXE_PATH_SET = old_fluent_exe_path
-    launcher._ANSYS_VERSION_SET = old_ansys_version
 
 
 def test_get_fluent_exe_path_from_pyfluent_fluent_root(monkeypatch):
@@ -176,15 +106,8 @@ def test_get_fluent_exe_path_from_pyfluent_fluent_root(monkeypatch):
     monkeypatch.setenv("AWP_ROOT232", "ansys_inc/v232")
     monkeypatch.setenv("AWP_ROOT231", "ansys_inc/v231")
     monkeypatch.setenv("AWP_ROOT222", "ansys_inc/v222")
-    old_ansys_version = launcher._ANSYS_VERSION_SET
-    pyfluent.set_ansys_version("22.2.0")
-    old_fluent_exe_path = launcher._FLUENT_EXE_PATH_SET
-    monkeypatch.setattr(Path, "exists", lambda self: True)
-    pyfluent.set_fluent_exe_path("ansys_inc/vNNN/fluent/bin/fluent")
     if platform.system() == "Windows":
         expected_path = Path("dev/vNNN/fluent") / "ntbin" / "win64" / "fluent.exe"
     else:
         expected_path = Path("dev/vNNN/fluent") / "bin" / "fluent"
     assert get_fluent_exe_path(product_version="23.1.0") == expected_path
-    launcher._FLUENT_EXE_PATH_SET = old_fluent_exe_path
-    launcher._ANSYS_VERSION_SET = old_ansys_version

--- a/tests/test_launcher_remote.py
+++ b/tests/test_launcher_remote.py
@@ -39,7 +39,7 @@ def test_launch_remote_instance(monkeypatch, new_solver_session):
     monkeypatch.setattr(pypim, "connect", mock_connect)
     monkeypatch.setattr(pypim, "is_configured", mock_is_configured)
 
-    if os.getenv("PYFLUENT_LAUNCH_CONTAINER") == "1":
+    if os.getenv("FLUENT_IMAGE_TAG"):
         monkeypatch.setattr(launcher, "get_ansys_version", lambda: docker_image_version.get_version())
 
     # Start fluent with launch_fluent
@@ -50,7 +50,7 @@ def test_launch_remote_instance(monkeypatch, new_solver_session):
     # Assert: PyFluent went through the pypim workflow
     assert mock_is_configured.called
     assert mock_connect.called
-    if os.getenv("PYFLUENT_LAUNCH_CONTAINER") == "1":
+    if os.getenv("FLUENT_IMAGE_TAG"):
         product_version = docker_image_version.get_version_for_filepath()
     else:
         product_version = "".join(launcher.get_ansys_version().split("."))[:-1]


### PR DESCRIPTION
From #1262:

We now have the following 3 options to specify Fluent launch path from PyFluent:

1. default - via AWP_ROOT env vars
2. user override - via the product_version param in launch_fluent
3. developer override - via PYFLUENT_FLUENT_ROOT env var

Other options are redundant and have been removed.