### PR TITLE
Feat/workflow wrapper extensions

### DIFF
--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -328,6 +328,8 @@ class PyMenu(PyStateContainer):
     -------
     __setattr__(name, value)
         Set state of the child object
+    rename(new_name)
+    name()
     create_command_arguments(command)
     """
 
@@ -364,20 +366,29 @@ class PyMenu(PyStateContainer):
                 f"{self.__class__.__name__} is not a named object class."
             )
 
-    def raise_method_not_yet_implemented_exception(self):
+    def name(self):
+        """Get the name of the named object"""
+        try:
+            return self._name_()
+        except AttributeError:
+            raise RuntimeError(
+                f"{self.__class__.__name__} is not a named object class."
+            )
+
+    def _raise_method_not_yet_implemented_exception(self):
         raise AttributeError("This method is yet to be implemented in pyfluent.")
 
     def delete_child(self):
-        self.raise_method_not_yet_implemented_exception()
+        self._raise_method_not_yet_implemented_exception()
 
     def delete_child_objects(self):
-        self.raise_method_not_yet_implemented_exception()
+        self._raise_method_not_yet_implemented_exception()
 
     def delete_all_child_objects(self):
-        self.raise_method_not_yet_implemented_exception()
+        self._raise_method_not_yet_implemented_exception()
 
     def fix_state(self):
-        self.raise_method_not_yet_implemented_exception()
+        self._raise_method_not_yet_implemented_exception()
 
     def create_command_arguments(self, command):
         request = DataModelProtoModule.CreateCommandArgumentsRequest()

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -48,8 +48,11 @@ class WorkflowWrapper:
                 )
             )
 
+        def _workflow_state(self):
+            return self._workflow()
+
         def _workflow_and_task_list_state(self):
-            workflow_state = self._workflow()
+            workflow_state = self._workflow_state()
             workflow_state_workflow = workflow_state["Workflow"]
             return (workflow_state, workflow_state_workflow["TaskList"])
 
@@ -59,7 +62,7 @@ class WorkflowWrapper:
             return self._command_source.task(task_state["_name_"])
 
         def _task_by_id(self, task_id):
-            workflow_state, _ = self._workflow_and_task_list_state()
+            workflow_state = self._workflow_state()
             return self._task_by_id_impl(task_id, workflow_state)
 
         def _all_task_objects(self):

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -82,6 +82,19 @@ class WorkflowWrapper:
             sub_task_ids = self._task.TaskList()
             return [self._command_source._task_by_id(task_id) for task_id in self._task.TaskList()]
 
+        def get_inactive_sub_tasks(self):
+            sub_task_ids = self._task.InactiveTaskList()
+            return [self._command_source._task_by_id(task_id) for task_id in self._task.InactiveTaskList()]
+
+        def get_id(self):
+            workflow_state = self._command_source._workflow_state()
+            for k, v in workflow_state.items():
+                if isinstance(v, dict) and '_name_' in v:
+                    if v['_name_'] == self.name():
+                        type_ , id_ = k.split(':')
+                        if type_ == "TaskObject":
+                            return id_
+
         @property
         def CommandArguments(self):
             return self._refreshed_command()

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -48,23 +48,25 @@ class WorkflowWrapper:
                 )
             )
 
-        def _task_by_id(self, task_id):
+        def _workflow_and_task_list_state(self):
             workflow_state = self._workflow()
             workflow_state_workflow = workflow_state["Workflow"]
-            workflow_state_tasklist = workflow_state_workflow["TaskList"]
+            return (workflow_state, workflow_state_workflow["TaskList"])
+
+        def _task_by_id_impl(self, task_id, workflow_state):
             task_key = "TaskObject:" + task_id
             task_state = workflow_state[task_key]
             return self._command_source.task(task_state["_name_"])
 
+        def _task_by_id(self, task_id):
+            workflow_state, _ = self._workflow_and_task_list_state()
+            return self._task_by_id_impl(task_id, workflow_state)
+
         def _all_task_objects(self):
-            workflow_state = self._workflow()
-            workflow_state_workflow = workflow_state["Workflow"]
-            workflow_state_tasklist = workflow_state_workflow["TaskList"]
+            workflow_state, task_list_state = self._workflow_and_task_list_state()
             tasks = []
-            for task_id in workflow_state_tasklist:
-                task_key = "TaskObject:" + task_id
-                task_state = workflow_state[task_key]
-                tasks.append(self._command_source.task(task_state["_name_"]))
+            for task_id in task_list_state:
+                tasks.append(self._task_by_id_impl(task_id, workflow_state))
             return tasks
 
         def _tasks_with_matching_attributes(self, attr, other_attr):

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -59,35 +59,32 @@ class WorkflowWrapper:
                 tasks.append(self._command_source.task(task_state["_name_"]))
             return tasks
 
-        def get_direct_upstream_tasks(self):
+        def _tasks_with_matching_attributes(self, attr, other_attr):
             this_command = self._command()
-            inputs = this_command.get_attr("requiredInputs")
-            if not inputs:
+            attrs = this_command.get_attr(attr)
+            if not attrs:
                 return []
-            inputs = set(inputs)
+            attrs = set(attrs)
             tasks = self._all_task_objects()
-            upstreams = []
+            matches = []
             for task in tasks:
                 command = task._command()
-                outputs = command.get_attr("outputs")
-                if outputs and (inputs & set(outputs)):
-                    upstreams.append(task)
-            return upstreams
+                other_attrs = command.get_attr(other_attr)
+                if other_attrs and (attrs & set(other_attrs)):
+                    matches.append(task)
+            return matches
+
+        def get_direct_upstream_tasks(self):
+            return self._tasks_with_matching_attributes(
+                attr="requiredInputs",
+                other_attr="outputs"
+                )
 
         def get_direct_downstream_tasks(self):
-            this_command = self._command()
-            outputs = this_command.get_attr("outputs")
-            if not outputs:
-                return []
-            outputs = set(outputs)
-            tasks = self._all_task_objects()
-            downstreams = []
-            for task in tasks:
-                command = task._command()
-                inputs = command.get_attr("requiredInputs")
-                if inputs and (set(inputs) & outputs):
-                    downstreams.append(task)
-            return downstreams
+            return self._tasks_with_matching_attributes(
+                attr="outputs",
+                other_attr="requiredInputs"
+                )
 
         @property
         def CommandArguments(self):

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -59,14 +59,7 @@ class WorkflowWrapper:
                 tasks.append(self._command_source.task(task_state["_name_"]))
             return tasks
 
-        def _tasks_with_matching_attributes(
-            self,
-            attr,
-            other_attr,
-            recursive,
-            names
-        ):
-            print("entering with names", names)
+        def _tasks_with_matching_attributes(self, attr, other_attr):
             this_command = self._command()
             attrs = this_command.get_attr(attr)
             if not attrs:
@@ -74,42 +67,26 @@ class WorkflowWrapper:
             attrs = set(attrs)
             tasks = [
                 task for task in self._all_task_objects() if
-                task.name() not in names
+                task.name() != self.name()
             ]
             matches = []
-            print("tasks", [task.name() for task in tasks])
             for task in tasks:
                 command = task._command()
                 other_attrs = command.get_attr(other_attr)
                 if other_attrs and (attrs & set(other_attrs)):
-                    print("names and task name", names, task.name())
-                    if recursive:
-                        task = (
-                            task,
-                            task._tasks_with_matching_attributes(
-                                attr,
-                                other_attr,
-                                recursive,
-                                names.union({task.name()})
-                            )
-                        )
                     matches.append(task)
             return matches
 
-        def get_direct_upstream_tasks(self, recursive=False):
+        def get_direct_upstream_tasks(self):
             return self._tasks_with_matching_attributes(
                 attr="requiredInputs",
-                other_attr="outputs",
-                recursive=recursive,
-                names={self.name()}
+                other_attr="outputs"
                 )
 
-        def get_direct_downstream_tasks(self, recursive=False):
+        def get_direct_downstream_tasks(self):
             return self._tasks_with_matching_attributes(
                 attr="outputs",
-                other_attr="requiredInputs",
-                recursive=recursive,
-                names={self.name()}
+                other_attr="requiredInputs"
                 )
 
         @property

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -65,7 +65,10 @@ class WorkflowWrapper:
             if not attrs:
                 return []
             attrs = set(attrs)
-            tasks = self._all_task_objects()
+            tasks = (
+                task for task in self._all_task_objects() if
+                task.name() != self.name()
+                )
             matches = []
             for task in tasks:
                 command = task._command()

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Tuple
 
 from ansys.fluent.core.services.datamodel_se import PyCallableStateObject
 
@@ -17,144 +17,243 @@ def _new_command_for_task(task, session):
     raise NewCommandError(task._name_())
 
 
+class TaskContainer(PyCallableStateObject):
+    """ Wrap a workflow TaskObject container
+
+        Methods
+        -------
+        __getitem__(attr)
+        __getattr__(attr)
+        __dir__()
+    """
+    def __init__(self, command_source):
+        self._container = command_source
+        self._task_container = command_source._workflow.TaskObject
+
+    def __getitem__(self, name):
+        return Task(self._container, name)
+
+    def __getattr__(self, attr):
+        return getattr(self._task_container, attr)
+
+    def __dir__(self):
+        return sorted(
+            set(
+                list(self.__dict__.keys())
+                + dir(type(self))
+                + dir(self._task_container)
+            )
+        )
+
+
+class Task(PyCallableStateObject):
+    """ Wrap a Workflow TaskObject instance, adding methods to discover
+        more about the relationships between TaskObjects.
+
+        Methods
+        -------
+        get_direct_upstream_tasks()
+        get_direct_downstream_tasks()
+        ordered_children()
+        inactive_ordered_children()
+        get_id()
+        get_idx()
+        __getattr__(attr)
+        __setattr__(attr, value)
+        __dir__()
+     """
+    def __init__(self, command_source, name: str) -> None:
+        self.__dict__.update(
+            dict(
+                _command_source=command_source,
+                _workflow=command_source._workflow,
+                _source=command_source._command_source,
+                _task=command_source._workflow.TaskObject[name],
+                _cmd=None,
+            )
+        )
+
+    def get_direct_upstream_tasks(self) -> list:
+        return self._tasks_with_matching_attributes(
+            attr="requiredInputs",
+            other_attr="outputs"
+            )
+
+    def get_direct_downstream_tasks(self) -> list:
+        return self._tasks_with_matching_attributes(
+            attr="outputs",
+            other_attr="requiredInputs"
+            )
+
+    def ordered_children(self) -> list:
+        return [self._command_source._task_by_id(task_id) for task_id in self._task.TaskList()]
+
+    def inactive_ordered_children(self) -> list:
+        return [self._command_source._task_by_id(task_id) for task_id in self._task.InactiveTaskList()]
+
+    def get_id(self) -> str:
+        workflow_state = self._command_source._workflow_state()
+        for k, v in workflow_state.items():
+            if isinstance(v, dict) and '_name_' in v:
+                if v['_name_'] == self.name():
+                    type_ , id_ = k.split(':')
+                    if type_ == "TaskObject":
+                        return id_
+
+    def get_idx(self) -> int:
+        return int(self.get_id()[len("TaskObject"):])
+
+    @property
+    def CommandArguments(self):
+        return self._refreshed_command()
+
+    def __getattr__(self, attr):
+        return getattr(self._task, attr)
+
+    def __setattr__(self, attr, value):
+        if attr in self.__dict__:
+            self.__dict__[attr] = value
+        else:
+            setattr(self._task, attr, value)
+
+    def __dir__(self):
+        return sorted(
+            set(list(self.__dict__.keys()) + dir(type(self)) + dir(self._task))
+        )
+
+    def _tasks_with_matching_attributes(
+        self,
+        attr: str,
+        other_attr: str
+    ) -> list:
+        this_command = self._command()
+        attrs = this_command.get_attr(attr)
+        if not attrs:
+            return []
+        attrs = set(attrs)
+        tasks = [
+            task for task in self._command_source.ordered_children() if
+            task.name() != self.name()
+        ]
+        matches = []
+        for task in tasks:
+            command = task._command()
+            other_attrs = command.get_attr(other_attr)
+            if other_attrs and (attrs & set(other_attrs)):
+                matches.append(task)
+        return matches
+
+    def _refreshed_command(self):
+        task_arg_state = self.Arguments.get_state()
+        cmd = self._command()
+        if task_arg_state:
+            cmd.set_state(task_arg_state)
+        return _MakeReadOnly(self._cmd_sub_items_read_only(cmd))
+
+    def _cmd_sub_items_read_only(self, cmd):
+        for item in cmd():
+            if type(getattr(cmd, item).get_state()) == dict:
+                setattr(
+                    cmd, item, self._cmd_sub_items_read_only(getattr(cmd, item))
+                )
+            setattr(cmd, item, _MakeReadOnly(getattr(cmd, item)))
+        return cmd
+
+    def _command(self):
+        if not self._cmd:
+            self._cmd = _new_command_for_task(self._task, self._source)
+        return self._cmd
+
+
 class WorkflowWrapper:
-    class TaskContainer(PyCallableStateObject):
-        def __init__(self, command_source):
-            self._container = command_source
-            self._task_container = command_source._workflow.TaskObject
+    """ Wrap a Workflow object, adding methods to discover
+        more about the relationships between TaskObjects.
 
