### PR TITLE
Updated isort version to avoid pre-commit.ci failure.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
   - id: black
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
   - id: isort
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
   - id: black
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.12.0
+  rev: 5.11.5
   hooks:
   - id: isort
 


### PR DESCRIPTION
We are experiencing this failure in most of the PRs.

![image](https://user-images.githubusercontent.com/106588300/215429757-e197273a-29e7-4c3d-b885-73de2ad7a0e3.png)
