### PR TITLE
FIX: missing https prefix in json_url parameter

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -171,7 +171,7 @@ html_theme_options = {
         },
     ],
     "switcher": {
-        "json_url": f"{cname}/release/versions.json",
+        "json_url": f"https://{cname}/release/versions.json",
         "version_match": get_version_match(__version__),
     },
     "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],


### PR DESCRIPTION
Fixes #1290 by adding the `https` prefix in the `json_url` parameter for the multi-version dropdown menu.

Note this fixes `dev` one the nightly docs are deployed. However, for `12.3`, this changes need to be cherry-picked.