-        def __getitem__(self, name):
-            return WorkflowWrapper.Task(self._container, name)
-
-        def __getattr__(self, attr):
-            return getattr(self._task_container, attr)
-
-        def __dir__(self):
-            return sorted(
-                set(
-                    list(self.__dict__.keys())
-                    + dir(type(self))
-                    + dir(self._task_container)
-                )
-            )
-
-    class Task(PyCallableStateObject):
-        def __init__(self, command_source, name):
-            self.__dict__.update(
-                dict(
-                    _command_source=command_source,
-                    _workflow=command_source._workflow,
-                    _source=command_source._command_source,
-                    _task=command_source._workflow.TaskObject[name],
-                    _cmd=None,
-                )
-            )
-
-        def _tasks_with_matching_attributes(self, attr, other_attr):
-            this_command = self._command()
-            attrs = this_command.get_attr(attr)
-            if not attrs:
-                return []
-            attrs = set(attrs)
-            tasks = [
-                task for task in self._command_source.ordered_children() if
-                task.name() != self.name()
-            ]
-            matches = []
-            for task in tasks:
-                command = task._command()
-                other_attrs = command.get_attr(other_attr)
-                if other_attrs and (attrs & set(other_attrs)):
-                    matches.append(task)
-            return matches
-
-        def get_direct_upstream_tasks(self):
-            return self._tasks_with_matching_attributes(
-                attr="requiredInputs",
-                other_attr="outputs"
-                )
-
-        def get_direct_downstream_tasks(self):
-            return self._tasks_with_matching_attributes(
-                attr="outputs",
-                other_attr="requiredInputs"
-                )
-
-        def ordered_children(self):
-            sub_task_ids = self._task.TaskList()
-            return [self._command_source._task_by_id(task_id) for task_id in self._task.TaskList()]
-
-        def get_inactive_sub_tasks(self):
-            sub_task_ids = self._task.InactiveTaskList()
-            return [self._command_source._task_by_id(task_id) for task_id in self._task.InactiveTaskList()]
-
-        def get_id(self):
-            workflow_state = self._command_source._workflow_state()
-            for k, v in workflow_state.items():
-                if isinstance(v, dict) and '_name_' in v:
-                    if v['_name_'] == self.name():
-                        type_ , id_ = k.split(':')
-                        if type_ == "TaskObject":
-                            return id_
-
-        def get_idx(self):
-            return int(self.get_id()[len("TaskObject"):])
-
-        @property
-        def CommandArguments(self):
-            return self._refreshed_command()
-
-        def _refreshed_command(self):
-            task_arg_state = self.Arguments.get_state()
-            cmd = self._command()
-            if task_arg_state:
-                cmd.set_state(task_arg_state)
-            return _MakeReadOnly(self._cmd_sub_items_read_only(cmd))
-
-        def _cmd_sub_items_read_only(self, cmd):
-            for item in cmd():
-                if type(getattr(cmd, item).get_state()) == dict:
-                    setattr(
-                        cmd, item, self._cmd_sub_items_read_only(getattr(cmd, item))
-                    )
-                setattr(cmd, item, _MakeReadOnly(getattr(cmd, item)))
-            return cmd
-
-        def _command(self):
-            if not self._cmd:
-                self._cmd = _new_command_for_task(self._task, self._source)
-            return self._cmd
-
-        def __getattr__(self, attr):
-            return getattr(self._task, attr)
-
-        def __setattr__(self, attr, value):
-            if attr in self.__dict__:
-                self.__dict__[attr] = value
-            else:
-                setattr(self._task, attr, value)
-
-        def __dir__(self):
-            return sorted(
-                set(list(self.__dict__.keys()) + dir(type(self)) + dir(self._task))
-            )
+        Methods
+        -------
+        task(name)
+        ordered_children()
+        __getattr__(attr)
+        __dir__()
+        __call__()
+     """
 
     def __init__(self, workflow, command_source):
         self._workflow = workflow
         self._command_source = command_source
 
-    def task(self, name):
-        return WorkflowWrapper.Task(self, name)
+    def task(self, name: str) -> Task:
+        """ Get a TaskObject by name, in a Task wrapper.
+        The wrapper adds extra functionality.
+
+        Parameters
+        ----------
+        name : str
+            Task name - the display name, not the internal ID.
+        """
+        return Task(self, name)
 
     @property
-    def TaskObject(self):
+    def TaskObject(self) -> TaskContainer:
         # missing from dir
-        return WorkflowWrapper.TaskContainer(self)
+        """ Get a TaskObject container wrapper that 'holds' the
+        underlying TaskObjects. The wrapper adds extra functionality.
+        """
+        return TaskContainer(self)
+
+    def ordered_children(self) -> list:
+        """ Get the ordered task list held by the workflow. Sorting is in terms
+        of the workflow order and only includes the top-level tasks, while other tasks
+        can be obtained by calling ordered_children() on a parent task. Given the
+        workflow:
+
+        o Workflow
+        |
+        |--o A
+        |
+        |--o B
+        |  |
+        |  |--o C
+        |  |
+        |  |--o D
+        |
+        |--o E
+
+        the ordered children of the workflow are A, B, E, while B has ordered children
+        C and D.
+        """
+
+        workflow_state, task_list_state = self._workflow_and_task_list_state()
+        tasks = []
+        for task_id in task_list_state:
+            tasks.append(self._task_by_id_impl(task_id, workflow_state))
+        return tasks
+
+    def __getattr__(self, attr):
+        """ Delegate attribute lookup to the wrapped workflow object
+        Parameters
+        ----------
+        attr : str
+            An attribute not defined in WorkflowWrapper
+        """
+        return getattr(self._workflow, attr)
+
+    def __dir__(self):
+        """ Override the behaviour of dir to include attributes in WorkflowWrapper and the underlying workflow.
+        """
+        return sorted(
+            set(list(self.__dict__.keys()) + dir(type(self)) + dir(self._workflow))
+        )
+
+    def __call__(self):
+        """ Delegate calls to the underlying workflow.
+        """
+        return self._workflow()
 
     def _workflow_state(self):
         return self._workflow()
 
-    def _workflow_and_task_list_state(self):
+    def _workflow_and_task_list_state(self) -> Tuple[dict, dict]:
         workflow_state = self._workflow_state()
         workflow_state_workflow = workflow_state["Workflow"]
         return (workflow_state, workflow_state_workflow["TaskList"])
@@ -168,13 +267,6 @@ class WorkflowWrapper:
         workflow_state = self._workflow_state()
         return self._task_by_id_impl(task_id, workflow_state)
 
-    def ordered_children(self) -> List[Task]:
-        workflow_state, task_list_state = self._workflow_and_task_list_state()
-        tasks = []
-        for task_id in task_list_state:
-            tasks.append(self._task_by_id_impl(task_id, workflow_state))
-        return tasks
-
     def _is_downstream(self, task, upstreams):
         if not upstreams:
             return not task.get_direct_upstream_tasks()
@@ -183,17 +275,6 @@ class WorkflowWrapper:
             downstreams_of_upstreams.extend(upstream.get_direct_downstream_tasks())
         matching_names = [task.name() for task in downstreams_of_upstreams]
         return task.name() in matching_names
-
-    def __getattr__(self, attr):
-        return getattr(self._workflow, attr)
-
-    def __dir__(self):
-        return sorted(
-            set(list(self.__dict__.keys()) + dir(type(self)) + dir(self._workflow))
-        )
-
-    def __call__(self):
-        return self._workflow()
 
 
 class _MakeReadOnly:

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -48,6 +48,14 @@ class WorkflowWrapper:
                 )
             )
 
+        def _task_by_id(self, task_id):
+            workflow_state = self._workflow()
+            workflow_state_workflow = workflow_state["Workflow"]
+            workflow_state_tasklist = workflow_state_workflow["TaskList"]
+            task_key = "TaskObject:" + task_id
+            task_state = workflow_state[task_key]
+            return self._command_source.task(task_state["_name_"])
+
         def _all_task_objects(self):
             workflow_state = self._workflow()
             workflow_state_workflow = workflow_state["Workflow"]
@@ -88,6 +96,10 @@ class WorkflowWrapper:
                 attr="outputs",
                 other_attr="requiredInputs"
                 )
+
+        def get_sub_tasks(self):
+            sub_task_ids = self._task.TaskList()
+            return [self._task_by_id(task_id) for task_id in self._task.TaskList()]
 
         @property
         def CommandArguments(self):

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -57,7 +57,7 @@ class WorkflowWrapper:
                 return []
             attrs = set(attrs)
             tasks = [
-                task for task in self._command_source.top_level_task_objects() if
+                task for task in self._command_source.ordered_children() if
                 task.name() != self.name()
             ]
             matches = []
@@ -80,7 +80,7 @@ class WorkflowWrapper:
                 other_attr="requiredInputs"
                 )
 
-        def get_sub_tasks(self):
+        def ordered_children(self):
             sub_task_ids = self._task.TaskList()
             return [self._command_source._task_by_id(task_id) for task_id in self._task.TaskList()]
 
@@ -99,9 +99,6 @@ class WorkflowWrapper:
 
         def get_idx(self):
             return int(self.get_id()[len("TaskObject"):])
-
-        def ordered_children(self):
-            return sorted(self.get_sub_tasks(), key=lambda task: task.get_idx())
 
         @property
         def CommandArguments(self):
@@ -171,18 +168,12 @@ class WorkflowWrapper:
         workflow_state = self._workflow_state()
         return self._task_by_id_impl(task_id, workflow_state)
 
-    def top_level_task_objects(self):
+    def ordered_children(self) -> List[Task]:
         workflow_state, task_list_state = self._workflow_and_task_list_state()
         tasks = []
         for task_id in task_list_state:
             tasks.append(self._task_by_id_impl(task_id, workflow_state))
         return tasks
-
-    def ordered_children(self) -> List[Task]:
-        return sorted(
-            self.top_level_task_objects(),
-            key=lambda task: task.get_idx()
-            )
 
     def _is_downstream(self, task, upstreams):
         if not upstreams:

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -387,10 +387,46 @@ def test_dummy_journal_data_model_methods(new_mesh_session):
 
 
 def test_meshing_workflow_related_tasks(new_mesh_session):
+    '''
+    o Workflow
+    |
+    |--o Import Geometry
+    |
+    |--o Add Local Sizing
+    |
+    |--o Generate the Surface Mesh
+    |
+    |--o Describe Geometry
+    |  |
+    |  |--o Enclose Fluid Regions (Capping)
+    |  |
+    |  |--o Create Regions
+    |
+    |--o Update Regions
+    |
+    |--o Add Boundary Layers
+    |
+    |--o Generate the Volume Mesh
+    '''
+
     w = new_mesh_session.workflow
     w.InitializeWorkflow(WorkflowType="Watertight Geometry")
 
-    gen_surf_mesh = w.task("Generate the Surface Mesh")
+    task_names = (
+        "Import Geometry",
+        "Add Local Sizing",
+        "Generate the Surface Mesh",
+        "Describe Geometry",
+        "Enclose Fluid Regions (Capping)",
+        "Create Regions",
+        "Update Regions",
+        "Add Boundary Layers",
+        "Generate the Volume Mesh",
+        )
+
+    import_geom, add_sizing, gen_surf_mesh, describe_geometry,\
+        cap, create_regions, update_regions, add_boundary_layers,\
+            gen_vol_mesh = [w.task(name) for name in task_names]
 
     upstreams = gen_surf_mesh.get_direct_upstream_tasks()
     upstream_names = set([upstream.name() for upstream in upstreams])
@@ -399,8 +435,6 @@ def test_meshing_workflow_related_tasks(new_mesh_session):
     downstreams = gen_surf_mesh.get_direct_downstream_tasks()
     downstream_names = set([downstream.name() for downstream in downstreams])
     assert not (downstream_names ^ set(["Describe Geometry", "Add Boundary Layers", "Generate the Volume Mesh"]))
-
-    describe_geometry = w.task("Describe Geometry")
 
     upstreams = describe_geometry.get_direct_upstream_tasks()
     upstream_names = set([upstream.name() for upstream in upstreams])

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -385,6 +385,8 @@ def test_dummy_journal_data_model_methods(new_mesh_session):
     assert msg.value.args[0] == "This method is yet to be implemented in pyfluent."
 
 
+@pytest.mark.dev
+@pytest.mark.fluent_231
 def test_meshing_workflow_structure(new_mesh_session):
     '''
     o Workflow

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -384,3 +384,18 @@ def test_dummy_journal_data_model_methods(new_mesh_session):
     with pytest.raises(AttributeError) as msg:
         w.task("Import Geometry").fix_state()
     assert msg.value.args[0] == "This method is yet to be implemented in pyfluent."
+
+
+def test_meshing_workflow_task_related_tasks(new_mesh_session):
+    w = new_mesh_session.workflow
+    w.InitializeWorkflow(WorkflowType="Watertight Geometry")
+
+    gen_surf_mesh = w.task("Generate the Surface Mesh")
+
+    upstreams = gen_surf_mesh.get_direct_upstream_tasks()
+    upstream_names = set([upstream.name() for upstream in upstreams])
+    assert not (upstream_names ^ set(["Import Geometry", "Add Local Sizing"]))
+
+    downstreams = gen_surf_mesh.get_direct_downstream_tasks()
+    downstream_names = set([downstream.name() for downstream in downstreams])
+    assert not (downstream_names ^ set(["Describe Geometry", "Add Boundary Layers", "Generate the Volume Mesh"]))

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -426,7 +426,7 @@ def test_meshing_workflow_related_tasks(new_mesh_session):
 
     import_geom, add_sizing, gen_surf_mesh, describe_geometry,\
         cap, create_regions, update_regions, add_boundary_layers,\
-            gen_vol_mesh = [w.task(name) for name in task_names]
+            gen_vol_mesh = all_tasks = [w.task(name) for name in task_names]
 
     def upstream_names(task):
         return {upstream.name() for upstream in task.get_direct_upstream_tasks()}
@@ -460,6 +460,12 @@ def test_meshing_workflow_related_tasks(new_mesh_session):
 
     assert upstream_names(gen_vol_mesh) == {"Update Regions", "Describe Geometry", "Add Boundary Layers", "Generate the Surface Mesh"}
     assert downstream_names(gen_vol_mesh) == set()
+
+    for task in all_tasks:
+        assert {sub_task.name() for sub_task in task.get_sub_tasks()} == ({
+            "Enclose Fluid Regions (Capping)",
+            "Create Regions",
+        } if task is describe_geometry else set())
 
     '''
     o Workflow

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -468,7 +468,7 @@ def test_meshing_workflow_structure(new_mesh_session):
         } if task is describe_geometry else set())
 
     for task in all_tasks:
-        assert {sub_task.name() for sub_task in task.get_inactive_sub_tasks()} == ({
+        assert {sub_task.name() for sub_task in task.inactive_ordered_children()} == ({
             "Apply Share Topology",
             "Update Boundaries",
         } if task is describe_geometry else set())

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -467,6 +467,18 @@ def test_meshing_workflow_related_tasks(new_mesh_session):
             "Create Regions",
         } if task is describe_geometry else set())
 
+    for task in all_tasks:
+        assert {sub_task.name() for sub_task in task.get_inactive_sub_tasks()} == ({
+            "Apply Share Topology",
+            "Update Boundaries",
+        } if task is describe_geometry else set())
+
+    task_ids = [task.get_id() for task in all_tasks]
+    # uniqueness test
+    assert len(set(task_ids)) == len(task_ids)
+    # ordering test
+    idxs = [int(id[len("TaskObject"):]) for id in task_ids]
+    assert sorted(idxs) == idxs
     '''
     o Workflow
     |
@@ -480,7 +492,6 @@ def test_meshing_workflow_related_tasks(new_mesh_session):
                                                         |-- Update Boundaries
                                                         |-- ...
     '''
-    insert_next_task = set(gen_surf_mesh.GetNextPossibleTasks())
-    assert insert_next_task == {
+    assert set(gen_surf_mesh.GetNextPossibleTasks()) == {
         'AddBoundaryType', 'UpdateBoundaries', 'SetUpPeriodicBoundaries', 'LinearMeshPattern',
         'ModifyMeshRefinement', 'ImproveSurfaceMesh', 'RunCustomJournal'}

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -386,7 +386,7 @@ def test_dummy_journal_data_model_methods(new_mesh_session):
     assert msg.value.args[0] == "This method is yet to be implemented in pyfluent."
 
 
-def test_meshing_workflow_related_tasks(new_mesh_session):
+def test_meshing_workflow_structure(new_mesh_session):
     '''
     o Workflow
     |
@@ -495,3 +495,23 @@ def test_meshing_workflow_related_tasks(new_mesh_session):
     assert set(gen_surf_mesh.GetNextPossibleTasks()) == {
         'AddBoundaryType', 'UpdateBoundaries', 'SetUpPeriodicBoundaries', 'LinearMeshPattern',
         'ModifyMeshRefinement', 'ImproveSurfaceMesh', 'RunCustomJournal'}
+
+    children = w.ordered_children()
+    expected_task_order = (
+        "Import Geometry",
+        "Add Local Sizing",
+        "Generate the Surface Mesh",
+        "Describe Geometry",
+        "Update Regions",
+        "Add Boundary Layers",
+        "Generate the Volume Mesh",
+        )
+
+    actual_task_order = tuple(child.name() for child in children)
+
+    assert actual_task_order == expected_task_order
+
+    assert [child.name() for child in children[3].ordered_children()] == [
+        "Enclose Fluid Regions (Capping)",
+        "Create Regions",
+    ]

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -462,7 +462,7 @@ def test_meshing_workflow_structure(new_mesh_session):
     assert downstream_names(gen_vol_mesh) == set()
 
     for task in all_tasks:
-        assert {sub_task.name() for sub_task in task.get_sub_tasks()} == ({
+        assert {sub_task.name() for sub_task in task.ordered_children()} == ({
             "Enclose Fluid Regions (Capping)",
             "Create Regions",
         } if task is describe_geometry else set())
@@ -512,6 +512,29 @@ def test_meshing_workflow_structure(new_mesh_session):
     assert actual_task_order == expected_task_order
 
     assert [child.name() for child in children[3].ordered_children()] == [
+        "Enclose Fluid Regions (Capping)",
+        "Create Regions",
+    ]
+
+    gen_surf_mesh.InsertNextTask(CommandName="AddBoundaryType")
+
+    children = w.ordered_children()
+    expected_task_order = (
+        "Import Geometry",
+        "Add Local Sizing",
+        "Generate the Surface Mesh",
+        "Add Boundary Type",
+        "Describe Geometry",
+        "Update Regions",
+        "Add Boundary Layers",
+        "Generate the Volume Mesh",
+        )
+
+    actual_task_order = tuple(child.name() for child in children)
+
+    assert actual_task_order == expected_task_order
+
+    assert [child.name() for child in children[4].ordered_children()] == [
         "Enclose Fluid Regions (Capping)",
         "Create Regions",
     ]

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -260,18 +260,17 @@ def test_accessors_for_argument_sub_items(new_mesh_session):
     ).CommandArguments.CadImportOptions.OneZonePer.is_read_only()
     assert (
         w.task(
-            "Import Geometry"
-        ).CommandArguments.CadImportOptions.OneZonePer.default_value()
-        == "body"
+            "Generate the Volume Mesh"
+        ).CommandArguments.VolumeFillControls.Type.default_value()
+        == "Cartesian"
     )
 
     # Test particular to string type (allowed_values() only available in string types)
     assert w.task(
-        "Import Geometry"
-    ).CommandArguments.CadImportOptions.OneZonePer.allowed_values() == [
-        "body",
-        "face",
-        "object",
+        "Generate the Volume Mesh"
+        ).CommandArguments.VolumeFillControls.Type.allowed_values() == [
+        "Octree",
+        "Cartesian"
     ]
     assert (
         w.task(

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -386,7 +386,7 @@ def test_dummy_journal_data_model_methods(new_mesh_session):
     assert msg.value.args[0] == "This method is yet to be implemented in pyfluent."
 
 
-def test_meshing_workflow_task_related_tasks(new_mesh_session):
+def test_meshing_workflow_related_tasks(new_mesh_session):
     w = new_mesh_session.workflow
     w.InitializeWorkflow(WorkflowType="Watertight Geometry")
 

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -399,3 +399,13 @@ def test_meshing_workflow_related_tasks(new_mesh_session):
     downstreams = gen_surf_mesh.get_direct_downstream_tasks()
     downstream_names = set([downstream.name() for downstream in downstreams])
     assert not (downstream_names ^ set(["Describe Geometry", "Add Boundary Layers", "Generate the Volume Mesh"]))
+
+    describe_geometry = w.task("Describe Geometry")
+
+    upstreams = describe_geometry.get_direct_upstream_tasks()
+    upstream_names = set([upstream.name() for upstream in upstreams])
+    assert not (upstream_names ^ set(["Generate the Surface Mesh", "Add Boundary Layers"]))
+
+    downstreams = describe_geometry.get_direct_downstream_tasks()
+    downstream_names = set([downstream.name() for downstream in downstreams])
+    assert not (downstream_names ^ set(["Update Regions", "Add Boundary Layers", "Generate the Volume Mesh"]))

--- a/tests/test_meshing_workflow.py
+++ b/tests/test_meshing_workflow.py
@@ -204,7 +204,7 @@ def test_command_args_including_task_object_datamodel_se(new_mesh_session):
     w = session_new.workflow
     w.InitializeWorkflow(WorkflowType="Watertight Geometry")
     igt = w.TaskObject["Import Geometry"]
-    assert igt.Arguments() == set()
+    assert igt.Arguments() == {}
     assert igt.CommandArguments.CadImportOptions()
     assert igt.CommandArguments.CadImportOptions.OneZonePer()
     assert igt.CommandArguments.CadImportOptions.OneZonePer.getAttribValue("default")
@@ -262,16 +262,16 @@ def test_accessors_for_argument_sub_items(new_mesh_session):
         w.task(
             "Import Geometry"
         ).CommandArguments.CadImportOptions.OneZonePer.default_value()
-        == "Body"
+        == "body"
     )
 
     # Test particular to string type (allowed_values() only available in string types)
     assert w.task(
         "Import Geometry"
     ).CommandArguments.CadImportOptions.OneZonePer.allowed_values() == [
-        "Body",
-        "Face",
-        "Object",
+        "body",
+        "face",
+        "object",
     ]
     assert (
         w.task(


### PR DESCRIPTION
An incremental improvement to the workflow interface: 
- provide information about the task hierarchy
-- which tasks are directly up/downstream of a given task, which is implied by task inputs/outputs. The methods are get_direct_upstream_tasks(), get_direct_downstream_tasks()
-- get all ordered children of either the workflow or of a given task. By recursion, the full hierarchy can by obtained. The method is ordered_children() (also inactive_ordered_children())
- remove the class nesting in workflow.py because of documentation difficulties
- add test for the new functionality. Also update existing tests, reflecting a recent API change in the backend, which is effective in 2023R2

N.b. I have deliberately avoided changing rst files to avoid conflicts with @hpohekar.