### PR TITLE
downgrade sphinx

### DIFF
--- a/requirements/requirements_doc.txt
+++ b/requirements/requirements_doc.txt
@@ -1,4 +1,4 @@
-Sphinx==6.1.3
+Sphinx==5.3.0
 jupyter_sphinx==0.4.0
 numpydoc==1.5.0
 matplotlib==3.6.3


### PR DESCRIPTION
Downgrade Sphinx to 5.3.0 to fix the built documentation (and by effect fix the multi-version switcher) and prevent ansys-sphinx-theme from breaking. 