### PR TITLE
Fix is_active checks

### DIFF
--- a/codegen/data/fluent_gui_help.xml
+++ b/codegen/data/fluent_gui_help.xml
@@ -50,9 +50,17 @@
             <h3>File Units</h3>
             <p>Specify the units in which the surface or volume mesh was created in. </p>
          </sect2>
+         <sect2 id="enablecleancad_importgeometry_importtype">
+            <h3>Import Type</h3>
+            <p>When the <b>File Format</b> is set to <b>CAD</b>, use the <b>Import Type</b> field to import a <b>Single File</b> (the default),or <b>Multiple Files</b>. When importing multiple files, the <b>Select File</b> dialog allows you to make multiple selections, as long as the files are in the same directory and are of the same CAD format. </p>
+         </sect2>
          <sect2 id="enablecleancad_importgeometry_lengthunit">
             <h3>Units</h3>
             <p>Select a suitable working unit for the meshing operation, with a min size of the order of 1. The model will be automatically scaled to meters when switching to the solver. It is recommended to select units so that the minimum size is between approximately 0.1 - 10. If the minimum size falls outside of this range, then you should change the units.</p>
+         </sect2>
+         <sect2 id="enablecleancad_importgeometry_usebodylabels">
+            <h3>Use Body Labels</h3>
+            <p>Specify that you want to use any composite body labels that are defined in your imported CAD geometry by choosing <b>Yes</b>. If the imported CAD file does not contain any body labels, then this will automatically be set to <b>No</b>.</p>
          </sect2>
          <sect2 id="enablecleancad_importgeometry_filename">
             <h3>File Name</h3>
@@ -61,6 +69,10 @@
          <sect2 id="enablecleancad_importgeometry_showimportcadpreferences">
             <h3>Advanced Options</h3>
             <p>Display advanced options that you may want to apply to the task.</p>
+         </sect2>
+         <sect2 id="enablecleancad_importgeometry_automaticobjectcreation">
+            <h3>Automatic Object and Label Creation?</h3>
+            <p>Determine whether or not mesh objects and labels are automatically created upon import, potentially and dramatically increasing the mesh import speed for very large cases. By default, this is set to <b>yes</b> however, if it is set to <b>no</b>, then no labels are created and a single mesh object is created employing all zones.</p>
          </sect2>
          <sect2 id="enablecleancad_importgeometry_ciseparation">
             <h3>Separate Zone By</h3>
@@ -239,6 +251,14 @@
             <h3>Auto Remesh to Remove Clustering?</h3>
             <p>Choose whether or not to automatically remesh in order to remove excessive clustering of nodes. By default (auto), this is done if local sizing has been assigned or Share Topology is invoked, but skipped if not. Performance may be improved if this is disabled. In addition, you can choose to use the much faster refaceting technique as an alternative to automatic remeshing. When importing the mesh, remeshing is only performed if this option is set to <b>yes</b> and then all faces are remeshed; and the refaceting option is not available because the initial mesh cannot be refaceted.</p>
          </sect2>
+         <sect2 id="enablecleancad_generatethesurfacemeshwtm_setvolumemeshmaxsize">
+            <h3>Set Volume Mesh Max Size?</h3>
+            <p>Determine whether or not you need to assign a maximum size for the volume mesh.</p>
+         </sect2>
+         <sect2 id="enablecleancad_generatethesurfacemeshwtm_volumemeshmaxsize">
+            <h3>Volume Mesh Max Size</h3>
+            <p>Specify a value for the maximum size for the volume mesh, and eliminate the need for Fluent to perform additional size function calculations when generating the volume mesh.</p>
+         </sect2>
          <sect2 id="enablecleancad_geometrysetup">
             <h3>Describe Geometry</h3>
             <p>Specify the type of geometry you are importing: whether it is a solid model a fluid model, or both. The workflow changes based on your selection. Additionally, for fluid volume extraction, you need to indicate whether or not any openings need to be closed. <a href="describe_geometry"> More... </a>
@@ -254,7 +274,7 @@
          </sect2>
          <sect2 id="enablecleancad_geometrysetup_walltointernal">
             <h3>Change all fluid-fluid boundary types from "wall" to "internal"?</h3>
-            <p>Choose whether or not to change interior fluid-fluid boundaries from type "wall" to "internal". Only internal boundaries bounded by two fluid regions are converted into internal zone types. Internal boundaries that are designated as "baffles" are retained as walls. </p>
+            <p>Choose whether or not to change interior fluid-fluid boundaries from type "wall" to "internal". Only internal boundaries bounded by two fluid regions are converted into internal zone types. If new fluid regions are assigned, this task is executed after the <b>Update Regions</b> task. Internal boundaries that are designated as "baffles" are retained as walls. </p>
          </sect2>
          <sect2 id="enablecleancad_geometrysetup_invokesharetopology">
             <h3>Do you need to apply Share Topology?</h3>
@@ -320,6 +340,10 @@
          <sect2 id="enablecleancad_createregions_numberofflowvolumes">
             <h3>Number of Flow Volumes</h3>
             <p>Confirm the number of flow volumes required for the analysis. The system will detect additional regions if they exist, however, it will detect fluid regions only where they are connected to capping surfaces.</p>
+         </sect2>
+         <sect2 id="enablecleancad_createregions_retaindeadregionname">
+            <h3>Do you want to retain dead region names?</h3>
+            <p>If any dead regions are present, you can choose to determine how such regions are named. Voids or dead regions are usually named <systemitem moreinfo="none">dead0</systemitem>, <systemitem moreinfo="none">dead1</systemitem>, <systemitem moreinfo="none">dead2</systemitem>, and so on, and can remain so when this prompt is set to <b>no</b>. When this prompt is set to <b>yes</b>, however, the dead region names will also be prefixed with the original dead region name (usually derived from an adjacent region), such as <systemitem moreinfo="none">dead0-fluid:1</systemitem>, <systemitem moreinfo="none">dead1-fluid:2</systemitem>, and so on.</p>
          </sect2>
          <sect2 id="enablecleancad_addboundarytype">
             <h3>Add Boundary Type</h3>
@@ -530,7 +554,7 @@
          </sect2>
          <sect2 id="enablecleancad_addmultizonecontrols_controltype">
             <h3>Multizone Controls and Sizing for</h3>
-            <p>Determine how you want to define the multi-zone control. Currently only region-based controls are supported.</p>
+            <p>Determine if you want to define the multi-zone control by selecting regions or edges.</p>
          </sect2>
          <sect2 id="enablecleancad_addmultizonecontrols_meshmethod">
             <h3>Mesh Method</h3>
@@ -559,7 +583,8 @@
          </sect2>
          <sect2 id="enablecleancad_addmultizonecontrols_sourcemethod">
             <h3>Source-Target Selection</h3>
-            <p>Choose one or more face zones or labels from the list below. Use the <b>Filter Text</b> drop-down to provide text and/or regular expressions in filtering the list (for example, using *, ?, and []). Choose <b>Use Wildcard</b> to provide wildcard expressions in filtering the list. When you use either ? or * in your expression, the matching list item(s) are automatically selected in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
+            <p>Choose one or more face zones or labels from the list below. 
+You can also provide the ability to select all source-target zones that are parallel to a global plane by choosing <b>Zones parallel to XY plane</b>, <b>Zones parallel to XZ plane</b>, or <b>Zones parallel to YZ plane</b>. For zones or labels. use the <b>Filter Text</b> drop-down to provide text and/or regular expressions in filtering the list (for example, using *, ?, and []). Choose <b>Use Wildcard</b> to provide wildcard expressions in filtering the list. When you use either ? or * in your expression, the matching list item(s) are automatically selected in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
             </p>
          </sect2>
          <sect2 id="enablecleancad_addmultizonecontrols_parallelselection">
@@ -578,15 +603,19 @@
          </sect2>
          <sect2 id="enablecleancad_addmultizonecontrols_assignsizeusing">
             <h3>Assign Size Using</h3>
-            <p>For edge-based multizone controls, you can choose from <b>Interval</b> or by <b>Size</b>.</p>
+            <p>For edge-based multizone controls, you can choose from <b>Interval</b>, <b>Size</b>, or <b>Smallest Height</b>. If <i>double graded</i> biasing is used and the <b>Interval</b> is set to an odd number (or the <b>Size</b> or <b>Smallest Height</b> results in an odd number <b>Interval</b>), the interval will automatically be increased by one.</p>
          </sect2>
          <sect2 id="enablecleancad_addmultizonecontrols_intervals">
             <h3>Number of Intervals</h3>
-            <p>Specify the number of intervals for the edge-based multizone control.</p>
+            <p>Specify the number of intervals for the edge-based multizone control. If <i>double graded</i> biasing is used and the <b>Interval</b> is set to an odd number (or the <b>Size</b> or <b>Smallest Height</b> results in an odd number <b>Interval</b>), the interval will automatically be increased by one.</p>
          </sect2>
          <sect2 id="enablecleancad_addmultizonecontrols_size">
             <h3>Size</h3>
             <p>Specify the minimum size for the edge-based multizone control.</p>
+         </sect2>
+         <sect2 id="enablecleancad_addmultizonecontrols_smallestheight">
+            <h3>Smallest Height</h3>
+            <p>Specify a value for the smallest height for the edge-based multizone control.</p>
          </sect2>
          <sect2 id="enablecleancad_addmultizonecontrols_biasmethod">
             <h3>Growth Pattern</h3>
@@ -594,15 +623,15 @@
          </sect2>
          <sect2 id="enablecleancad_addmultizonecontrols_growthmethod">
             <h3>Assign Growth Using</h3>
-            <p>add help text</p>
+            <p>For edge-based multizone controls when using variable <b>Growth Pattern</b>s, determine how you would like to determine the growth: either as a <b>Growth Rate</b> or as <b>Bias Factor</b>.</p>
          </sect2>
          <sect2 id="enablecleancad_addmultizonecontrols_growthrate">
             <h3>Growth Rate</h3>
-            <p>add help text</p>
+            <p>Specify a value for the growth rate for the multizone, or use the default value.</p>
          </sect2>
-         <sect2 id="enablecleancad_addmultizonecontrols_lastfirstratio">
-            <h3>Last-First Ratio</h3>
-            <p>add help text</p>
+         <sect2 id="enablecleancad_addmultizonecontrols_biasfactor">
+            <h3>Bias Factor</h3>
+            <p>Specify a value for the bias factor for the multizone, or use the default value. The <b>Bias Factor</b> is the ratio of the largest to the smallest segment on the edge.</p>
          </sect2>
          <sect2 id="enablecleancad_addmultizonecontrols_edgelabellist">
             <h3>Labels</h3>
@@ -622,6 +651,14 @@
             <h3>Regions</h3>
             <p>Select the named region(s) from the list to which you would like to generate the multi-zone mesh. Use the <b>Filter Text</b> drop-down to provide text and/or regular expressions in filtering the list (for example, using *, ?, and []). Choose <b>Use Wildcard</b> to provide wildcard expressions in filtering the list. When you use either ? or * in your expression, the matching list item(s) are automatically selected in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
             </p>
+         </sect2>
+         <sect2 id="enablecleancad_generatethemultizonemesh_nonconformal">
+            <h3>Non-Conformal Mesh between Mutizone and the rest?</h3>
+            <p>Optionally specify that multizone regions are non-conformally connected to other volumetric regions.  If you want to have a conformal mesh but, because of meshing constraints, that is not possible, then you can switch to non-conformal here and avoid doing so in the CAD model.</p>
+         </sect2>
+         <sect2 id="enablecleancad_generatethemultizonemesh_sizefunctionscalefactor">
+            <h3>Size Function Scale Factor</h3>
+            <p>Enable the scaling of the multizone mesh. In some cases when the multizone region is too coarse when compared to the adjacent surface mesh, a connection is not possible. You can specify a size function scaling factor here to improve the sizing match between the multizone and the non-multizone regions and avoid any free faces. Typically, a value between 0.7 and 0.8 is recommended.</p>
          </sect2>
          <sect2 id="enablecleancad_generatethevolumemeshwtm">
             <h3>Create Volume Mesh</h3>
@@ -665,6 +702,10 @@
             <h3>Show Global Boundary Layer Settings</h3>
             <p>Display global settings for your boundary layers. Note that these settings are not applied for Multizone boundary layers</p>
          </sect2>
+         <sect2 id="enablecleancad_generatethevolumemeshwtm_mergeboundarylayers">
+            <h3>Merge Boundary Layer Cells within Regions?</h3>
+            <p>Choose whether or not you want to have the boundary layer mesh merged into the bulk mesh.</p>
+         </sect2>
          <sect2 id="enablecleancad_generatethevolumemeshwtm_prismgapfactor">
             <h3>Gap Factor</h3>
             <p>Specify the relative gap-size (based on local mesh size) between two boundary layer caps. If this limit is exceeded, the boundary layer will automatically be compressed.</p>
@@ -685,13 +726,25 @@
             <h3>Adjacent Attach Angle</h3>
             <p>Specify the angle for which the boundary layer would imprint on an adjacent boundary.</p>
          </sect2>
+         <sect2 id="enablecleancad_generatethevolumemeshwtm_prismstairstepoptions">
+            <h3>Use default stair-step handling?</h3>
+            <p>Use this option to reduce the stair-stepping at certain locations based on quality or proximity criteria. By default, <b>Yes</b> allows you to retain the default stair-step handling, otherwise you can also choose <b>No, Exclude proximity check</b>, <b>No, Exclude quality check</b>, or <b>No, Exclude both checks</b>.</p>
+         </sect2>
+         <sect2 id="enablecleancad_generatethevolumemeshwtm_solver">
+            <h3>Solver</h3>
+            <p>Specify the target solver for which you want to generate the volume mesh (<b>Fluent</b> or <b>CFX</b>).</p>
+         </sect2>
          <sect2 id="enablecleancad_generatethevolumemeshwtm_volumefill">
             <h3>Fill With</h3>
             <p>Specify the type of cell to be used in the volumetric mesh: polyhedron (default), tetrahedron, hexahedron, or polyhedron-hexahedron.</p>
          </sect2>
+         <sect2 id="enablecleancad_generatethevolumemeshwtm_meshfluidregions">
+            <h3>Mesh Fluid Regions</h3>
+            <p>Choose whether to mesh the fluid regions in addition to the solid regions. This is enabled by default, and can be enabled along with the <b>Mesh Solid Regions</b> option, however, both options cannot be turned off at the same time.</p>
+         </sect2>
          <sect2 id="enablecleancad_generatethevolumemeshwtm_meshsolidregions">
             <h3>Mesh Solid Regions</h3>
-            <p>Choose whether to mesh the solid regions in addition to the fluid regions.</p>
+            <p>Choose whether to mesh the solid regions in addition to the fluid regions. This is enabled by default, and can be enabled along with the <b>Mesh Fluid Regions</b> option, however, both options cannot be turned off at the same time.</p>
          </sect2>
          <sect2 id="enablecleancad_generatethevolumemeshwtm_growthrate">
             <h3>Growth Rate</h3>
@@ -1190,6 +1243,10 @@
             <h3>Ignore Boundary Layers at Acute Angles?</h3>
             <p>Specify whether to automatically ignore boundary layers where there is an acute angle. Note that if there are sharp angles adjacent to other regions with boundary layers, some boundary layer removal may occur in those adjacent regions.</p>
          </sect2>
+         <sect2 id="enablecleancad_addboundarylayers_additionalignoredlayers">
+            <h3>Acute Angle Buffer Layers</h3>
+            <p>Indicate the number of buffer layers that can be placed around ignored boundary layer faces, extending the ignored regions around sharp angles. Increasing the value increases the number of faces for which the boundary layer will be ignored at acute angles.</p>
+         </sect2>
          <sect2 id="enablecleancad_addboundarylayers_modifyatinvalidnormals">
             <h3>Modify Surface Mesh at Invalid Normals?</h3>
             <p>Specify whether to automatically change the surface mesh where invalid normal faces are detected. To grow the boundary layer mesh in the proper direction (away from the boundary), normal vectors (valid) are required at the boundary face nodes of the surface mesh. <a href="add_boundary_layer">More...</a>
@@ -1215,7 +1272,7 @@
             <p>Choose how you want to make your selection (by object, label, or zone name).</p>
          </sect2>
          <sect2 id="enablecleancad_createlocalrefinementregions_zoneselectionlist">
-            <h3>Objects</h3>
+            <h3>Zones</h3>
             <p>Choose one or more zones from the list below. Use the <b>Filter Text</b> drop-down to provide text and/or regular expressions in filtering the list (for example, using *, ?, and []). Choose <b>Use Wildcard</b> to provide wildcard expressions in filtering the list. When you use either ? or * in your expression, the matching list item(s) are automatically selected in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
             </p>
          </sect2>
@@ -1225,8 +1282,13 @@
             </p>
          </sect2>
          <sect2 id="enablecleancad_createlocalrefinementregions_objectselectionlist">
-            <h3>Zones</h3>
+            <h3>Objects</h3>
             <p>Choose one or more objects from the list below. Use the <b>Filter Text</b> drop-down to provide text and/or regular expressions in filtering the list (for example, using *, ?, and []). Choose <b>Use Wildcard</b> to provide wildcard expressions in filtering the list. When you use either ? or * in your expression, the matching list item(s) are automatically selected in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
+            </p>
+         </sect2>
+         <sect2 id="enablecleancad_createlocalrefinementregions_objectselectionsingle">
+            <h3>Object</h3>
+            <p>Choose a single object from the list below. Use the <b>Filter Text</b> field to provide text and/or regular expressions in filtering the list. The matching list item(s) are automatically displayed in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
             </p>
          </sect2>
          <sect2 id="enablecleancad_createlocalrefinementregions_boundingboxobject">
@@ -1367,7 +1429,7 @@
          </sect2>
          <sect2 id="enablecleancad_managezones_operation">
             <h3>Operation</h3>
-            <p>Indicate the operation you wish to perform on the zones. When the task is located prior volume meshing: <b>Separate Zones</b>, <b>Split Cylinders</b>, or <b>Extract Edges</b>. When the task is located after volume meshing: <b>Change prefix</b>, <b>Rename</b>, or <b>Merge</b>. If your imported CAD geometry contains bodies with multiple body labels, you can also choose <b>Merge cells within each body label</b>
+            <p>Indicate the operation you wish to perform on the zones. When the task is located prior volume meshing: <b>Separate Zones</b>, <b>Split Cylinders</b>, <b>Split normal to X</b>, <b>Split normal to Y</b>, <b>Split normal to Z</b>, or <b>Extract Edges</b>. When the task is located after volume meshing: <b>Change prefix</b>, <b>Rename</b>, or <b>Merge</b>. If your imported CAD geometry contains bodies with multiple body labels, you can also choose <b>Merge cells within each body label</b>
             </p>
          </sect2>
          <sect2 id="enablecleancad_managezones_operationname">
@@ -1482,7 +1544,7 @@
          </sect2>
          <sect2 id="enabledirtycad_partmanagement_fmdfilename">
             <h3>CAD File</h3>
-            <p>Select a CAD file to import into your simulation. Standard Ansys file types, among others, are supported, including .scdoc, .agdb, .fmd, .fmdb, .fmd, .pmdb, .tgf, and .msh. To quickly import multiple CAD files, you can use basic wildcard expression patterns such as the * or ? wildcards. <a href="import_cad_and_part_management">More...</a>
+            <p>Select a CAD file to import into your simulation. Standard Ansys file types, among others, are supported, including .scdoc, .dsco, .agdb, .fmd, .fmdb, .fmd, .pmdb, .tgf, and .msh. To quickly import multiple CAD files, you can use basic wildcard expression patterns such as the * or ? wildcards. <a href="import_cad_and_part_management">More...</a>
             </p>
          </sect2>
          <sect2 id="enabledirtycad_partmanagement_lengthunit">
@@ -1518,6 +1580,10 @@
          <sect2 id="enabledirtycad_partmanagement_partperbody">
             <h3>Part per body</h3>
             <p>Enable this option to make all bodies available as individual parts in the CAD Model tree once the CAD file is loaded into the task.</p>
+         </sect2>
+         <sect2 id="enabledirtycad_partmanagement_prefixparentname">
+            <h3>Prefix component name</h3>
+            <p>This applies the name of the component (or assembly) as a prefix to the individual part names when the geometry is loaded into the task.</p>
          </sect2>
          <sect2 id="enabledirtycad_partmanagement_edgeextraction">
             <h3>Extract Edges</h3>
@@ -1568,6 +1634,14 @@
             <h3>Prefix object name to zone name</h3>
             <p>Append the name of the object to the beginning of the name of the zone.</p>
          </sect2>
+         <sect2 id="enabledirtycad_partmanagement_mergechildren">
+            <h3>Merge all children</h3>
+            <p>This option is only available when there are nested objects in the Meshing Model tree, and you want to assign object property settings to the top-level object. Upon updating the task, disabling this option ensures that each nested sub-object becomes its own geometry object, whereas enabling this option merges all child sub-objects into a single geometry object. </p>
+         </sect2>
+         <sect2 id="enabledirtycad_partmanagement_usedefaultsettings">
+            <h3>Use default settings for sub-objects</h3>
+            <p>This option is only available when there are nested objects in the Meshing Model tree, and you want to assign object property settings to the top-level object. Upon updating the task, enabling this option applies the top-level (or the default) object settings to all child sub-objects, whereas disabling this option lets you define separate object settings for your individual sub-objects.</p>
+         </sect2>
          <sect2 id="enabledirtycad_partmanagement_global">
             <h3>Coordinate System</h3>
             <p>Specify whether to apply the transformation to the <b>Local</b> or <b>Global</b> coordinate system. The local coordinate system is one that is associated with the individual CAD geometry as it is being created, where one chooses to re-orient that CAD sketch and create the model. Its orientation can vary based on its placement in an assembly of the entire model (for example, tires for a car). The global coordinate system has a fixed orientation, whereas the local coordinate system will have a different orientation. If, however, the CAD part was created without changing the coordinate systems, then there will be no difference between the local and global coordinate systems. </p>
@@ -1599,6 +1673,50 @@
          <sect2 id="enabledirtycad_partmanagement_translatez">
             <h3>Translate (Z)</h3>
             <p>Specify the distance (using display units) along the Z axis to apply the translation.</p>
+         </sect2>
+         <sect2 id="enabledirtycad_partmanagement_rotateaboutaxis_angle">
+            <h3>Angle</h3>
+            <p>specify a rotational angle (in degrees) of transformation.</p>
+         </sect2>
+         <sect2 id="enabledirtycad_partmanagement_rotateaboutaxis_pivotx">
+            <h3>Pivot (X)</h3>
+            <p>Specify the X coordinate (using display units) of the pivot point, based on the specified coordinate system. </p>
+         </sect2>
+         <sect2 id="enabledirtycad_partmanagement_rotateaboutaxis_pivoty">
+            <h3>Pivot (Y)</h3>
+            <p>Specify the Y coordinate (using display units) of the pivot point, based on the specified coordinate system. </p>
+         </sect2>
+         <sect2 id="enabledirtycad_partmanagement_rotateaboutaxis_pivotz">
+            <h3>Pivot (Z)</h3>
+            <p>Specify the Z coordinate (using display units) of the pivot point, based on the specified coordinate system. </p>
+         </sect2>
+         <sect2 id="enabledirtycad_partmanagement_rotateaboutaxis_axisx">
+            <h3>Axis (X)</h3>
+            <p>Specify the X component of the rotational axis, based on the specified coordinate system. </p>
+         </sect2>
+         <sect2 id="enabledirtycad_partmanagement_rotateaboutaxis_axisy">
+            <h3>Axis (Y)</h3>
+            <p>Specify the Y component of the rotational axis, based on the specified coordinate system.</p>
+         </sect2>
+         <sect2 id="enabledirtycad_partmanagement_rotateaboutaxis_axisz">
+            <h3>Axis (Z)</h3>
+            <p>Specify the Z component of the rotational axis, based on the specified coordinate system.</p>
+         </sect2>
+         <sect2 id="enabledirtycad_partmanagement_scaling_scalex">
+            <h3>Scale (X)</h3>
+            <p>Specify the X component of the scale factor, based on the specified coordinate system.</p>
+         </sect2>
+         <sect2 id="enabledirtycad_partmanagement_scaling_scaley">
+            <h3>Scale (Y)</h3>
+            <p>Specify the Y component of the scale factor, based on the specified coordinate system.</p>
+         </sect2>
+         <sect2 id="enabledirtycad_partmanagement_scaling_scalez">
+            <h3>Scale (Z)</h3>
+            <p>Specify the Z component of the scale factor, based on the specified coordinate system.</p>
+         </sect2>
+         <sect2 id="enabledirtycad_partmanagement_mirror_mirrorabout">
+            <h3>Mirror About</h3>
+            <p>Specify the plane about which the geometry will be mirrored (either <b>XY</b>, <b>YZ</b>, or <b>ZX</b>).</p>
          </sect2>
          <sect2 id="enabledirtycad_describegeometryandflow">
             <h3>Describe Geometry And Flow</h3>
@@ -1701,17 +1819,17 @@
          </sect2>
          <sect2 id="enabledirtycad_createexternalflowboundaries_objectselectionsingle">
             <h3>Objects</h3>
-            <p>Choose a single object from the list below. Use the <b>Filter Text</b> drop-down to provide text and/or regular expressions in filtering the list (for example, using *, ?, and []). Choose <b>Use Wildcard</b> to provide wildcard expressions in filtering the list. When you use either ? or * in your expression, the matching list item(s) are automatically selected in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
+            <p>Choose a single object from the list below. Use the <b>Filter Text</b> field to provide text and/or regular expressions in filtering the list. The matching list item(s) are automatically displayed in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
             </p>
          </sect2>
          <sect2 id="enabledirtycad_createexternalflowboundaries_zoneselectionsingle">
             <h3>Zones</h3>
-            <p>Choose a single zone from the list below. Use the <b>Filter Text</b> drop-down to provide text and/or regular expressions in filtering the list (for example, using *, ?, and []). Choose <b>Use Wildcard</b> to provide wildcard expressions in filtering the list. When you use either ? or * in your expression, the matching list item(s) are automatically selected in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
+            <p>Choose a single zone from the list below. Use the <b>Filter Text</b> field to provide text and/or regular expressions in filtering the list. The matching list item(s) are automatically displayed in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
             </p>
          </sect2>
          <sect2 id="enabledirtycad_createexternalflowboundaries_labelselectionsingle">
             <h3>Labels</h3>
-            <p>Choose a single label from the list below. Use the <b>Filter Text</b> drop-down to provide text and/or regular expressions in filtering the list (for example, using *, ?, and []). Choose <b>Use Wildcard</b> to provide wildcard expressions in filtering the list. When you use either ? or * in your expression, the matching list item(s) are automatically selected in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
+            <p>Choose a single label from the list below. Use the <b>Filter Text</b> field to provide text and/or regular expressions in filtering the list. The matching list item(s) are automatically displayed in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
             </p>
          </sect2>
          <sect2 id="enabledirtycad_createexternalflowboundaries_boundingboxobject">
@@ -1932,17 +2050,17 @@
          </sect2>
          <sect2 id="enabledirtycad_identifyconstructionsurfaces_objectselectionsingle">
             <h3>Object</h3>
-            <p>Choose a single object from the list below. Use the <b>Filter Text</b> drop-down to provide text and/or regular expressions in filtering the list (for example, using *, ?, and []). When you use either ? or * in your expression, the matching list item(s) are automatically selected in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
+            <p>Choose a single object from the list below. Use the <b>Filter Text</b> field to provide text and/or regular expressions in filtering the list. The matching list item(s) are automatically displayed in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
             </p>
          </sect2>
          <sect2 id="enabledirtycad_identifyconstructionsurfaces_zoneselectionsingle">
             <h3>Zone</h3>
-            <p>Choose a single zone from the list below. Use the <b>Filter Text</b> drop-down to provide text and/or regular expressions in filtering the list (for example, using *, ?, and []). When you use either ? or * in your expression, the matching list item(s) are automatically selected in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
+            <p>Choose a single zone from the list below. Use the <b>Filter Text</b> field to provide text and/or regular expressions in filtering the list. The matching list item(s) are automatically displayed in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
             </p>
          </sect2>
          <sect2 id="enabledirtycad_identifyconstructionsurfaces_labelselectionsingle">
             <h3>Label</h3>
-            <p>Choose a single label from the list below. Use the <b>Filter Text</b> drop-down to provide text and/or regular expressions in filtering the list (for example, using *, ?, and []). When you use either ? or * in your expression, the matching list item(s) are automatically selected in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
+            <p>Choose a single label from the list below. Use the <b>Filter Text</b> field to provide text and/or regular expressions in filtering the list. The matching list item(s) are automatically displayed in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
             </p>
          </sect2>
          <sect2 id="enabledirtycad_identifyconstructionsurfaces_objectselectionlist">
@@ -2028,7 +2146,7 @@
          </sect2>
          <sect2 id="enabledirtycad_createporousregions_inputmethod">
             <h3>Creation Method</h3>
-            <p>Indicate whether you are creating the porous region using <b>Direct coordinates</b>, or by using a <b>Text file</b>.</p>
+            <p>Indicate whether you are creating the porous region using <b>Direct coordinates</b>, by using a <b>Text file</b>, or by specifying a <b>Nonrectangular</b> region.</p>
          </sect2>
          <sect2 id="enabledirtycad_createporousregions_filename">
             <h3>File Name</h3>
@@ -2069,7 +2187,11 @@
          </sect2>
          <sect2 id="enabledirtycad_createporousregions_buffersize">
             <h3>Buffer Size</h3>
-            <p>Specify a value for the buffer size ratio. The buffer is created as an extra layer. The thickness is equivalent to the product of the buffer size ratio and the core thickness. The core thickness is the distance between P1 and P4.</p>
+            <p>Specify a value for the buffer size. The buffer is created as an extra layer. The thickness is equivalent to the product of the buffer size ratio and the core thickness. The core thickness is the distance between P1 and P4.</p>
+         </sect2>
+         <sect2 id="enabledirtycad_createporousregions_nonrectangularbuffersize">
+            <h3>Buffer Size</h3>
+            <p>Specify a value for the buffer size of the nonrectangular porous region. The buffer is created as an extra layer.</p>
          </sect2>
          <sect2 id="enabledirtycad_createporousregions_meshsize">
             <h3>Mesh Size</h3>
@@ -2077,11 +2199,11 @@
          </sect2>
          <sect2 id="enabledirtycad_createporousregions_thickness">
             <h3>Thickness</h3>
-            <p>Specify the total height of the porous region.</p>
+            <p>Specify the thickness (or the total height) of the porous region.</p>
          </sect2>
          <sect2 id="enabledirtycad_createporousregions_numberoflayers">
             <h3>Number of Layers</h3>
-            <p>Specify the number of porous layers.</p>
+            <p>Specify the number of layers, or divisions, along the thickness of the porous region.</p>
          </sect2>
          <sect2 id="enabledirtycad_createporousregions_featureangle">
             <h3>Feature Extraction Angle</h3>
@@ -2092,18 +2214,19 @@
             <p>Choose how you want to make your selection (by object, zone, or label).</p>
          </sect2>
          <sect2 id="enabledirtycad_createporousregions_objectselectionlist">
-            <h3>Objects</h3>
-            <p>Choose one or more objects (or voids) from the list below. Use the <b>Filter Text</b> drop-down to provide text and/or regular expressions in filtering the list (for example, using *, ?, and []). Choose <b>Use Wildcard</b> to provide wildcard expressions in filtering the list. When you use either ? or * in your expression, the matching list item(s) are automatically selected in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
+            <h3>Object</h3>
+            <p>Choose a single object (or void) from the list below. Use the <b>Filter Text</b> field to provide text and/or regular expressions in filtering the list. The matching list item(s) are automatically displayed in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
             </p>
          </sect2>
          <sect2 id="enabledirtycad_createporousregions_zoneselectionlist">
-            <h3>Zones</h3>
-            <p>Choose one or more face zones from the list below. Use the <b>Filter Text</b> drop-down to provide text and/or regular expressions in filtering the list (for example, using *, ?, and []). Choose <b>Use Wildcard</b> to provide wildcard expressions in filtering the list. When you use either ? or * in your expression, the matching list item(s) are automatically selected in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
+            <h3>Zone</h3>
+            <p>Choose a single face zone from the list below. Use the <b>Filter Text</b> field to provide text and/or regular expressions in filtering the list. The matching list item(s) are automatically displayed in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
             </p>
          </sect2>
          <sect2 id="enabledirtycad_createporousregions_labelselectionlist">
-            <h3>Labels</h3>
-            <p>Select one or more labels that will correspond to the porous region.</p>
+            <h3>Label</h3>
+            <p>Select a single label that will correspond to the porous region. Use the <b>Filter Text</b> field to provide text and/or regular expressions in filtering the list. The matching list item(s) are automatically displayed in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
+            </p>
          </sect2>
          <sect2 id="enabledirtycad_createporousregions_flipdirection">
             <h3>Flip</h3>
@@ -2135,6 +2258,11 @@
          <sect2 id="enabledirtycad_createlocalrefinementregions_objectselectionlist">
             <h3>Zones</h3>
             <p>Choose one or more zones from the list below. Use the <b>Filter Text</b> drop-down to provide text and/or regular expressions in filtering the list (for example, using *, ?, and []). Choose <b>Use Wildcard</b> to provide wildcard expressions in filtering the list. When you use either ? or * in your expression, the matching list item(s) are automatically selected in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
+            </p>
+         </sect2>
+         <sect2 id="enabledirtycad_createlocalrefinementregions_objectselectionsingle">
+            <h3>Object</h3>
+            <p>Choose a single object from the list below. Use the <b>Filter Text</b> field to provide text and/or regular expressions in filtering the list. The matching list item(s) are automatically displayed in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
             </p>
          </sect2>
          <sect2 id="enabledirtycad_createlocalrefinementregions_labelselectionlist">
@@ -2370,7 +2498,7 @@
          </sect2>
          <sect2 id="enabledirtycad_choosemeshcontroloptions_wraptargetbothoptions">
             <h3>Compute Size Field For</h3>
-            <p>Determine how the size controls are calculated in the <b>Add Local Sizing</b> task: using <b>Both Wrap and Target</b> values (the default), by <b>Target Only</b>, or by <b>Wrap Only</b>. For complex models, computational expense can be lowered by choosing one of the other options. If either <b>Wrap Only</b> or <b>Target Only</b> is selected, then the other values are determined using the <b>Wrap/Target Size Ratio</b> value.</p>
+            <p>Determine how the size controls are calculated in the <b>Add Local Sizing</b> task: using <b>Both Wrap and Target</b> values, by <b>Target Only</b> (the default), or by <b>Wrap Only</b>. For complex models, computational expense can be lowered by choosing one of the other options. If either <b>Wrap Only</b> or <b>Target Only</b> is selected, then the other values are determined using the <b>Wrap/Target Size Ratio</b> value.</p>
          </sect2>
          <sect2 id="enabledirtycad_choosemeshcontroloptions_wraptargetraio">
             <h3>Wrap/Target Size Control Ratio</h3>
@@ -2378,7 +2506,7 @@
          </sect2>
          <sect2 id="enabledirtycad_choosemeshcontroloptions_existingsizefield">
             <h3>Existing Size Field For</h3>
-            <p>Determine which existing size field files will be used: <b>Both Wrap and Target</b> (the default), <b>Target Only</b>, or <b>Wrap Only</b>. For complex models, computational expense can be lowered by choosing one of the other options. If either <b>Target Only</b> or <b>Target Only</b> is selected, then the other values are determined using the <b>Wrap/Target Size Ratio</b> value.</p>
+            <p>Determine which existing size field files will be used: <b>Both Wrap and Target</b> (the default), <b>Target Only</b>, or <b>Wrap Only</b>. For complex models, computational expense can be lowered by choosing one of the other options. If either <b>Wrap Only</b> or <b>Target Only</b> is selected, then the other values are determined using the <b>Wrap/Target Size Ratio</b> value.</p>
          </sect2>
          <sect2 id="enabledirtycad_choosemeshcontroloptions_targesizefieldfilename">
             <h3>Target Size Field File</h3>
@@ -2570,7 +2698,7 @@
          </sect2>
          <sect2 id="enabledirtycad_defineleakagethreshold_regionselectionsingle">
             <h3>Identified Regions</h3>
-            <p>Choose one or more regions from the list of identified regions below. Use the <b>Filter Text</b> drop-down to provide text and/or regular expressions in filtering the list (for example, using *, ?, and []). Choose <b>Use Wildcard</b> to provide wildcard expressions in filtering the list. When you use either ? or * in your expression, the matching list item(s) are automatically selected in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
+            <p>Choose a single region from the list of identified regions below. Use the <b>Filter Text</b> field to provide text and/or regular expressions in filtering the list. The matching list item(s) are automatically displayed in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
             </p>
          </sect2>
          <sect2 id="enabledirtycad_setupboundarylayers">
@@ -2731,6 +2859,10 @@
             <p>Specify a value for the minimum dihedral angle for the specified region. A dihedral angle of 30 degrees are recommended or use the default value. You should not exceed 30 degrees. <img src="graphics/g_flu_ug_workflows_dihedral_angle_example.png"/>
             </p>
          </sect2>
+         <sect2 id="enabledirtycad_generatethesurfacemeshftm_projectongeometry">
+            <h3>Project on Geometry of the CFD Surface Mesh Objects?</h3>
+            <p>Determine whether, after surface meshing, Fluent will project the mesh nodes back onto to the original CAD model.</p>
+         </sect2>
          <sect2 id="enabledirtycad_generatethesurfacemeshftm_surfacequality">
             <h3>Surface Mesh Target Skewness</h3>
             <p>This is the target maximum surface mesh quality. The recommended value is between 0.7 and 0.85. <img src="graphics/g_flu_ug_workflows_surf_mesh_target_skewness_example.png"/>
@@ -2758,6 +2890,11 @@
             <p>Choose whether or not to extend or expand the surface mesh into any interior pockets or cavities. <img src="graphics/g_flu_ug_workflows_surf_mesh_inner_wrap_example2.png"/>
             </p>
          </sect2>
+         <sect2 id="enabledirtycad_generatethesurfacemeshftm_gapcoverzonerecovery">
+            <h3>Gap-Cover Zone Recovery</h3>
+            <p>Determine whether or not to keep or remove the zones representing the cap covers. When set to <b>Yes</b>, the zones representing the gap covers are retained, whereas when set to <b>No</b> (the default), the zones for the gap covers are removed. <img src="graphics/g_flu_ug_workflows_surf_mesh_gap_zone_example.png"/>
+            </p>
+         </sect2>
          <sect2 id="enabledirtycad_generatethesurfacemeshftm_globalmin">
             <h3>Global Minimum</h3>
             <p>Specify a global minimum value for the surface mesh. The default minimum value is calculated based on available target and wrap size controls and bodies of influence. <img src="graphics/g_flu_ug_workflows_surf_mesh_global_min_example2.png"/>
@@ -2775,20 +2912,24 @@
             <p>Specify a name for the gap cover object, or retain the default name.</p>
          </sect2>
          <sect2 id="enabledirtycad_creategapcover_gapsizeratio">
-            <h3>Gap Size Ratio</h3>
-            <p>Specify a value for the gap size ratio that, when multiplied by the local initial size field, corresponds to the size of the gap that needs to be covered.</p>
+            <h3>Max Gap Size Factor</h3>
+            <p>Specify a value for the gap size factor that, when multiplied by the local initial size field, corresponds to the size of the gap that needs to be covered.</p>
          </sect2>
          <sect2 id="enabledirtycad_creategapcover_sizingmethod">
-            <h3>Sizing Method</h3>
-            <p>Determine the method for specifying the gap cover sizing controls. The <b>Use Size Controls</b> option uses the control settings defined in the <b>Choose Mesh Controls</b> task. Using the <b>Fixed</b> option requires you to provide a value for the <b>Fixed Gap Size</b>. If this task is located at a point in the workflow prior to the <b>Choose Mesh Control Options</b> task, then only the <b>Fixed</b> option is available.</p>
+            <h3>Method</h3>
+            <p>Determine the method for specifying the gap cover sizing controls. The <b>Wrapper Based on Size Field</b> option uses the size field control settings defined in the <b>Choose Mesh Controls</b> task. Using the <b>FiUniform Wrapperxed</b> option requires you to provide a value for the <b>Max Gap Size</b>. If this task is located at a point in the workflow prior to the <b>Choose Mesh Control Options</b> task, then only the <b>Uniform Wrapper</b> option is available.</p>
          </sect2>
          <sect2 id="enabledirtycad_creategapcover_gapsize">
-            <h3>Fixed Gap Size</h3>
-            <p>A specified fixed width for the gap.</p>
+            <h3>Max Gap Size</h3>
+            <p>A specified maximum width for the gap.</p>
          </sect2>
          <sect2 id="enabledirtycad_creategapcover_selectiontype">
             <h3>Select By</h3>
             <p>Choose how you want to make your selection (for instance, by object name, zone name, or label name).</p>
+         </sect2>
+         <sect2 id="enabledirtycad_creategapcover_advancedoptions">
+            <h3>Advanced Options</h3>
+            <p>Display advanced options that you may want to apply to the task.</p>
          </sect2>
          <sect2 id="enabledirtycad_creategapcover_objectselectionlist">
             <h3>Objects</h3>
@@ -2804,6 +2945,22 @@
             <h3>Labels</h3>
             <p>Select one or more labels that represent the contact source. Use the <b>Filter Text</b> field to provide text and/or regular expressions in filtering the list (for example, using *, ?, and []). Choose <b>Use Wildcard</b> to provide wildcard expressions in filtering the list. When you use either ? or * in your expression, the matching list item(s) are automatically selected in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
             </p>
+         </sect2>
+         <sect2 id="enabledirtycad_creategapcover_gapcoverbetweenzones">
+            <h3>Only Between Zones</h3>
+            <p>Determine if you only want to cover gaps between boundary zones (<b>Yes</b>), or if you want to cover all gaps within and between boundary zones (<b>No</b>)</p>
+         </sect2>
+         <sect2 id="enabledirtycad_creategapcover_gapcoverrefinefactor">
+            <h3>Resolution Factor</h3>
+            <p>Allows you to control the resolution of the gap cover size based on a scaling of the <b>Max Gap Size</b> (or <b>Max Gap Size Factor</b>). It ranges from 0.0625 to 1 with a default value of 1.0). The higher the <b>Resolution Factor</b>, the more likely that some gaps may not be fully covered. Depending on the gap in question, lowering the <b>Resolution Factor</b> reduces the wrapper to sufficiently cover the gap in most cases.</p>
+         </sect2>
+         <sect2 id="enabledirtycad_creategapcover_maxislandfaceforgapcover">
+            <h3>Maximum Number of Island Faces</h3>
+            <p>Specify the maximum face count required for isolated areas (islands) to be created during surface mesh generation. Any islands that have a face count smaller than this value will be removed, and only larger islands will remain.</p>
+         </sect2>
+         <sect2 id="enabledirtycad_creategapcover_gapcoverfeatureimprint">
+            <h3>Project Nodes on Edge Features?</h3>
+            <p>Use this option to better define gap coverings. When this option is set to <b>Yes</b>, the gap covers are more accurate. Once the coarse wrap closes any gaps, this option also snaps the nodes of the wrapper onto all previously defined edge features to more closely cover the gaps. Setting this option to <b>Yes</b>, however, can be computationally expensive when modeling large vehicles (such as in aerospace), thus, the default is <b>No</b>. <img src="graphics/g_flu_ug_workflows_gap_project_nodes_example.png"/> Here, when set to <b>No</b>, wrapper faces at the corners are not on the geometry and are incorrectly marked as a gap. When set to <b>Yes</b>, only wrap faces at the gap are marked.</p>
          </sect2>
          <sect2 id="enabledirtycad_createcontactpatch">
             <h3>Create Contact Patch</h3>
@@ -2909,6 +3066,10 @@
             <h3>Overlay With</h3>
             <p>Determine how you want the deviated faces to be displayed (either with the mesh or with the geometry).</p>
          </sect2>
+         <sect2 id="enabledirtycad_identifydeviatedfaces_includegapcovergeometry">
+            <h3>Include Gap Cover Geometry</h3>
+            <p>Determine if you want to include any gap covers in the check for deviated faces. If so, the default minimum and maximum deviation range is automatically calculated.</p>
+         </sect2>
          <sect2 id="enabledirtycad_generatethevolumemeshftm">
             <h3>Generate the Volume Mesh</h3>
             <p>This task will generate the volume mesh for all the fluid regions. It will generate the cell type based on the selection from the <b>Volume Fill</b> setting in the <b>Update Region Settings </b> task. Boundary layer prisms will also be generated if assigned for the fluid region. Use the <b>Edit Volume Fill Setting</b> option to view previous settings and edit them accordingly prior to creating the volume mesh.</p>
@@ -2937,6 +3098,35 @@
          <sect2 id="enabledirtycad_generatethevolumemeshftm_orthogonalquality">
             <h3>Quality Improve Limit</h3>
             <p>This value sets the threshold for when mesh quality improvements are automatically invoked that employ the orthogonal quality limit, and is recommended to be around 0.04.</p>
+         </sect2>
+         <sect2 id="enabledirtycad_generatethevolumemeshftm_octreepeellayers">
+            <h3>Octree Peel Layers</h3>
+            <p>Specify the number of octree layers to be removed between the boundary and the core. The resulting cavity will be filled with tet cells for hexcore meshes and with poly cells for polyhexcore meshes.  <img src="graphics/g_flu_ug_workflows_vol_peel_example.png"/>
+            </p>
+         </sect2>
+         <sect2 id="enabledirtycad_generatethevolumemeshftm_fillwithsizefield">
+            <h3>Use Size Field</h3>
+            <p>Determine whether or not you want to use size fields when generating the volume mesh. Generating the volume mesh using size fields can require additional memory as you increase the number of processing cores. This is because the size field is replicated for each core as the size field is not properly distributed. When using size fields, you are limited by the size of the machine. When not using size fields, however, you require less memory and you can use a higher number of cores with limited RAM, leading to a faster mesh generation.</p>
+         </sect2>
+         <sect2 id="enabledirtycad_generatethevolumemeshftm_octreeboundaryfacesizeratio">
+            <h3>Octree/Boundary Size Ratio</h3>
+            <p>Specify the ratio between the octree face size and the boundary face size. The default is 2.5 such that the octree mesh near the boundary is 2.5 times larger than the boundary mesh. <img src="graphics/g_flu_ug_workflows_vol_oct_ratio_example.png"/>
+            </p>
+         </sect2>
+         <sect2 id="enabledirtycad_generatethevolumemeshftm_globalbufferlayers">
+            <h3>Buffer Layers</h3>
+            <p>Specify the number of buffer layers for the octree volume mesh. If size controls have not been defined previously, then the default is 2, otherwise the default is calculated based on the maximum growth size. <img src="graphics/g_flu_ug_workflows_vol_buff_layers_example.png"/>
+            </p>
+         </sect2>
+         <sect2 id="enabledirtycad_generatethevolumemeshftm_tetpolygrowthrate">
+            <h3>Tet/Poly Growth Rate</h3>
+            <p>Specify the maximum growth rate for tet and poly cells. By default, this corresponds to a growth rate of 1.2. <img src="graphics/g_flu_ug_workflows_vol_tp_growth_rate_example.png"/>
+            </p>
+         </sect2>
+         <sect2 id="enabledirtycad_generatethevolumemeshftm_conformalprismsplit">
+            <h3>Conformal Prism Split</h3>
+            <p>Since neighboring zones with different numbers of layers will lead to conformal prism layers between them, use this field to determine whether you want to split the boundary layer cells conformally or not. When this option is set to <b>Yes</b>, the prism sides of the two zones will share nodes. This option is only available when stair-stepping is invoked. Note that adjacent regions should have an even ratio of prism layers when using this option. <img src="graphics/g_flu_ug_workflows_vol_tp_conf_split_example.png"/>
+            </p>
          </sect2>
          <sect2 id="enabledirtycad_updateboundaries">
             <h3>Update Boundaries</h3>
@@ -3138,11 +3328,13 @@
          </sect2>
          <sect2 id="enabledirtycad_createcollarmesh_objectselectionsingle">
             <h3>Objects</h3>
-            <p>Choose a single object from the list below. </p>
+            <p>Choose a single object from the list below. Use the <b>Filter Text</b> field to provide text and/or regular expressions in filtering the list. The matching list item(s) are automatically displayed in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
+            </p>
          </sect2>
          <sect2 id="enabledirtycad_createcollarmesh_edgeselectionlist">
             <h3>Edge Zone</h3>
-            <p>Choose a single edge zone from the list below for your edge-based collar mesh.</p>
+            <p>Choose a single edge zone from the list below for your edge-based collar mesh. Use the <b>Filter Text</b> field to provide text and/or regular expressions in filtering the list. The matching list item(s) are automatically displayed in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
+            </p>
          </sect2>
          <sect2 id="enabledirtycad_createcollarmesh_zoneselectionlist">
             <h3>Zones</h3>
@@ -3222,7 +3414,7 @@
          </sect2>
          <sect2 id="enabledirtycad_createcomponentmesh_objectselectionsingle">
             <h3>Objects</h3>
-            <p>Choose a single object from the list below. Use the <b>Filter Text</b> drop-down to provide text and/or regular expressions in filtering the list (for example, using *, ?, and []). Choose <b>Use Wildcard</b> to provide wildcard expressions in filtering the list. When you use either ? or * in your expression, the matching list item(s) are automatically selected in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
+            <p>Choose a single object from the list below. Use the <b>Filter Text</b> field to provide text and/or regular expressions in filtering the list. The matching list item(s) are automatically displayed in the list. Use ^, |, and &amp; in your expression to indicate boolean operations for NOT, OR, and AND, respectively. <a href="wf_using_wildcards"> More... </a>
             </p>
          </sect2>
          <sect2 id="enabledirtycad_createcomponentmesh_zoneselectionlist">
@@ -3365,6 +3557,14 @@
          <sect2 id="enabledirtycad_identifyorphans_overlapboundaries">
             <h3>Overlap Boundaries?</h3>
             <p>Determine if you need to account for any overlapping boundaries that may be present in your overset mesh (due to overlapping geometry and boundaries or those sometimes generated by collar meshes). You can improve the overset performance by setting this option to <b>no</b>.</p>
+         </sect2>
+         <sect2 id="enabledirtycad_identifyorphans_enablegridpriority">
+            <h3>Enable Grid Priorities</h3>
+            <p>Controls the ability to prioritize your overset grids (meshes). The priorities of the overset mesh are then carried over into the solver.</p>
+         </sect2>
+         <sect2 id="enabledirtycad_identifyorphans_checkoversetinterfaceintersection">
+            <h3>Check Overset Interface Intersection</h3>
+            <p>Enabled by default, Fluent checks for any overset interface intersections while identifying orphans. Disable this option to skip the intersection check and increase the speed of identifying orphans.</p>
          </sect2>
          <sect2 id="enabledirtycad_identifyorphans_numberoforphans">
             <h3>Number Of Orphans</h3>
@@ -3746,6 +3946,10 @@
             <h3>Use Wireframe</h3>
             <p>Toggle the display of the model in wireframe.</p>
          </sect2>
+         <sect2 id="twf_associatemesh_renamecellzones">
+            <h3>Modify Zone Names?</h3>
+            <p>Determines how your zones names appear once this task is complete, depending on your preferences. When set to <b>Yes, using row names</b>, this field will change the associated cell (or face) zone name according to the corresponding <b>Name</b>. When set to <b>Yes, using row numbers</b>, this field will change the associated cell (or face) zone name according to the corresponding <b>Row</b> number. You can also choose <b>No</b> to keep the zone names as they are.</p>
+         </sect2>
          <sect2 id="twf_createcfdmodel">
             <h3>Create CFD Model</h3>
             <p>Use this task to formally create the CFD model. For each blade row, specify the number of modeled passages (or sectors) per row. Make sure to first specify the <b>Axis of Rotation</b>. Use the graphics window to visually verify and ensure the CFD model is constructed properly.</p>
@@ -3755,8 +3959,8 @@
             <p>Specify the rotational axis for the generated CFD turbomachine geometry.</p>
          </sect2>
          <sect2 id="twf_createcfdmodel_restricttofactors">
-            <h3>Restrict To Factors</h3>
-            <p>Choose whether or not to restrict the number of model blades to a factor of the number of blades.</p>
+            <h3>Apply Sector Number Restrictions</h3>
+            <p>Choose whether or not to restrict the number of model blade sectors to a factor of the number of blades.</p>
          </sect2>
          <sect2 id="twf_mapregioninfo">
             <h3>Region Information</h3>
@@ -4502,7 +4706,7 @@
          </sect2>
          <sect2 id="flremote_remotesession_case_app_bc_airflowwall_thermalcondition">
             <h3>Thermal Conditions</h3>
-            <p>Choose the type of energy equation boundary conditions at the wall.</p>
+            <p>Choose the type of thermal conditions at the wall.</p>
          </sect2>
          <sect2 id="flremote_remotesession_case_app_bc_airflowwall_temperature">
             <h3>Temperature [K]</h3>
@@ -5006,7 +5210,7 @@
          </sect2>
          <sect2 id="flremote_remotesession_case_app_runtype_airflow">
             <h3>Airflow</h3>
-            <p>Select to include air flow effects as part of your simulation.</p>
+            <p>Select to include airflow effects as part of your simulation.</p>
          </sect2>
          <sect2 id="flremote_remotesession_case_app_runtype_particles">
             <h3>Particles</h3>
@@ -5788,6 +5992,98 @@ face values.</p>
          <sect2 id="flremote_remotesession_case_results_surfacedefs_pointsettings_z">
             <h3>Z</h3>
             <p>Specify the z-component of the point location.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_domain_frame">
+            <h3>Reference Frame (Single Domain)</h3>
+            <p>Choose between a Fixed or Rotating cell zone.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_domain_rotationspeed">
+            <h3>Speed [rev/min]</h3>
+            <p>Specify the rotational speed.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_domain_axisdirectionx">
+            <h3>Axis Direction X</h3>
+            <p>Specify the x-component of the rotation axis vector.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_domain_axisdirectiony">
+            <h3>Axis Direction Y</h3>
+            <p>Specify the y-component of the rotation axis vector.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_domain_axisdirectionz">
+            <h3>Axis Direction Z</h3>
+            <p>Specify the z-component of the rotation axis vector.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_ice_icingmodel_sheddingflag">
+            <h3>Ice Shedding</h3>
+            <p>Enables the Ice Shedding model.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_ice_conditions_surfaceinterface">
+            <h3>Ice - Surface Interface</h3>
+            <p>Choose the type of material on which the ice is accreting.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_ice_conditions_crackdetectioncriteria">
+            <h3>Crack Detection Criteria</h3>
+            <p>Choose the ice cracking detection criteria.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_ice_conditions_principalstrength">
+            <h3>Cohesive Tensile Strength [Pa]</h3>
+            <p>Specify the Cohesive Tensile Strength limit.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_ice_conditions_fracturetoughness">
+            <h3>Fracture Toughness [Pa.m^0.5]</h3>
+            <p>Specify the Fracture Toughness limit.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_ice_conditions_youngmodulus">
+            <h3>Youngs Modulus [Pa]</h3>
+            <p>Specify Young&#8217;s modulus for the ice material.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_ice_conditions_poissonratio">
+            <h3>Poissons Ratio</h3>
+            <p>Specify Poisson&#8217;s ratio for the ice material.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_bc_airflowwall_isrotating">
+            <h3>Rotating</h3>
+            <p>Select to set the wall as rotating.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_bc_airflowwall_rotationspeed">
+            <h3>Speed [rev/min]</h3>
+            <p>Specify the rotational speed.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_bc_airflowwall_referenceframe">
+            <h3>Reference Frame</h3>
+            <p>Choose a wall motion relative to the absolute reference frame or to the adjacent cell-zone.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_bc_airflowwall_axiscenterx">
+            <h3>Axis Origin X [m]</h3>
+            <p>Specify the x-position of the center of rotation.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_bc_airflowwall_axiscentery">
+            <h3>Axis Origin Y [m]</h3>
+            <p>Specify the y-position of the center of rotation.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_bc_airflowwall_axiscenterz">
+            <h3>Axis Origin Z [m]</h3>
+            <p>Specify the z-position of the center of rotation.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_bc_airflowwall_axisdirectionx">
+            <h3>Axis Direction X</h3>
+            <p>Specify the x-component of the rotation axis vector.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_bc_airflowwall_axisdirectiony">
+            <h3>Axis Direction Y</h3>
+            <p>Specify the y-component of the rotation axis vector.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_bc_airflowwall_axisdirectionz">
+            <h3>Axis Direction Z</h3>
+            <p>Specify the z-component of the rotation axis vector.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_solution_icerun_sheddingoutput_sheddinginterval">
+            <h3>Shedding Interval [s]</h3>
+            <p>Specify the time between shedding occurrences.</p>
+         </sect2>
+         <sect2 id="flremote_remotesession_case_app_solution_icerun_sheddingoutput_outputfiles">
+            <h3>Numbered Output Files</h3>
+            <p>Choose to create an output file for every shedding occurrence.</p>
          </sect2>
       </sect1>
    </article>
@@ -6842,7 +7138,7 @@ face values.</p>
          </sect2>
          <sect2 id="lbapp_remotesession_case_results_graphics_pathlines_coarsen">
             <h3>Coarsen</h3>
-            <p>help text for coarsen</p>
+            <p>Reduce the number of pathlines included in the display.</p>
          </sect2>
          <sect2 id="lbapp_remotesession_case_results_graphics_pathlines_pathlinesfield">
             <h3>Pathlines Field</h3>
@@ -6930,11 +7226,11 @@ face values.</p>
          </sect2>
          <sect2 id="lbapp_remotesession_case_results_graphics_pathlines_plot_xaxisfunction">
             <h3>X Axis Function</h3>
-            <p>help text for x axis function.</p>
+            <p>Lists the X-axis function.</p>
          </sect2>
          <sect2 id="lbapp_remotesession_case_results_graphics_pathlines_plot_enabled">
             <h3>Enabled</h3>
-            <p>help text for enabled.</p>
+            <p>Enable pathline plots.</p>
          </sect2>
          <sect2 id="lbapp_remotesession_case_results_graphics_pathlines_colormap_visible">
             <h3>Visible</h3>
@@ -7805,7 +8101,7 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_interfaceboundaryzone_fluidsolidinterface_chtwall_">
             <h3>Pressure Dependence</h3>
-            <p>Specify the wall pressure dependency as either exponential or linear.</p>
+            <p>Specify the pressure dependency of the slip model along the interface as either exponential or linear.</p>
          </sect2>
          <sect2 id="flmatpro_interfaceboundaryzone_fluidsolidinterface_chtwall_palfa">
             <h3>Alpha</h3>
@@ -7820,8 +8116,8 @@ face values.</p>
             <p>Select the cell zone(s) on which the condition for adaptive meshing applies</p>
          </sect2>
          <sect2 id="flmatpro_numericalcontrols_contactparameters_elementdilatationmode">
-            <h3>Element dilatation</h3>
-            <p>Select the mode for handling element dilation in contact detection such as Program controlled or User value.</p>
+            <h3>Element Dilatation</h3>
+            <p>Select the mode for handling element dilation in contact detection such as <b>Program controlled</b> or <b>User Value</b>.</p>
          </sect2>
          <sect2 id="flmatpro_general_meshfile">
             <h3>Mesh file</h3>
@@ -7841,11 +8137,11 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_general_geometrytype">
             <h3>Geometry Type</h3>
-            <p>Indicates the dimensionality of the geometry to be represented by the mesh file.</p>
+            <p>Indicates the dimensionality of the geometry to be represented by the mesh file. If the mesh is a 2D plane, the simulation may be planar (Vz equal to 0), channel (Vz not equal to 0), axisymmetric (Y axis being the axis of symmetry + Vw = 0),  swirling (axisymmetric, with the Y axis being the axis of symmetry + Vw not equal to 0) and film (planar + thickness(es)).  Note: Vw is the rotation velocity around the Y axis.</p>
          </sect2>
          <sect2 id="flmatpro_general_calculationtype">
             <h3>Calculation Type</h3>
-            <p>Indicates the specific type of calculation to be performed. Calculations can be <b>Steady</b>, <b>Continuation</b> and <b>Transient</b>.</p>
+            <p>Indicates the specific type of calculation to be performed. Calculations can be <b>Steady</b>, <b>Continuation</b>, <b>Transient</b>, or <b>Volume of Fluid</b> when you want to perform a transient simulation of a filling process.</p>
          </sect2>
          <sect2 id="flmatpro_general_taskname">
             <h3>Task name</h3>
@@ -7889,47 +8185,55 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_layerdefinition_layermaterial">
             <h3>Material</h3>
-            <p>help text for material</p>
+            <p>Specify the material to be used for a given layer.</p>
          </sect2>
          <sect2 id="flmatpro_layerdefinition_zoneid">
             <h3>Zones</h3>
-            <p>help text for zones</p>
+            <p>For film simulations, select one or more boundary zones to specify the inlet of the current layer. For shell simulations, select one or more cell zones to specify the support of the current layer.</p>
          </sect2>
-         <sect2 id="flmatpro_layerdefinition_comment">
-            <h3>Thickness H</h3>
-            <p>help text for thickness h</p>
+         <sect2 id="flmatpro_layerdefinition_option">
+            <h3>Option</h3>
+            <p>Define the current layer in terms of a thickness function <b>f(X,Y,Z)</b> (default), or as a <b>Thickness Profile</b> (CSV file).</p>
+         </sect2>
+         <sect2 id="flmatpro_layerdefinition_thicknesslabel">
+            <h3>Field Name</h3>
+            <p>Enter the name found in the CSV File for the thickness profile.</p>
+         </sect2>
+         <sect2 id="flmatpro_layerdefinition_thicknessprofile">
+            <h3>CSV File</h3>
+            <p>Use the <b>Load CSV File</b> button to browse for and select a comma-separated value file that can define the current layer.</p>
          </sect2>
          <sect2 id="flmatpro_layerdefinition_a">
             <h3>A</h3>
-            <p>help text for a</p>
+            <p>Specify the constant coefficient of the linear expression for the initial thickness.</p>
          </sect2>
          <sect2 id="flmatpro_layerdefinition_b">
             <h3>B</h3>
-            <p>help text for b</p>
+            <p>Specify the thickness gradient in the X direction of the linear expression for the initial thickness.</p>
          </sect2>
          <sect2 id="flmatpro_layerdefinition_c">
             <h3>C</h3>
-            <p>help text for c</p>
+            <p>Specify the thickness gradient in the Y direction of the linear expression for the initial thickness.</p>
          </sect2>
          <sect2 id="flmatpro_layerdefinition_d">
             <h3>D</h3>
-            <p>help text for d</p>
+            <p>Specify the thickness gradient in the Z direction of the linear expression for the initial thickness (only for shell simulations).</p>
          </sect2>
          <sect2 id="flmatpro_layerdefinition_stresscondition_activation">
             <h3>Activation</h3>
-            <p>help text for activation</p>
+            <p>Allows you to specify a stress condition at the inlet of a layer simulated with a DCPP viscoelastic model.</p>
          </sect2>
          <sect2 id="flmatpro_layerdefinition_stresscondition_directionofanisotropy">
             <h3>Direction of Anisotropy</h3>
-            <p>help text for direction of anisotropy</p>
+            <p>Specify the direction of anysotropy of the orientation tensor (x or y).</p>
          </sect2>
          <sect2 id="flmatpro_layerdefinition_stresscondition_anisotropyfactor">
             <h3>Anisotropy Factor</h3>
-            <p>help text for anisotropy factor</p>
+            <p>Specify the anisotropy factor ranging between 0 (isotropic) and 1 (anisotropic).</p>
          </sect2>
          <sect2 id="flmatpro_layerdefinition_stresscondition_stretching">
             <h3>Stretching</h3>
-            <p>help text for stretching</p>
+            <p>Specify the inlet stretching (a streching of 1 means no stretching).</p>
          </sect2>
          <sect2 id="flmatpro_material_visibility">
             <h3>View properties</h3>
@@ -8033,7 +8337,7 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_material_viscositylaw_power_expo">
             <h3>Power law index</h3>
-            <p>An index usually ranging between 0 and 1; it quantifies the rate of shear thinning.  On a log-log diagram, the index corresponds to the slope of shear stress curve vs. shear rate.  A value of 1 corresponds to a constant viscosity Newtonian fluid, while values lower than 1 indicate shear thinning. Using the drop-down menu, you can enter a constant value, or a valid expression (for transient, continuation, or volume of fluid simulations only).</p>
+            <p>An index usually ranging between 0 and 1; it quantifies the rate of shear thinning.  On a log-log diagram, the index corresponds to the slope of shear stress curve versus shear rate.  A value of 1 corresponds to a constant viscosity Newtonian fluid, while values lower than 1 indicate shear thinning. Using the drop-down menu, you can enter a constant value, or a valid expression (for transient, continuation, or volume of fluid simulations only).</p>
          </sect2>
          <sect2 id="flmatpro_material_viscositylaw_birdcarreau_fac">
             <h3>Zero shear viscosity</h3>
@@ -8073,7 +8377,7 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_material_viscositylaw_bingham_fac">
             <h3>Plastic viscosity</h3>
-            <p>On a linear diagram, the plastic viscosity indicates the slope of the shear stress curve vs. shear rate beyond the yield stress threshold.  It also corresponds to the asymptotic value of the shear viscosity at very high shear rate.</p>
+            <p>On a linear diagram, the plastic viscosity indicates the slope of the shear stress curve versus shear rate beyond the yield stress threshold.  It also corresponds to the asymptotic value of the shear viscosity at very high shear rate.</p>
          </sect2>
          <sect2 id="flmatpro_material_viscositylaw_bingham_ystr">
             <h3>Yield stress threshold</h3>
@@ -8085,7 +8389,7 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_material_viscositylaw_modifiedbingham_fac">
             <h3>Plastic viscosity</h3>
-            <p>On a linear diagram, the plastic viscosity indicates the slope of the shear stress curve vs. shear rate beyond the yield stress threshold.  It also corresponds to the asymptotic value of the shear viscosity at very high shear rate.</p>
+            <p>On a linear diagram, the plastic viscosity indicates the slope of the shear stress curve versus shear rate beyond the yield stress threshold.  It also corresponds to the asymptotic value of the shear viscosity at very high shear rate.</p>
          </sect2>
          <sect2 id="flmatpro_material_viscositylaw_modifiedbingham_ystr">
             <h3>Yield stress threshold</h3>
@@ -8101,11 +8405,11 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_material_viscositylaw_herschelbulkley_fac2">
             <h3>Consistency factor</h3>
-            <p>On a linear diagram, the consistency factor indicates the shear stress growth vs. shear rate beyond the yield stress threshold.</p>
+            <p>On a linear diagram, the consistency factor indicates the shear stress growth versus shear rate beyond the yield stress threshold.</p>
          </sect2>
          <sect2 id="flmatpro_material_viscositylaw_herschelbulkley_expo">
             <h3>Power law index</h3>
-            <p>On a linear diagram, the power law index indicates the change of slope of the shear stress growth vs. shear rate beyond the yield stress threshold. The rate of shear thinning increases when the index decreases down to 0. Using the drop-down menu, you can enter a constant value, or a valid expression (for transient, continuation, or volume of fluid simulations only).</p>
+            <p>On a linear diagram, the power law index indicates the change of slope of the shear stress growth versus shear rate beyond the yield stress threshold. The rate of shear thinning increases when the index decreases down to 0. Using the drop-down menu, you can enter a constant value, or a valid expression (for transient, continuation, or volume of fluid simulations only).</p>
          </sect2>
          <sect2 id="flmatpro_material_viscositylaw_herschelbulkley_gcrit">
             <h3>Critical shear rate</h3>
@@ -8117,11 +8421,11 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_material_viscositylaw_modifiedherschelbulkley_fac2">
             <h3>Consistency factor</h3>
-            <p>On a linear diagram, the consistency factor indicates the shear stress growth vs. shear rate beyond the yield stress threshold.</p>
+            <p>On a linear diagram, the consistency factor indicates the shear stress growth versus shear rate beyond the yield stress threshold.</p>
          </sect2>
          <sect2 id="flmatpro_material_viscositylaw_modifiedherschelbulkley_expo">
             <h3>Power law index</h3>
-            <p>On a linear diagram, the power law index indicates the change of slope of the shear stress growth vs. shear rate beyond the yield stress threshold. The rate of shear thinning increases when the index decreases down to 0. Using the drop-down menu, you can enter a constant value, or a valid expression (for transient, continuation, or volume of fluid simulations only).</p>
+            <p>On a linear diagram, the power law index indicates the change of slope of the shear stress growth versus shear rate beyond the yield stress threshold. The rate of shear thinning increases when the index decreases down to 0. Using the drop-down menu, you can enter a constant value, or a valid expression (for transient, continuation, or volume of fluid simulations only).</p>
          </sect2>
          <sect2 id="flmatpro_material_viscositylaw_modifiedherschelbulkley_gcrit">
             <h3>Critical shear rate</h3>
@@ -8177,7 +8481,7 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_material_viscositylaw_fulcher_f1">
             <h3>F1</h3>
-            <p>Coefficient that can be used for applying an overall vertical shift of the viscosity curve vs. temperature.  It is redundant with the zero shear viscosity.</p>
+            <p>Coefficient that can be used for applying an overall vertical shift of the viscosity curve versus temperature.  It is redundant with the zero shear viscosity.</p>
          </sect2>
          <sect2 id="flmatpro_material_viscositylaw_fulcher_f2">
             <h3>F2</h3>
@@ -8185,7 +8489,7 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_material_viscositylaw_fulcher_f3">
             <h3>F3</h3>
-            <p>Temperature corresponding to the vertical asymptote of the viscosity curve vs. temperature.  In other words, it is the temperature at which the model would predict an infinite viscosity, suggesting fusion or solidification.</p>
+            <p>Temperature corresponding to the vertical asymptote of the viscosity curve versus temperature.  In other words, it is the temperature at which the model would predict an infinite viscosity, suggesting fusion or solidification.</p>
          </sect2>
          <sect2 id="flmatpro_material_viscositylaw_wlf_c1">
             <h3>C1</h3>
@@ -8209,7 +8513,7 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_material_simplifiedviscoelasticlaw_weightingcoefficient">
             <h3>Weighting Coefficient</h3>
-            <p>At the first approximation, it controls the swelling intensity vs. flow rate. Use swelling-based experimental data to fine-tune the values for this property.</p>
+            <p>At the first approximation, it controls the swelling intensity versus flow rate. Use swelling-based experimental data to fine-tune the values for this property.</p>
          </sect2>
          <sect2 id="flmatpro_material_simplifiedviscoelasticlaw_shearviscosity_sheardependency">
             <h3>Shear-rate dependency model</h3>
@@ -8229,7 +8533,7 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_material_simplifiedviscoelasticlaw_shearviscosity_spower_expo">
             <h3>Power law index</h3>
-            <p>An index usually ranging between 0 and 1; it quantifies the rate of shear thinning.  On a log-log diagram, the index corresponds to the slope of shear stress curve vs. shear rate.  A value of 1 corresponds to a constant viscosity Newtonian fluid, while values lower than 1 indicate shear thinning. Using the drop-down menu, you can enter a constant value, or a valid expression (for transient, continuation, or volume of fluid simulations only).</p>
+            <p>An index usually ranging between 0 and 1; it quantifies the rate of shear thinning.  On a log-log diagram, the index corresponds to the slope of shear stress curve versus shear rate.  A value of 1 corresponds to a constant viscosity Newtonian fluid, while values lower than 1 indicate shear thinning. Using the drop-down menu, you can enter a constant value, or a valid expression (for transient, continuation, or volume of fluid simulations only).</p>
          </sect2>
          <sect2 id="flmatpro_material_simplifiedviscoelasticlaw_shearviscosity_sbirdcarreau_fac">
             <h3>Zero first normal viscosity</h3>
@@ -8309,7 +8613,7 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_material_simplifiedviscoelasticlaw_firstnormalviscosity_fnpower_expo">
             <h3>Power law index</h3>
-            <p>An index usually ranging between 0 and 1; it quantifies the rate of shear thinning.  On a log-log diagram, the index corresponds to the slope of shear stress curve vs. pseudo shear rate.  A value of 1 corresponds to a constant normal viscosity Newtonian fluid, while values lower than 1 indicate shear thinning. Using the drop-down menu, you can enter a constant value, or a valid expression (for transient, continuation, or volume of fluid simulations only).</p>
+            <p>An index usually ranging between 0 and 1; it quantifies the rate of shear thinning.  On a log-log diagram, the index corresponds to the slope of shear stress curve versus pseudo shear rate.  A value of 1 corresponds to a constant normal viscosity Newtonian fluid, while values lower than 1 indicate shear thinning. Using the drop-down menu, you can enter a constant value, or a valid expression (for transient, continuation, or volume of fluid simulations only).</p>
          </sect2>
          <sect2 id="flmatpro_material_simplifiedviscoelasticlaw_firstnormalviscosity_fnbirdcarreau_fac">
             <h3>Zero first normal viscosity</h3>
@@ -9392,6 +9696,10 @@ face values.</p>
             <h3>Activate</h3>
             <p>Enable this option to activate the foaming properties of the fluid cell zone.</p>
          </sect2>
+         <sect2 id="flmatpro_cellzone_foaming_activable">
+            <h3>Not Available</h3>
+            <p>Displays a message describing when this feature is available.</p>
+         </sect2>
          <sect2 id="flmatpro_cellzone_foaming_freezing">
             <h3>Enable Freezing</h3>
             <p>Enable this option to freeze the bubble radius on some parts of your fluid domain. Freezing the bubble radius in the die is common practice as foaming should not occur in a well tuned extrusion die.</p>
@@ -9404,13 +9712,21 @@ face values.</p>
             <h3>Solid material</h3>
             <p>Specify a solid material for the cell zone.</p>
          </sect2>
+         <sect2 id="flmatpro_cellzone_deformablemold">
+            <h3>Deformable Mold</h3>
+            <p>Enabling this option will allow deformation of the mold.</p>
+         </sect2>
+         <sect2 id="flmatpro_cellzone_deformablepart">
+            <h3>Deformable Part</h3>
+            <p>Enabling this option will allow deformation of the part.</p>
+         </sect2>
          <sect2 id="flmatpro_cellzone_fluidmodel">
             <h3>Fluid model</h3>
-            <p>Specify a model for the fluid zone. Currently only <b>Generalized Newtonian</b> is supported.</p>
+            <p>Specify a model for the fluid zone. You can choose from <b>Generalized Newtonian</b>, <b>Simplified Viscoelastic</b>, or <b>Differential Viscoelastic</b>.</p>
          </sect2>
          <sect2 id="flmatpro_cellzone_solidmodel">
             <h3>Solid model</h3>
-            <p>Specify whether the solid is being modeled as <b>Inelastic</b>.</p>
+            <p>Specify whether the solid is being modeled as <b>Elastic</b> or <b>Inelastic</b>.</p>
          </sect2>
          <sect2 id="flmatpro_cellzone_moldmodel">
             <h3>Mold model</h3>
@@ -9535,6 +9851,10 @@ face values.</p>
          <sect2 id="flmatpro_cellzone_solidmotion_solidtranslationvelocity_vz">
             <h3>Vz</h3>
             <p>Specify a value for the Z-component of the translational velocity of the solid motion. Using the drop-down menu, you can enter a constant value, or a valid expression (for transient simulations only).</p>
+         </sect2>
+         <sect2 id="flmatpro_cellzone_soliddeformation_updatecoordinates">
+            <h3>Update coordinates</h3>
+            <p>When this option is disabled, coordinates of the solid mesh will not be updated during deformation.</p>
          </sect2>
          <sect2 id="flmatpro_cellzone_moldmotion_motiontype">
             <h3>Motion type</h3>
@@ -9678,7 +9998,7 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_cellzone_porousmedia_tensorpermeability_pzz">
             <h3>Pzz</h3>
-            <p>Specify the positive-definte Z-Z Cartesian components of the tensor permeability.</p>
+            <p>Specify the positive-definite Z-Z Cartesian components of the tensor permeability.</p>
          </sect2>
          <sect2 id="flmatpro_cellzone_volumeconservation_activation">
             <h3>Activation</h3>
@@ -9696,6 +10016,14 @@ face values.</p>
          <sect2 id="flmatpro_cellzone_matrixreinforcement_activation">
             <h3>Activation</h3>
             <p>For transient Generalized Newtonian fluid zones and 2d planar, shell or 3D problems, indicate the matrix reinforcement.</p>
+         </sect2>
+         <sect2 id="flmatpro_cellzone_matrixreinforcement_activable1">
+            <h3>Not Available (1)</h3>
+            <p>Displays a message describing when this feature is available.</p>
+         </sect2>
+         <sect2 id="flmatpro_cellzone_matrixreinforcement_activable2">
+            <h3>Not Available (2)</h3>
+            <p>Displays a message describing when this feature is available.</p>
          </sect2>
          <sect2 id="flmatpro_cellzone_inflationpressure_pressure">
             <h3>Inflation Pressure</h3>
@@ -9750,12 +10078,20 @@ face values.</p>
             <p>Choose a boundary for the outlet section of the extrudate remeshing zone.</p>
          </sect2>
          <sect2 id="flmatpro_deformationzone_inletsectionfordie">
-            <h3>Inlet Section</h3>
+            <h3>Inlet Section (Constant or Adaptive Die)</h3>
             <p>For constant or adaptive die sections, specify a boundary for the inlet section of the extrudate.</p>
          </sect2>
          <sect2 id="flmatpro_deformationzone_outletsectionfordie">
-            <h3>Outlet Section</h3>
+            <h3>Outlet Section (Constant or Adaptive Die)</h3>
             <p>For constant or adaptive die sections, specify a boundary for the outlet section of the extrudate.</p>
+         </sect2>
+         <sect2 id="flmatpro_deformationzone_deformationzonetype">
+            <h3>Type</h3>
+            <p>Allows you to choose from a list of available deformation zones types.</p>
+         </sect2>
+         <sect2 id="flmatpro_deformationzone_freedisplacement">
+            <h3>Free Displacement on Section</h3>
+            <p>Allows you to choose a list of boundary zones where mesh deformation will be free (no constraints of any type).</p>
          </sect2>
          <sect2 id="flmatpro_fluidboundaryzone_boundaryzonetype">
             <h3>Type</h3>
@@ -9850,19 +10186,19 @@ face values.</p>
             <p>For slip conditions, specify how the shear force is calculated with respect to the tangential relative velocity.  </p>
          </sect2>
          <sect2 id="flmatpro_fluidboundaryzone_wall_frictioncoefficientnavier">
-            <h3>Friction coefficient</h3>
+            <h3>Friction coefficient (Navier)</h3>
             <p>Specify the friction coefficient for the Navier law slip conditions. Using the drop-down menu, you can enter a constant value, or a valid expression (for transient, continuation, or volume of fluid simulations only).</p>
          </sect2>
          <sect2 id="flmatpro_fluidboundaryzone_wall_frictioncoefficientgeneralizednavier">
-            <h3>Friction coefficient</h3>
+            <h3>Friction coefficient (Navier)</h3>
             <p>Specify the friction coefficient for the Generalized Navier law slip conditions. Using the drop-down menu, you can enter a constant value, or a valid expression (for transient, continuation, or volume of fluid simulations only).</p>
          </sect2>
          <sect2 id="flmatpro_fluidboundaryzone_wall_scalingfactorgeneralizednavier">
-            <h3>Scaling Factor</h3>
+            <h3>Scaling factor (Generalized Navier)</h3>
             <p>Specify the scaling factor for the Generalized Navier law slip conditions.</p>
          </sect2>
          <sect2 id="flmatpro_fluidboundaryzone_wall_exponentgeneralizednavier">
-            <h3>Exponent</h3>
+            <h3>Exponent (Generalized Navier)</h3>
             <p>Specify the exponent for the Generalized Navier law slip conditions.</p>
          </sect2>
          <sect2 id="flmatpro_fluidboundaryzone_wall_firstfrictioncoefficient">
@@ -9874,7 +10210,7 @@ face values.</p>
             <p>Specify the second  friction coefficient for the slip conditions. Using the drop-down menu, you can enter a constant value, or a valid expression (for transient, continuation, or volume of fluid simulations only).</p>
          </sect2>
          <sect2 id="flmatpro_fluidboundaryzone_wall_frictioncoefficientasymptotic">
-            <h3>Friction coefficient</h3>
+            <h3>Friction coefficient (Asymptotic)</h3>
             <p>Specify the friction coefficient for the asymptotic slip conditions. Using the drop-down menu, you can enter a constant value, or a valid expression (for transient, continuation, or volume of fluid simulations only).</p>
          </sect2>
          <sect2 id="flmatpro_fluidboundaryzone_wall_scalingfactor">
@@ -10119,11 +10455,11 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_fluidboundaryzone_thermalcondition_minnormalvelocity">
             <h3>Minimum Normal Velocity</h3>
-            <p>help text for minimum normal velocity</p>
+            <p>Specify the minimum normal velocity. The local temperature will be imposed if the local velocity is entering the flow domain and if its magnitude is greater than this parameter.</p>
          </sect2>
          <sect2 id="flmatpro_fluidboundaryzone_thermalcondition_penaltycoefficient">
             <h3>Penalty Coefficient</h3>
-            <p>help text for penalty coefficient</p>
+            <p>Specify the penalty coefficient. The higher the penaly coefficient, the better the temperature will be imposed, however, the system to be solved becomes that much stiffer.</p>
          </sect2>
          <sect2 id="flmatpro_fluidboundaryzone_thermalcondition_temperatureprofile">
             <h3>CSV Filename</h3>
@@ -10135,7 +10471,7 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_solidboundaryzone_boundaryzonetype">
             <h3>Type</h3>
-            <p>Choose the type of boundary zone, such as Temperature, Insulated, Symmetry, Convection, Heat flux, Heat flux and convection, or Temperature profile. </p>
+            <p>Choose the type of solid boundary zone as Fixed, Free, Symmetry, Normal Displacement, Normal Force Density, Cartesian Displacement, or Force. </p>
          </sect2>
          <sect2 id="flmatpro_solidboundaryzone_boundaryzoneid">
             <h3>Boundary Zone</h3>
@@ -10168,6 +10504,90 @@ face values.</p>
          <sect2 id="flmatpro_solidboundaryzone_thermalcondition_temperaturelabel">
             <h3>Field Name</h3>
             <p>Identifies the temperature-related data to be loaded from the specified CSV file.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_normaldisplacementcondition_type">
+            <h3>Type</h3>
+            <p>Specify the normal displacement of the solid as constant or by importing a displacement profile.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_normaldisplacementcondition_dn">
+            <h3>Normal Displacement</h3>
+            <p>Specify the normal displacement of the solid.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_normaldisplacementcondition_dlabel">
+            <h3>Field Name</h3>
+            <p>Identifies the displacement-related data to be loaded from the specified CSV file.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_normaldisplacementcondition_csvfile">
+            <h3>CSV File</h3>
+            <p>Specify the name and location of the CSV file containing the displacement-related data.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_normaldisplacementcondition_freetangentialdisplacement">
+            <h3>Allow Non-Zero Tangential Displacement</h3>
+            <p>Deselecting this option forces the displacement to be strictly tangential to the solid.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_normaldisplacementcondition_profile">
+            <h3>Normal Displacement Condition</h3>
+            <p>Specify the normal displacement of a boundary of an elastic solid.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_normalforcedensitycondition_fn">
+            <h3>Normal Force Density</h3>
+            <p>Specify the normal force density applied on the solid surface.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_normalforcedensitycondition_freetangentialdisplacement">
+            <h3>Allow Non-Zero Tangential Displacement</h3>
+            <p>Deselecting this option forces the displacement to be strictly tangential to the solid.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_cartesiandisplacementcondition_point1_px">
+            <h3>X1</h3>
+            <p>Specify the X component of the rotation axis for the first point.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_cartesiandisplacementcondition_point1_py">
+            <h3>Y1</h3>
+            <p>Specify the y component of the rotation axis for the first point.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_cartesiandisplacementcondition_point1_pz">
+            <h3>Z1</h3>
+            <p>Specify the Z component of the rotation axis for the first point.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_cartesiandisplacementcondition_point2_px">
+            <h3>X2</h3>
+            <p>Specify the X component of the rotation axis for the second point.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_cartesiandisplacementcondition_point2_py">
+            <h3>Y2</h3>
+            <p>Specify the Y component of the rotation axis for the second point.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_cartesiandisplacementcondition_point2_pz">
+            <h3>Z2</h3>
+            <p>Specify the Z component of the rotation axis for the second point.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_cartesiandisplacementcondition_angulardisplacement_omega">
+            <h3>Angular Displacement</h3>
+            <p>Specify the angular displacement at which the solid is rotating about the axis defined by the two points Pt1 and Pt2.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_cartesiandisplacementcondition_translationdisplacement_tx">
+            <h3>Tx</h3>
+            <p>Specify the x-component of displacement of the solid due to translation.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_cartesiandisplacementcondition_translationdisplacement_ty">
+            <h3>Ty</h3>
+            <p>Specify the y-component of displacement of the solid due to translation.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_cartesiandisplacementcondition_translationdisplacement_tz">
+            <h3>Tz</h3>
+            <p>Specify the z-component of displacement of the solid due to translation.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_forcecondition_fx">
+            <h3>Fx</h3>
+            <p>Specify the x-component of force acting on the solid surface as constant or using an expression.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_forcecondition_fy">
+            <h3>Fy</h3>
+            <p>Specify the y-component of force acting on the solid surface as constant or using an expression.</p>
+         </sect2>
+         <sect2 id="flmatpro_solidboundaryzone_forcecondition_fz">
+            <h3>Fz</h3>
+            <p>Specify the z-component of force acting on the solid surface as constant or using an expression.</p>
          </sect2>
          <sect2 id="flmatpro_porousboundaryzone_boundaryzonetype">
             <h3>Type</h3>
@@ -10247,27 +10667,28 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_contactboundaryzone_contactcondition_variableheattransfer_dependencyfunction_function">
             <h3>Function</h3>
-            <p>Specify the type of dependency function to use: either "ramp" or "smoothed ramp".</p>
+            <p>Specify the type of dependency function to use: either <b>Ramp</b> or <b>Smoothed ramp</b>. <b>Start_ct</b> must be lower than <b>End_ct</b> and <b>Fct(start_ct)</b> must be different from <b>Fct(end_ct)</b>. <img src="graphics/g_flu_ug_matpro_dependency_function.png"/>
+            </p>
          </sect2>
          <sect2 id="flmatpro_contactboundaryzone_contactcondition_variableheattransfer_dependencyfunction_field">
             <h3>Field</h3>
             <p>Displays the contact time.</p>
          </sect2>
          <sect2 id="flmatpro_contactboundaryzone_contactcondition_variableheattransfer_dependencyfunction_x1">
-            <h3>X1</h3>
-            <p>Specify the X-component of the first point of the (smoothed) ramp dependency function.</p>
+            <h3>Start_ct</h3>
+            <p>Specify the x-component of the first point of the (smoothed) ramp dependency function.</p>
          </sect2>
          <sect2 id="flmatpro_contactboundaryzone_contactcondition_variableheattransfer_dependencyfunction_y1">
-            <h3>Y1</h3>
-            <p>Specify the Y-component of the first point of the (smoothed) ramp dependency function.</p>
+            <h3>Fct(start_ct)</h3>
+            <p>Specify the y-component of the first point of the (smoothed) ramp dependency function.</p>
          </sect2>
          <sect2 id="flmatpro_contactboundaryzone_contactcondition_variableheattransfer_dependencyfunction_x2">
-            <h3>X2</h3>
-            <p>Specify the X-component of the second point of the (smoothed) ramp dependency function.</p>
+            <h3>End_ct</h3>
+            <p>Specify the x-component of the second point of the (smoothed) ramp dependency function.</p>
          </sect2>
          <sect2 id="flmatpro_contactboundaryzone_contactcondition_variableheattransfer_dependencyfunction_y2">
-            <h3>Y2</h3>
-            <p>Specify the Y-component of the second point of the (smoothed) ramp dependency function.</p>
+            <h3>Fct(end_ct)</h3>
+            <p>Specify the y-component of the second point of the (smoothed) ramp dependency function.</p>
          </sect2>
          <sect2 id="flmatpro_contactboundaryzone_contactcondition_slippingcoefficient">
             <h3>Slipping coefficient</h3>
@@ -10281,13 +10702,77 @@ face values.</p>
             <h3>Darts are pointing to</h3>
             <p>Determine the direction of the contact, using darts in the graphics window: whether they are pointing toward the mold body or toward the mold cavity.</p>
          </sect2>
+         <sect2 id="flmatpro_moldboundaryzone_boundaryzoneid">
+            <h3>Boundary Zone</h3>
+            <p>Specify one or more surfaces to assign to this boundary.</p>
+         </sect2>
+         <sect2 id="flmatpro_moldboundaryzone_boundaryzonetype">
+            <h3>Type</h3>
+            <p>Choose the type of boundary zone for the mold as Fixed, Free, Symmetry, Normal Displacement, Normal Force Density, or Contact with Fluid. </p>
+         </sect2>
+         <sect2 id="flmatpro_moldboundaryzone_normaldisplacementcondition_freetangentialdisplacement">
+            <h3>Allow Non-Zero Tangential Displacement</h3>
+            <p>Deselecting this option forces the displacement to be strictly tangential to the mold.</p>
+         </sect2>
+         <sect2 id="flmatpro_moldboundaryzone_normaldisplacementcondition_dn">
+            <h3>Normal Displacement</h3>
+            <p>Specify the displacement of the mold normal to the surface.</p>
+         </sect2>
+         <sect2 id="flmatpro_moldboundaryzone_normalforcedensitycondition_fn">
+            <h3>Normal Force Density</h3>
+            <p>Specify the normal force density of the boundary on the mold surface.</p>
+         </sect2>
+         <sect2 id="flmatpro_moldboundaryzone_normalforcedensitycondition_freetangentialdisplacement">
+            <h3>Allow Non-Zero Tangential Displacement</h3>
+            <p>Deselecting this option forces the displacement to be strictly tangential to the mold.</p>
+         </sect2>
+         <sect2 id="flmatpro_moldboundaryzone_thermalcondition_temperatureimposed">
+            <h3>Temperature</h3>
+            <p>Specify the imposed temperature at this boundary.</p>
+         </sect2>
+         <sect2 id="flmatpro_moldboundaryzone_thermalcondition_temperaturelabel">
+            <h3>Field Name</h3>
+            <p>Enter the name found in the CSV File for the temperature profile.</p>
+         </sect2>
+         <sect2 id="flmatpro_moldboundaryzone_thermalcondition_temperatureprofile">
+            <h3>CSV File</h3>
+            <p>Click the <guibutton moreinfo="none">Load Temperature Profile</guibutton> button to select the CSV file for the temperature profile.</p>
+         </sect2>
+         <sect2 id="flmatpro_moldboundaryzone_thermalcondition_thermaloption">
+            <h3>Option</h3>
+            <p>Specify the thermal conditions at this mold boundary. You can choose an insulated wall, or impose a heat flux (constant and/or convective), or impose the temperature of the wall, and provide the parameters of the selected energy boundary condition.</p>
+         </sect2>
+         <sect2 id="flmatpro_partboundaryzone_boundaryzoneid">
+            <h3>Boundary Zone</h3>
+            <p>Specify one or more surfaces to assign to this boundary.</p>
+         </sect2>
+         <sect2 id="flmatpro_partboundaryzone_boundaryzonetype">
+            <h3>Type</h3>
+            <p>Choose the type of boundary zone for the part as Fixed, Free, Symmetry, Normal Displacement, Normal Force Density, or Immersed in Fluid. </p>
+         </sect2>
+         <sect2 id="flmatpro_partboundaryzone_normaldisplacementcondition_freetangentialdisplacement">
+            <h3>Allow Non-Zero Tangential Displacement</h3>
+            <p>Deselecting this option forces the displacement to be strictly tangential to the part.</p>
+         </sect2>
+         <sect2 id="flmatpro_partboundaryzone_normaldisplacementcondition_dn">
+            <h3>Normal Displacement</h3>
+            <p>Specify the displacement of the part normal to the surface.</p>
+         </sect2>
+         <sect2 id="flmatpro_partboundaryzone_normalforcedensitycondition_fn">
+            <h3>Normal Force Density</h3>
+            <p>Specify the normal force density of the boundary on the part surface.</p>
+         </sect2>
+         <sect2 id="flmatpro_partboundaryzone_normalforcedensitycondition_freetangentialdisplacement">
+            <h3>Allow Non-Zero Tangential Displacement</h3>
+            <p>Deselecting this option forces the displacement to be strictly tangential to the part.</p>
+         </sect2>
          <sect2 id="flmatpro_interfaceboundaryzone_conformal">
             <h3>Conformal Interface</h3>
             <p>Enable this option if the interface is conformal, that is, the two cell zones share the same mesh nodes along the interface. </p>
          </sect2>
          <sect2 id="flmatpro_interfaceboundaryzone_interfacetype">
             <h3>Type</h3>
-            <p>Specify the type of interface such as Fluid-Solid, Fluid-Fluid, Solid-Solid, Fluid-Porous (beta) and Solid-Porous (beta) </p>
+            <p>Specify the type of interface such as Fluid-Solid, Fluid-Fluid, Solid-Solid, Fluid-Porous and Solid-Porous. </p>
          </sect2>
          <sect2 id="flmatpro_interfaceboundaryzone_boundaryzoneid">
             <h3>Interface Zone</h3>
@@ -10357,9 +10842,13 @@ face values.</p>
             <h3>Moving Interface</h3>
             <p>For conformal fluid-fluid interfaces, indicate whether the interface is in motion or not.</p>
          </sect2>
-         <sect2 id="flmatpro_interfaceboundaryzone_fluidfluidinterface_chtwall_slipspecification">
-            <h3>Slip Specification</h3>
-            <p>help text for slip specification</p>
+         <sect2 id="flmatpro_interfaceboundaryzone_fluidfluidinterface_freenormalvelocity">
+            <h3>Allow Non-Zero Normal Velocity</h3>
+            <p>Deselecting this option forces the normal velocity to be null along the interface.</p>
+         </sect2>
+         <sect2 id="flmatpro_interfaceboundaryzone_fluidfluidinterface_freetangentialvelocity">
+            <h3>Allow Non-Zero Tangential Velocity</h3>
+            <p>Deselecting this option forces the tangential velocity to be null along the interface.</p>
          </sect2>
          <sect2 id="flmatpro_interfaceboundaryzone_fluidfluidinterface_chtwall_slipmodel">
             <h3>Slip Model</h3>
@@ -10368,18 +10857,6 @@ face values.</p>
          <sect2 id="flmatpro_interfaceboundaryzone_fluidfluidinterface_chtwall_frictioncoefficientnavier">
             <h3>Friction Coefficient</h3>
             <p>Specify the friction coefficient for slip conditions.</p>
-         </sect2>
-         <sect2 id="flmatpro_interfaceboundaryzone_fluidfluidinterface_chtwall_frictioncoefficientgeneralizednavier">
-            <h3>Friction Coefficient</h3>
-            <p>help text for friction coefficient</p>
-         </sect2>
-         <sect2 id="flmatpro_interfaceboundaryzone_fluidfluidinterface_chtwall_scalingfactorgeneralizednavier">
-            <h3>Scaling Factor</h3>
-            <p>help text for scaling factor</p>
-         </sect2>
-         <sect2 id="flmatpro_interfaceboundaryzone_fluidfluidinterface_chtwall_exponentgeneralizednavier">
-            <h3>Exponent</h3>
-            <p>help text for exponent</p>
          </sect2>
          <sect2 id="flmatpro_interfaceboundaryzone_fluidfluidinterface_chtwall_firstfrictioncoefficient">
             <h3>First Friction Coefficient</h3>
@@ -10397,21 +10874,9 @@ face values.</p>
             <h3>First Friction Coefficient</h3>
             <p>Specify the first friction coefficient for slip conditions.</p>
          </sect2>
-         <sect2 id="flmatpro_interfaceboundaryzone_fluidfluidinterface_chtwall_firstscalingfactorgeneralizedthreshold">
-            <h3>First Scaling Factor</h3>
-            <p>help text for first scaling factor</p>
-         </sect2>
          <sect2 id="flmatpro_interfaceboundaryzone_fluidfluidinterface_chtwall_secondfrictioncoefficientgeneralizedthreshold">
             <h3>Second Friction Coefficient</h3>
             <p>Specify the second  friction coefficient for slip conditions.</p>
-         </sect2>
-         <sect2 id="flmatpro_interfaceboundaryzone_fluidfluidinterface_chtwall_secondscalingfactorgeneralizedthreshold">
-            <h3>Second Scaling Factor</h3>
-            <p>help text for second scaling factor</p>
-         </sect2>
-         <sect2 id="flmatpro_interfaceboundaryzone_fluidfluidinterface_chtwall_exponentgeneralizedthreshold">
-            <h3>Exponent</h3>
-            <p>help text for exponent</p>
          </sect2>
          <sect2 id="flmatpro_interfaceboundaryzone_fluidfluidinterface_chtwall_frictioncoefficientasymptotic">
             <h3>Friction Coefficient</h3>
@@ -10445,9 +10910,81 @@ face values.</p>
             <h3>Beta</h3>
             <p>Specify a value for the exponential pressure dependency.</p>
          </sect2>
+         <sect2 id="flmatpro_guidingdevice_guidingdevicetype">
+            <h3>Type</h3>
+            <p>Specify the guiding device type as <b>Conveyor belt</b>.</p>
+         </sect2>
+         <sect2 id="flmatpro_guidingdevice_enablecontact">
+            <h3>Enable Contact</h3>
+            <p>This option is enabled by default and enables contact between the free surface and the conveyor belt. When disabled, the conveyor belt model will be deactivated without deleting the guiding device boundary zone. Disabling this option can be useful as a starting point when setting up a more complex case.</p>
+         </sect2>
+         <sect2 id="flmatpro_guidingdevice_conveyorbelt_point_px">
+            <h3>Px</h3>
+            <p>Specify the x-coordinate of the conveyor belt plane.</p>
+         </sect2>
+         <sect2 id="flmatpro_guidingdevice_conveyorbelt_point_py">
+            <h3>Py</h3>
+            <p>Specify the y-coordinate of the conveyor belt plane.</p>
+         </sect2>
+         <sect2 id="flmatpro_guidingdevice_conveyorbelt_point_pz">
+            <h3>Pz</h3>
+            <p>Specify the z-coordinate of the conveyor belt plane.</p>
+         </sect2>
+         <sect2 id="flmatpro_guidingdevice_conveyorbelt_normal_nx">
+            <h3>Nx</h3>
+            <p>Specify the x-component of the normal direction to the conveyor belt plane.</p>
+         </sect2>
+         <sect2 id="flmatpro_guidingdevice_conveyorbelt_normal_ny">
+            <h3>Ny</h3>
+            <p>Specify the y-component of the normal direction to the conveyor belt plane.</p>
+         </sect2>
+         <sect2 id="flmatpro_guidingdevice_conveyorbelt_normal_nz">
+            <h3>Nz</h3>
+            <p>Specify the z-component of the normal direction to the conveyor belt plane.</p>
+         </sect2>
+         <sect2 id="flmatpro_guidingdevice_conveyorbelt_translationvelocity_vx">
+            <h3>Vx</h3>
+            <p>Specify a value for the x-component of the translational velocity of the conveyor belt.</p>
+         </sect2>
+         <sect2 id="flmatpro_guidingdevice_conveyorbelt_translationvelocity_vy">
+            <h3>Vy</h3>
+            <p>Specify a value for the y-component of the translational velocity of the conveyor belt.</p>
+         </sect2>
+         <sect2 id="flmatpro_guidingdevice_conveyorbelt_translationvelocity_vz">
+            <h3>Vz</h3>
+            <p>Specify a value for the z-component of the translational velocity of the conveyor belt.</p>
+         </sect2>
+         <sect2 id="flmatpro_guidingdevice_contactcondition_freesurfaces">
+            <h3>Free Surfaces</h3>
+            <p>Specify the free surfaces that will be in contact with the conveyor belt.</p>
+         </sect2>
+         <sect2 id="flmatpro_guidingdevice_contactcondition_penetrationaccuracy">
+            <h3>Penetration Accuracy</h3>
+            <p>Specify the penetration accuracy. If the penetration of a point into the conveyor belt plane is greater than the penetration accuracy, the time step will be rejected. The calculation will then be restarted from the previous time step with a smaller time-step increment. The default value is set according to the dimensions of the mesh, and you will generally not need to modify it.</p>
+         </sect2>
+         <sect2 id="flmatpro_guidingdevice_contactcondition_slippingcoefficient">
+            <h3>Slipping Coefficient</h3>
+            <p>Specify a value or an expression for the slipping coefficient. If the slip coefficient and penalty coefficient have the same value and if that value is very large, then it is assumed that the fluid sticks to the conveyor belt when it comes into contact. Full slippage at the contact boundary is assumed if the slip coefficient is zero.</p>
+         </sect2>
+         <sect2 id="flmatpro_guidingdevice_contactcondition_penaltycoefficient">
+            <h3>Penalty Coefficient</h3>
+            <p>Specify a value or an expression for the penalty coefficient, which enforces the condition that the fluid velocity must be equal to the conveyor belt velocity in the normal direction.</p>
+         </sect2>
          <sect2 id="flmatpro_temperatureinitialization_zoneid">
             <h3>Cell Zones</h3>
             <p>Specify one or more cell zones to which to assign this temperature initialization.</p>
+         </sect2>
+         <sect2 id="flmatpro_temperatureinitialization_option">
+            <h3>Option</h3>
+            <p>Specifies the temperature initialization method. Select <b>f(X,Y,Z)</b> to specify the components of the temperature initialization equation. To initialize the temperature field using a CSV file containing a temperature profile, select <b>Temperature profile</b>.</p>
+         </sect2>
+         <sect2 id="flmatpro_temperatureinitialization_temperatureprofile">
+            <h3>CSV File</h3>
+            <p>Click the <guibutton moreinfo="none">Load Temperature Profile</guibutton> button to select the CSV file for the temperature profile.</p>
+         </sect2>
+         <sect2 id="flmatpro_temperatureinitialization_temperaturelabel">
+            <h3>Field Name</h3>
+            <p>Enter the name found in the CSV File for the temperature profile.</p>
          </sect2>
          <sect2 id="flmatpro_temperatureinitialization_comment">
             <h3>Temperature T</h3>
@@ -10489,6 +11026,46 @@ face values.</p>
             <h3>Z</h3>
             <p>Specify a value for the z-coordinate of the desired point for the assigned pressure. </p>
          </sect2>
+         <sect2 id="flmatpro_assigndisplacement_zoneid">
+            <h3>Search Zone</h3>
+            <p>Select the cell zone(s) in which the point closest to the coordinates&#160;provided below must be located.</p>
+         </sect2>
+         <sect2 id="flmatpro_assigndisplacement_displacement_fixdx">
+            <h3>Fix Dx</h3>
+            <p>Enable this option to set a fixed displacement value for the x-coordinate of the solid at the desired point.</p>
+         </sect2>
+         <sect2 id="flmatpro_assigndisplacement_displacement_dx">
+            <h3>Dx</h3>
+            <p>Specify a value for the x-coordinate of the fixed displacement at the desired point.</p>
+         </sect2>
+         <sect2 id="flmatpro_assigndisplacement_displacement_fixdy">
+            <h3>Fix Dy</h3>
+            <p>Enable this option to set a fixed displacement value for the y-coordinate of the solid at the desired point.</p>
+         </sect2>
+         <sect2 id="flmatpro_assigndisplacement_displacement_dy">
+            <h3>Dy</h3>
+            <p>Specify a value for the y-coordinate of the fixed displacement at the desired point.</p>
+         </sect2>
+         <sect2 id="flmatpro_assigndisplacement_displacement_fixdz">
+            <h3>Fix Dz</h3>
+            <p>Enable this option to set a fixed displacement value for the z-coordinate of the solid at the desired point.</p>
+         </sect2>
+         <sect2 id="flmatpro_assigndisplacement_displacement_dz">
+            <h3>Dz</h3>
+            <p>Specify a value for the z-coordinate of the fixed displacement at the desired point.</p>
+         </sect2>
+         <sect2 id="flmatpro_assigndisplacement_point_px">
+            <h3>X</h3>
+            <p>Specify a value for the x-coordinate of the desired point for the assigned displacement. </p>
+         </sect2>
+         <sect2 id="flmatpro_assigndisplacement_point_py">
+            <h3>Y</h3>
+            <p>Specify a value for the y-coordinate of the desired point for the assigned displacement. </p>
+         </sect2>
+         <sect2 id="flmatpro_assigndisplacement_point_pz">
+            <h3>Z</h3>
+            <p>Specify a value for the z-coordinate of the desired point for the assigned displacement. </p>
+         </sect2>
          <sect2 id="flmatpro_probe_px">
             <h3>X</h3>
             <p>Specify the X-component of the probe location.</p>
@@ -10507,31 +11084,31 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_activation">
             <h3>Enabled</h3>
-            <p>Indicate whether or not to use adaptive meshing.</p>
+            <p>Indicate whether or not to use adaptive meshing. By default, adaptive meshing is enabled (the check box is checked). You may disable it by unchecking the box; this can be useful for a preliminary trial simulation. When enabled, additional properties are available.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_nstep">
             <h3>Number of Steps</h3>
-            <p>Indicate the number of time steps to use for adaptive meshing. A value of 1 indicates that adaptive meshing will take place at each time step.</p>
+            <p>Indicate the number of time steps to use for adaptive meshing. A value of 1 indicates that adaptive meshing will take place at each time step. Adaptive meshing is invoked after every sequence of N successful steps, by default N = 5. This is a recommended value as a good compromise between the need of best mesh quality (frequent adaptive meshing) and the necessity of speeding up the calculation (less frequent adaptive meshing). For transient cases, the value should preferably never be less than 4.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_maxdiv">
             <h3>Maximum Number of Subdivisions</h3>
-            <p>Specify the number of times a primitive element (that is, an element of the initial mesh, as created in the mesh generator) can be subdivided recursively.</p>
+            <p>Specify the number of times a primitive element (that is, an element of the initial mesh, as created in the mesh generator) can be subdivided recursively. Adaptive meshing involves up to M levels of element subdivision, by default M equals 3. Depending on the conditions to satisfy, elements are recursively split into sub-elements. With each level of subdivision, the local element density increases by a factor up to 4: three levels of subdivision potentially increase the number of elements by a factor up to 64. There is never more than one level of subdivision between adjacent elements. Unless conformalization is asked, quads are usually subdivided into quads; tris are subdivided into tris. However, other subdivisions are possible when the aspect ratio and/or the skewness requires it.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_start">
             <h3>Adaptive Meshing at Start</h3>
-            <p>Indicate whether or not to use adaptive meshing at the start of the calculations. That is, for blow molding and thermoforming simulations that involve both contact and adaptive meshing, you can specify that an additional adaptive meshing step is performed before the start of the transient simulation. </p>
+            <p>Indicate whether or not to use adaptive meshing at the start of the calculations. That is, for blow molding and thermoforming simulations that involve both contact and adaptive meshing, you can specify that an additional adaptive meshing step is performed before the start of the transient simulation. Adaptive meshing is not enabled at the start of the calculation, by default the checkbox is unchecked. It is assumed that the initial finite element mesh is of acceptable quality, so that an initial adaption step is often not needed. If the initial mesh is of insufficient quality, you may ask for an initial mesh adaption.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_conformalization">
             <h3>Conformalization</h3>
-            <p>Indicate whether or not to use conformalization on the mesh. For 2D and shell meshes that use the recursive subdivision technique, you can enable conformalization for the mesh.</p>
+            <p>Indicate whether or not to use conformalization on the mesh. For 2D and shell meshes that use the recursive subdivision technique, you can enable conformalization for the mesh. Conformalization of elements is invoked by default; the checkbox is checked. Adjacent elements are not always subdivided up to the same level, and two smaller elements may be adjacent to a less-subdivided element. A non-conformal situation is created where a middle mesh node may miss a contribution from the adjacent large element. This is internally solved with appropriate constraints. Alternatively, you can invoke mesh conformalization. </p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_triangulation">
             <h3>Triangulation</h3>
-            <p>Indicate whether to use partial or full triangulation for the mesh.  If Full triangulation is used, when one element is selected for remeshing, the whole moving domain (that is, the domain for which there are local criteria activated) will be remeshed. With big meshes, the cost of this operation could be too high. Partial triangulation is when one element is selected for remeshing, a zone defined upon the neighbors of this element will be remeshed (and not the entire mesh), and is preferable for large meshes.</p>
+            <p>Indicate whether to use partial or full triangulation for the mesh.  If Full triangulation is used, when one element is selected for remeshing, the whole moving domain (that is, the domain for which there are local criteria activated) will be remeshed. With big meshes, the cost of this operation could be too high. Partial triangulation is when one element is selected for remeshing, a zone defined upon the neighbors of this element will be remeshed (and not the entire mesh), and is preferable for large meshes. By default, full triangulation is invoked, and is recommended unless otherwise specified. Full or partial triangulation can be invoked, respectively depending whether the adaptive meshing is applied on the entire fluid mesh or only on portions surrounding elements of bad quality. </p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_angleconservation">
             <h3>Angle Conservation</h3>
-            <p>Enables angle conservation on the border of the remeshed zone(s).</p>
+            <p>Enables angle conservation on the border of the remeshed zone(s). A sequence of adaptive meshing tends to erode sharp borders or edges of a fluid domain. It is especially visible on convex borders. By default, angles are not preserved. Enable this option if you want angles above a given value to be preserved and enter the value. The angle between two adjacent boundary elements is defined as the angle between vectors normal to these elements. </p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_angle">
             <h3>Angle [deg]</h3>
@@ -10542,92 +11119,104 @@ face values.</p>
             <p>Indicate whether or not to use mapping for the adaptive meshing. A mapping technique is used that projects the nodes along the local normal to the free surface, since the remeshing algorithm used for triangular / tetrahedral element generation builds a new mesh on the basis of the old mesh, rather than the original geometry.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_mapping_symmetries">
-            <h3>Planes of symmetry taken into account</h3>
-            <p>Indicate whether or not to account for symmetry planes.</p>
+            <h3>Planes of Symmetry Taken into Account</h3>
+            <p>Indicate whether or not to account for symmetry planes. A specific mapping treatment is applied in order to preserve planes of symmetry and not geometrically distort them. By default, the option is not enabled and it is recommended unless otherwise specified.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_mapping_threshold">
-            <h3>Threshold value</h3>
-            <p>This field triggers the mapping of the nodes. The contact algorithm uses internal fields that are named contact_field and are defined on the free surface. This field stores the contact information for each node and initially has a value of either 0 or 1. If a node of the free surface is in contact, the field value is 1, otherwise the value is 0. However, after a remeshing step, the contact_field values must be interpolated onto the newly generated mesh. After this interpolation, the contact_field values are no longer limited to being either 0 or 1, but can be intermediate values (for example, 0.3). If a node of the free surface has a contact_field value greater than the threshold, the node is assumed to be in contact and will be mapped. The default value of the threshold is 0.8</p>
+            <h3>Threshold Value</h3>
+            <p>This field triggers the mapping of the nodes. The contact algorithm uses internal fields that are named <i>contact_field</i> and are defined on the free surface. This field stores the contact information for each node and initially has a value of either 0 or 1. If a node of the free surface is in contact, the field value is 1, otherwise the value is 0. However, after a remeshing step, the <i>contact_field</i> values must be interpolated onto the newly generated mesh. After this interpolation, the <i>contact_field</i> values are no longer limited to being either 0 or 1, but can be intermediate values (for example, 0.3). If a node of the free surface has a <i>contact_field</i> value greater than the threshold, the node is assumed to be in contact and will be mapped. The default value of the threshold is 0.8. Contact is formally described with a step function taking values 0 and 1. With the calls to adaptive meshing and the subsequent interpolation of fields, the transition stripe from non-contact to contact areas may diffuse. The threshold value is used for removing the uncertainty and assessing contact beyond the threshold. By default, the threshold is set to 0.8. </p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_mapping_scalingfactor">
-            <h3>Scaling factor</h3>
-            <p>This parameter is used to determine if a point on the free surface is in the vicinity of the mold surface. The distance between the free surface point and the mold surface must be less than typical_size*scaling_factor, where typical_size is the maximum size of a face (or a segment in 2D)  of the mold surface. The default value of Scaling factor is 0.6.</p>
+            <h3>Scaling Factor</h3>
+            <p>This parameter is used to determine if a point on the free surface is in the vicinity of the mold surface. The distance between the free surface point and the mold surface must be less than <i>typical_size*scaling_factor</i>, where typical_size is the maximum size of a face (or a segment in 2D)  of the mold surface. The scaling factor is used to determine whether a point of the fluid is in the vicinity of the mold surface; the vicinity being defined as a fraction (scaling factor) of a typical element size of the mold. By default, the threshold is set to 0.6. </p>
+         </sect2>
+         <sect2 id="flmatpro_adaptivemeshing_mapping_maxdisplacementmode">
+            <h3>Maximum Displacement Mode</h3>
+            <p>Allows you to set the method for determining the maximum displacement of surface nodes during the mapping stage of the adaptive meshing as either <b>Program controlled</b> or <b>User Value</b>. It is the upper bound of the displacement applied to nodes that are mapped onto the contact surface. By default, the value is <b>Program Controlled</b>. You can change this and specify a <b>User Value</b> when prompted.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_mapping_maxdisplacement">
-            <h3>Maximum displacement</h3>
+            <h3>User Displacement</h3>
             <p>In order to avoid highly distorted elements in the layer of elements adjacent to the free surface, the displacement of the mapped nodes is limited to this value. A good practice is to define the maximum displacement as 10 to 25 percent of the minimum element size imposed in the adaptive meshing setup. The default value is calculated from the typical mesh size.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_mapping_penetrationtolerance">
-            <h3>Penetration tolerance</h3>
-            <p>This parameter is used to provide a tolerance level for the distance between the free surface and the mold surface. If a point on the free surface is located inside the mold at a distance from the mold surface below this tolerance, the point will not be moved; otherwise the position of the point is corrected. Three options are available: a value of max displacement sets the penetration tolerance to be equivalent to the maximum displacement; a value of penetration accuracy sets the penetration tolerance to be equivalent to the minimum of the penetration accuracies; a value of user input allows you to provide your own value for the tolerance.</p>
+            <h3>Penetration Tolerance</h3>
+            <p>This parameter is used to provide a tolerance level for the distance between the free surface and the mold surface. If a point on the free surface is located inside the mold at a distance from the mold surface below this tolerance, the point will not be moved; otherwise the position of the point is corrected. Three options are available: a value of max displacement sets the penetration tolerance to be equivalent to the maximum displacement; a value of penetration accuracy sets the penetration tolerance to be equivalent to the minimum of the penetration accuracies; a value of user input allows you to provide your own value for the tolerance. Fluid points in contact with the mold which are at a distance lower than the <b>Penetration Tolerance</b> will not be mapped onto the mold surface. By default, the <b>Penetration Tolerance</b> is <b>Program Controlled</b>. You can change this and specify it to be equal to the <b>Maximum Displacement</b> given above or to a <b>User Value</b> when prompted.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_mapping_penetrationvalue">
-            <h3>User value</h3>
-            <p>Specify a value for the penetration tolerance, where it is recommended to keep the penetration tolerance to be less than or equal to the penetration accuracy </p>
+            <h3>User Value</h3>
+            <p>Specify a value for the penetration tolerance, where it is recommended to keep the penetration tolerance to be less than or equal to the penetration accuracy.</p>
+         </sect2>
+         <sect2 id="flmatpro_adaptivemeshing_criterionwarning">
+            <h3>Warning</h3>
+            <p>Provides a message for defining a condition when activating an adaptive meshing criterion.</p>
+         </sect2>
+         <sect2 id="flmatpro_adaptivemeshing_criterion_activatewarning">
+            <h3>Warning</h3>
+            <p>Provides a message for activating an adaptive meshing criterion.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_criterion_criterionquality_lqactivation">
             <h3>Enabled</h3>
-            <p>Indicate whether or not to consider the condition on the mesh quality in order to trigger adaptive meshing.</p>
+            <p>Indicate whether or not to consider the condition on the mesh quality in order to trigger adaptive meshing. You may disable it by unchecking the box; this can be useful for a preliminary trial simulation. </p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_criterion_criterionquality_quality">
             <h3>Quality</h3>
-            <p>Specify a value for the expected quality of the mesh.</p>
+            <p>Specify a value for the expected quality of the mesh. A quality criterion decreasing from 1 (very good) down to 0 (very bad) is evaluated, and which incorporates geometric features such as aspect ratio, internal angles, skewness and bending. Fluid elements which do not match the required quality will be adapted. By default, a quality of 0.8 is required. </p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_criterion_criterionquality_size">
             <h3>Size</h3>
-            <p>Specify a value for the expected element size of the mesh.</p>
+            <p>Specify a value for the expected element size of the mesh. Fluid elements which do not match the assigned size will be adapted. A default value is evaluated as a fraction of the overall geometric dimension of the mesh. It can be changed. </p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_criterion_criterioncontact_lcactivation">
             <h3>Enabled</h3>
-            <p>Indicate whether or not to consider the condition on contact in order to trigger adaptive meshing </p>
+            <p>Indicate whether or not to consider the condition on contact in order to trigger adaptive meshing. Once a contact condition is enabled (the checkbox is checked) additional properties are available and you may disable it by unchecking the box; note that at least one condition must be enabled. </p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_criterion_criterioncontact_boundaryzoneid">
-            <h3>Mold surfaces of contact</h3>
-            <p>Select the contact surface(s) to consider for the condition on contact.</p>
+            <h3>Mold Surfaces of Contact</h3>
+            <p>Select the contact zone(s) of the mold to consider for the present contact condition.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_criterion_criterioncontact_method">
             <h3>Method</h3>
-            <p>Specify the method for the local criterion: "distance", "curvature", or "angle and curvature".</p>
+            <p>Specify the method for the local criterion: <b>distance</b>, <b>curvature</b>, or <b>angle and curvature</b>.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_criterion_criterioncontact_minsize">
-            <h3>Minimum size</h3>
-            <p>Specify the minimum size for elements close to the mold boundary.</p>
+            <h3>Minimum Size</h3>
+            <p>Specify the minimum size for newly created elements close to the mold boundary surface. This is the minimum side length of newly created elements, necessary for preventing the creation of a mesh that is too dense. By default, this parameter is assigned a value that is of the order of a tenth of the average edge length in the input mesh.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_criterion_criterioncontact_mindistance">
-            <h3>Minimum distance</h3>
-            <p>Specify the minimum distance below which the minimum size is applied.</p>
+            <h3>Minimum Distance</h3>
+            <p>Specify the minimum distance below which the minimum size is applied. This is the distance between fluid zone and mold below which new fluid elements will be created with the specified minimum size. By default, the minimum distance is set to 0. </p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_criterion_criterioncontact_maxsize">
-            <h3>Maximum size</h3>
-            <p>Specify the maximum size for elements far from the mold boundary.</p>
+            <h3>Maximum Size</h3>
+            <p>Specify the maximum size for newly created elements far from the mold boundary surface. This is the maximum side length of newly created elements, necessary for preventing the creation of a mesh that is too coarse. By default, this parameter is assigned a value that is of the order of the average edge length in the input mesh.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_criterion_criterioncontact_maxdistance">
-            <h3>Maximum distance</h3>
-            <p>Specify the maximum distance beyond which the maximum size is applied.</p>
+            <h3>Maximum Distance</h3>
+            <p>Specify the maximum distance beyond which the maximum size is applied. This is the distance between fluid zone and mold beyond which new fluid elements will be created with the specified maximum size. By default, this parameter is assigned a value that is of the order of the average edge length in the input mesh.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_criterion_criterioncontact_a">
             <h3>Fraction of Radius of Curvature</h3>
-            <p>For the curvature method, this value is dimensionless, and its default value is 0.2. This value should lead to almost 30 elements to mesh a circle.</p>
+            <p>For the curvature method, this value is dimensionless, and its default value is 0.2. This value should lead to almost 30 elements to mesh a circle. Sufficiently close to the contact mold, element size will be a given fraction of the local radius of curvature, unless it hits the minimum size as lower bound. The selected default value of 0.2 suggests that about 5 fluid elements can be created for matching 1 radian (57 degrees) of a curved mold portion. </p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_criterion_criterioncontact_b">
             <h3>Typical Distance to Mold</h3>
-            <p>For the curvature method, this value has the units of length, and is the typical size of segments of the mesh.</p>
+            <p>For the curvature method, this value has the units of length, and is the typical size of segments of the mesh. This is the distance between a fluid element and the mold below which mesh refinement begins. It is important to anticipate the contact, for having smaller elements before contact occurrence. By default, the value is a fraction of a typical geometric length of the input mesh. </p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_criterion_criterioncontact_c">
             <h3>Coefficient of Proportionality</h3>
-            <p>For the curvature method, this value has units of length, and is typically zero.</p>
+            <p>For the curvature method, this value has units of length, and is typically zero. This coefficient may be interpreted as the intended size of the fluid elements when the contact occurs along a flat portion of the mold. For avoiding undesired interferences, either the <b>Fraction of Radius of Curvature</b> or the <b>Coefficient of Proportionality</b> should vanish. </p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_criterion_criterioncontact_tolerance">
             <h3>Tolerance</h3>
-            <p>For the angle and curvature method, this value defines the tolerance for the contact. Note that if you set the tolerance to a very small value, it may produce unachievable values of ; that is, a given fluid element may never reach , because there are set limits to how many times an element can be subdivided. It is recommended that you set the tolerance to be 0.1&#8211;0.2 percent of the overall size of the mold.</p>
+            <p>For the angle and curvature method, this value defines the tolerance for the contact. Note that if you set the tolerance to a very small value, it may produce unachievable values of ; that is, a given fluid element may never reach , because there are set limits to how many times an element can be subdivided. It is recommended that you set the tolerance to be 0.1&#8211;0.2 percent of the overall size of the mold. This is the maximum distance you would ideally like between any node of the mold and the nearest fluid element. This tolerance is used to locally calculate an ideal fluid element size, in that it could approach the mold within the stated tolerance.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_criterion_criterioncontact_criticaldistance">
-            <h3>Critical distance</h3>
-            <p>For the angle and curvature method, this value has units of length, and is typically 10 percent of the typical size of the segments in the mesh. Note that a larger value for results in larger areas of the fluid where the elements are subdivided, which produces higher element counts. On the other hand, if you choose a value that is too small, there may not be sufficient meshing iterations to reduce the elements to an appropriate size. To ensure that is not too small, you must account for the meshing frequency and the velocity of the parison / preform / sheet. The default for this parameter is one percent of the medium diagonal of the axis-aligned minimum box bounding the whole geometry</p>
+            <h3>Critical Distance</h3>
+            <p>For the angle and curvature method, this value has units of length, and is typically 10 percent of the typical size of the segments in the mesh. Note that a larger value for results in larger areas of the fluid where the elements are subdivided, which produces higher element counts. On the other hand, if you choose a value that is too small, there may not be sufficient meshing iterations to reduce the elements to an appropriate size. To ensure that is not too small, you must account for the meshing frequency and the velocity of the parison / preform / sheet. The default for this parameter is one percent of the medium diagonal of the axis-aligned minimum box bounding the whole geometry. The critical distance corresponds to an anticipation distance from which mold angles and curvature will have a growing effect on the fluid mesh discretization. It is important to anticipate the contact, for having smaller elements before contact occurrence. By default, this parameter is assigned a value that is of the order of the average edge length in the input mesh. </p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_criterion_criterionoverlap_loactivation">
             <h3>Enabled</h3>
-            <p>Indicate whether or not to apply the current condition on overlapping parts for adaptive meshing.</p>
+            <p>Indicate whether or not to apply the current condition on overlapping parts for adaptive meshing. When multiple conditions are defined, they may by enabled or disabled at will. Once enabled, additional options are available.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_criterion_criterionoverlap_partid">
             <h3>Overlapping Parts</h3>
@@ -10635,19 +11224,19 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_criterion_criterionoverlap_unrefinementtreshold">
             <h3>Unrefinement Threshold</h3>
-            <p>Specify the required threshold for local mesh unrefinement. The operating mode depends on the cell selection method. For the cell selection method based on inside field variation: when an element of the fluid zone is far enough from the border of the overlapping part (that is, when the corresponding overlapping or inside field exhibits small or no variation), the element can be selected for unrefinement. For the cell selection method based on average inside field values: when an element of the fluid zone is far enough from the overlapping part (that is, when the corresponding overlapping or inside field exhibits small values), the element can be selected for unrefinement. </p>
+            <p>Specify the required threshold for local mesh unrefinement. A so-called inside function (or overlapping function) is used to determine whether a fluid element is overlapped by a restrictor or a moving part, or not. It then received the value 1 or 0, respectively. For fluid elements far from the transition stripe, the function exhibits nearly no variation, and they can be selected for unrefinement if the variation is below the threshold value. By default, the threshold value is set to 0.01. The operating mode depends on the cell selection method. For the cell selection method based on inside field variation: when an element of the fluid zone is far enough from the border of the overlapping part (that is, when the corresponding overlapping or inside field exhibits small or no variation), the element can be selected for unrefinement. For the cell selection method based on average inside field values: when an element of the fluid zone is far enough from the overlapping part (that is, when the corresponding overlapping or inside field exhibits small values), the element can be selected for unrefinement. </p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_criterion_criterionoverlap_refinementtreshold">
             <h3>Refinement Threshold</h3>
-            <p>Specify the required threshold for local mesh refinement. The operating mode depends on the cell selection method. For the cell selection method based on inside field variation: when an element of the fluid zone is close enough to the border of the overlapping part (that is, when the corresponding overlapping or inside field exhibits large variation), the element can be selected for refinement. For the cell selection method based on average inside field values: when an element of the fluid zone is close enough to the overlapping part or overlapped (that is, when the corresponding overlapping or inside field exhibits large values), the element can be selected for refinement. </p>
+            <p>Specify the required threshold for local mesh refinement. A so-called inside function (or overlapping function) is used to determine whether a fluid element is overlapped by a restrictor or a moving part, or not. It then received the value 1 or 0, respectively. For fluid elements located near or in the transition stripe, the function exhibits variation, and they can be selected for refinement if the variation is above the threshold value. By default, the threshold value is set to 0.05. The operating mode depends on the cell selection method. For the cell selection method based on inside field variation: when an element of the fluid zone is close enough to the border of the overlapping part (that is, when the corresponding overlapping or inside field exhibits large variation), the element can be selected for refinement. For the cell selection method based on average inside field values: when an element of the fluid zone is close enough to the overlapping part or overlapped (that is, when the corresponding overlapping or inside field exhibits large values), the element can be selected for refinement. </p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_criterion_criterionoverlap_selectionmethod">
             <h3>Cell Selection Method</h3>
-            <p>Specify whether the cell selection method for refinement/unrefinement is based on the variations or on the values of the overlapping or inside field.</p>
+            <p>Specify whether the cell selection method for refinement/unrefinement is based on the variations or on the values of the overlapping or inside field. By default, the selection method for refinement and unrefinement checks the <b>Variation of inside field</b> versus both thresholds. Another method consists of checking the <b>Average of inside field</b> versus both thresholds. The behavior differs since elements overlapped by the solid part will also be refined.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_type">
             <h3>Type</h3>
-            <p>Specify the method in which you want to define the refinement zone: <b>along boundaries</b>, <b>box</b>, or  <b>sphere</b>.</p>
+            <p>Specify the method in which you want to define the refinement zone: <b>along boundaries</b>, <b>box</b>, or  <b>sphere</b>. For 2D cases, the box and the sphere are respectively reduced to rectangle and circle.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_alongboundaries_boundary">
             <h3>Boundary</h3>
@@ -10659,55 +11248,55 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_alongboundaries_minsize">
             <h3>Minimum Size</h3>
-            <p>Specify the minimum size for elements close to the mold boundary.</p>
+            <p>Specify the minimum size for elements close to the mold boundary. This sets the minimum size for newly created elements close to the selected boundary. By default, this parameter is assigned a value that is of the order of a tenth of the average edge length in the input mesh.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_alongboundaries_mindistance">
             <h3>Minimum Distance</h3>
-            <p>Specify the minimum distance below which the minimum size is applied.</p>
+            <p>Specify the minimum distance below which the minimum size is applied. This is the distance between fluid points and selected boundaries below which new fluid elements will be created with the specified minimum size. By default, the minimum distance is set to 0.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_alongboundaries_maxsize">
             <h3>Maximum Size</h3>
-            <p>Specify the maximum size for elements far from the mold boundary.</p>
+            <p>Specify the maximum size for elements far from the mold boundary. This sets the maximum size for newly created elements beyond a given distance to the selected boundary. By default, this parameter is assigned a value that is of the order of the average edge length in the input mesh.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_alongboundaries_maxdistance">
             <h3>Maximum Distance</h3>
-            <p>Specify the maximum distance beyond which the maximum size is applied.</p>
+            <p>Specify the maximum distance beyond which the maximum size is applied. This is the distance between fluid point and selected boundary beyond which new fluid elements will be created with the specified maximum size. By default, this parameter is assigned a value that is of the order of the average edge length in the input mesh.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_alongboundaries_a">
             <h3>Fraction of Radius of Curvature</h3>
-            <p>For the curvature method, this value is dimensionless, and its default value is 0.2. This value should lead to almost 30 elements to mesh a circle.</p>
+            <p>For the curvature method, this value is dimensionless, and its default value is 0.2. This value should lead to almost 30 elements to mesh a circle. Sufficiently close to the selected boundary, element size will be a given fraction of the local radius of curvature, unless it hits the minimum size as lower bound. The selected default value of 0.2 suggests that about 5 fluid elements can be created for matching 1 rad (57&#176;) of a curved boundary portion.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_alongboundaries_b">
             <h3>Typical Distance to Boundary</h3>
-            <p>For the curvature method, this value has the units of length, and is the typical size of segments of the mesh.</p>
+            <p>For the curvature method, this value has the units of length, and is the typical size of segments of the mesh. The typical depth of the zone adjacent to the boundary where elements can be remeshed based on the local curvature. By default, the value is a fraction of a typical geometric length of the input mesh.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_alongboundaries_c">
             <h3>Coefficient of Proportionality</h3>
-            <p>For the curvature method, this value has units of length, and is typically zero.</p>
+            <p>For the curvature method, this value has units of length, and is typically zero.  This coefficient may be interpreted as the intended size of the fluid elements along a flat portion of the selected boundary. For avoiding undesired interferences, either the <b>Fraction of Radius of Curvature</b> or the <b>Coefficient of Proportionality</b> should vanish.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_box_xmin">
             <h3>Xmin</h3>
-            <p>Specify a value for the minimum position on the X axis for the refinement zone box.</p>
+            <p>Specify a value for the minimum position on the X axis for the refinement zone box (the X-coordinate of the lower-left-front point). The default value is 0.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_box_ymin">
             <h3>Ymin</h3>
-            <p>Specify a value for the minimum position on the Y axis for the refinement zone box.</p>
+            <p>Specify a value for the minimum position on the Y axis for the refinement zone box (the Y-coordinate of the lower-left-front point). The default value is 0.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_box_zmin">
             <h3>Zmin</h3>
-            <p>Specify a value for the minimum position on the Z axis for the refinement zone box.</p>
+            <p>Specify a value for the minimum position on the Z axis for the refinement zone box (the Z-coordinate of the lower-left-front point). The default value is 0.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_box_xmax">
             <h3>Xmax</h3>
-            <p>Specify a value for the maximum position on the X axis for the refinement zone box.</p>
+            <p>Specify a value for the maximum position on the X axis for the refinement zone box (the X-coordinate of the upper-right-back point). The default value is 0.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_box_ymax">
             <h3>Ymax</h3>
-            <p>Specify a value for the maximum position on the Y axis for the refinement zone box.</p>
+            <p>Specify a value for the maximum position on the Y axis for the refinement zone box (the Y-coordinate of the upper-right-back point). The default value is 0.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_box_zmax">
             <h3>Zmax</h3>
-            <p>Specify a value for the maximum position on the Z axis for the refinement zone box.</p>
+            <p>Specify a value for the maximum position on the Z axis for the refinement zone box (the Z-coordinate of the upper-right-back point). The default value is 0.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_box_sizeofxyz">
             <h3>Element Size</h3>
@@ -10715,39 +11304,39 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_box_sizeofxyz_info">
             <h3>Size</h3>
-            <p>The dimensions of the rectangle are dictated by: A + B * x + C * y + D * z </p>
+            <p>The dimensions of the element can be either a constant or linear function of coordinates: A + B * x + C * y + D * z </p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_box_sizeofxyz_sa">
             <h3>A</h3>
-            <p>Specify the length of the box.</p>
+            <p>Specify the length of the element.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_box_sizeofxyz_sb">
             <h3>B</h3>
-            <p>A coefficient for the rectangle size, 0 by default.</p>
+            <p>A coefficient for the element size (a constant coefficient of the affine size function), 0 by default.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_box_sizeofxyz_sc">
             <h3>C</h3>
-            <p>A coefficient for the rectangle size, 0 by default.</p>
+            <p>A coefficient for the element size (a coefficient of the affine size function), 0 by default.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_box_sizeofxyz_sd">
             <h3>D</h3>
-            <p>A coefficient for the rectangle size, 0 by default.</p>
+            <p>A coefficient for the element size (a coefficient of the affine size function), 0 by default.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_sphere_xc">
             <h3>Xc</h3>
-            <p>Specify the X coordinate of the center of the sphere.</p>
+            <p>Specify the X coordinate of the center of the sphere. The default value is 0.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_sphere_yc">
             <h3>Yc</h3>
-            <p>Specify the Y coordinate of the center of the sphere.</p>
+            <p>Specify the Y coordinate of the center of the sphere. The default value is 0.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_sphere_zc">
             <h3>Zc</h3>
-            <p>Specify the Z coordinate of the center of the sphere.</p>
+            <p>Specify the Z coordinate of the center of the sphere. The default value is 0.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_sphere_diameter">
             <h3>Diameter</h3>
-            <p>Specify a value for the sphere diameter.</p>
+            <p>Specify a value for the sphere diameter. The default value is 0.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_sphere_sizeofradius">
             <h3>Element Size</h3>
@@ -10759,11 +11348,11 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_sphere_sizeofradius_ra">
             <h3>A</h3>
-            <p>A coefficient for the spherical element size.</p>
+            <p>A coefficient for the spherical element size, that is, a constant coefficient of the affine size function. The default value is 0.</p>
          </sect2>
          <sect2 id="flmatpro_adaptivemeshing_refinementzone_sphere_sizeofradius_rb">
             <h3>B</h3>
-            <p>A coefficient for the spherical element size.</p>
+            <p>A coefficient for the spherical element size, that is, a coefficient of the affine size function.  The default value is 0.</p>
          </sect2>
          <sect2 id="flmatpro_restartoptions_restarttype">
             <h3>Restart Type</h3>
@@ -10853,13 +11442,17 @@ face values.</p>
             <h3>Decouple computation of free surfaces</h3>
             <p>Decouples the calculation of free surfaces to produce a stabilizing effect in some cases.</p>
          </sect2>
+         <sect2 id="flmatpro_numericalcontrols_decouplingviscoelasticstress">
+            <h3>Decouple Computation of Viscoelastic Stresses</h3>
+            <p>Decouples the calculation of viscoelastic stress to produce a stabilizing effect in some cases (the solver updates the viscoelastic stresses fields after calculation of the velocities).</p>
+         </sect2>
          <sect2 id="flmatpro_numericalcontrols_kinematiccondition">
             <h3>Integration method on free surfaces</h3>
             <p>Choose the type of integration for the free surface: program controlled, line integration, or surface integration.</p>
          </sect2>
          <sect2 id="flmatpro_numericalcontrols_integrationrule">
             <h3>Integration Rule for Transient Terms</h3>
-            <p>Allows you to select standard or hybrid integration rule for transient terms. The hybrid integration rule is recommended for transient nonisothermal flow or heat conduction problems involving thermal shocks (for example, a glass pressing problem).</p>
+            <p>Allows you to select standard or hybrid integration rule for transient terms. The hybrid integration rule is recommended for transient thermal flow or heat conduction problems involving thermal shocks (for example, a glass pressing problem).</p>
          </sect2>
          <sect2 id="flmatpro_numericalcontrols_picard">
             <h3>Picard iterations</h3>
@@ -10921,6 +11514,18 @@ face values.</p>
             <h3>Pressure at slip wall</h3>
             <p>Choose an interpolation type used to calculate the pressure applied along a slipping wall to enforce the zero normal velocity condition.</p>
          </sect2>
+         <sect2 id="flmatpro_numericalcontrols_interpolation_displacementinterpolation">
+            <h3>Displacement</h3>
+            <p>Choose an interpolation type used to calculate the displacement of an elastic solid.</p>
+         </sect2>
+         <sect2 id="flmatpro_numericalcontrols_fsiparameters_penaltycoefficient">
+            <h3>Penalty Coefficient</h3>
+            <p>Specify a value for the fluid-structure interaction penalty coefficient. This enforces the condition that the fluid velocity must be equal to the wall velocity of the elastic solid, in the normal direction. The value for the penalty coefficient should only be changed to account for fluid slip on the solid surface.</p>
+         </sect2>
+         <sect2 id="flmatpro_numericalcontrols_fsiparameters_stabilitycoefficient">
+            <h3>Stability Coefficient</h3>
+            <p>This value should only be changed if the fluid sticks to the solid surface. The stability coefficient can be modified to prevent problems from occurring during the calculation when the fluid sticks to the solid surface at points where the velocity is already imposed. The stability coefficient is dimensionless and the value must be small with respect to 1.</p>
+         </sect2>
          <sect2 id="flmatpro_numericalcontrols_contactparameters_penetrationaccuracy">
             <h3>Penetration Accuracy</h3>
             <p>If the penetration of a point into the mold is greater than the penetration accuracy, the time step will be rejected. The calculation will then be restarted from the previous time step with a smaller time-step increment. The default value is set according to the dimensions of the mesh, and you will generally not need to modify it. </p>
@@ -10932,6 +11537,18 @@ face values.</p>
          <sect2 id="flmatpro_numericalcontrols_contactparameters_searchsettings">
             <h3>Search Settings</h3>
             <p>You have the choice of five predefined groups of search settings. The groups can be &#8220;faster&#8221; (that is, result in faster computation times for the search) or &#8220;safer&#8221; (that is, conduct searches that are more thorough but require more computation time). By default, a fast group of settings is selected, as this group is appropriate for a relatively broad range of cases.</p>
+         </sect2>
+         <sect2 id="flmatpro_numericalcontrols_contactparameters_divisions">
+            <h3>Search Sector Divisions per Axis</h3>
+            <p>Allows you to modify the search sector division along each Cartesian axis. In order to speed up the search of contact, the search zone is divided into N sectors along each Cartesian axis, that is, the search zone is divided into N^3 search sectors. The actual search occurs in the sector that contains the point of interest. The larger sector divisions, the faster search in a specific sector but a greater risk of missing something.</p>
+         </sect2>
+         <sect2 id="flmatpro_numericalcontrols_contactparameters_expansion">
+            <h3>Expansion of Search Zone</h3>
+            <p>Allows you to modify the expansion of the search zone. This expansion is a increment to the dimension of the Cartesian box that surrounds the whole mold. This increment is expressed in a percentage of the largest dimension of that box.</p>
+         </sect2>
+         <sect2 id="flmatpro_numericalcontrols_contactparameters_overlap">
+            <h3>Overlap of Sectors</h3>
+            <p>Allows you to modify the overlap of search sectors. Using overlapping sectors decreases the risk of overlooking (large) finite elements on the border of contiguous sectors. The larger the overlap, the safer search but a more expensive search in a given sector.</p>
          </sect2>
          <sect2 id="flmatpro_numericalcontrols_distortioncheck_action">
             <h3>Action if Limits Exceeded</h3>
@@ -10960,6 +11577,10 @@ face values.</p>
          <sect2 id="flmatpro_numericalcontrols_distortioncheck_reductionrate">
             <h3>Reduction Rate of Time Step</h3>
             <p>For transient calculations, specify a value for the time step reduction rate. This is a factor that multiplies the current time step when a significant risk of element distortion is detected.</p>
+         </sect2>
+         <sect2 id="flmatpro_numericalcontrols_advancedvolumeconservation">
+            <h3>Advanced Volume Conservation</h3>
+            <p>Enable this to enhance volume conservation in the calculations involving adaptive meshing.</p>
          </sect2>
          <sect2 id="flmatpro_continuationcontrols_initialstep">
             <h3>Initial Value</h3>
@@ -11031,19 +11652,19 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_voftransientcontrols_maxitertimestep">
             <h3>Maximum Number of Time Steps</h3>
-            <p>help text for maximum number of time steps</p>
+            <p>Specify a value for the maximum number of time steps for the transient calculations.</p>
          </sect2>
          <sect2 id="flmatpro_voftransientcontrols_accuracy">
             <h3>Accuracy</h3>
-            <p>help text for accuracy</p>
+            <p>Controls the accuracy of the scheme. Recommended values of are on the order of 0.2-0.5. Note that an extremely low value of this parameter can reduce the time step to such a degree that the fluid front does not progress anymore. Consequently, the time step will be increased and you then run the risk of engaging in an oscillatory forward/backwards marching scheme that calculates several useless iterations without improved accuracy. An inherent limitation of the VOF model is that it cannot process changes that are smaller than the element size.</p>
          </sect2>
          <sect2 id="flmatpro_voftransientcontrols_filtering">
             <h3>Filtering Threshold on Fluid Fraction</h3>
-            <p>help text for filtering threshold on fluid fraction</p>
+            <p>Some variations of the fluid fraction in the wet zone (far from interface with dry zone) may be filtered with this parameter: all variations higher than this threshold will be smoothed. The variations smaller than the threshold will be unchanged. For example, with a threshold of 0.1, if the local value of the Fluid Fraction is 0.95 (instead of 1.0 ideally), then the variation = 0.05 (= 1.0 - 0.95) is below the threshold. Consequently, the value is unchanged. However, for a value of 0.89 (instead of 1.0 ideally), then the variation = 0.11 (= 1.0 - 0.89) is above the threshold. Consequently, the value will be filtered (value reset to 1.0).</p>
          </sect2>
          <sect2 id="flmatpro_voftransientcontrols_stopwhenfull">
             <h3>Stop Run When Cavity Full</h3>
-            <p>help text for stop run when cavity full</p>
+            <p>By default, the VOF calculation is stopped when the geometry is completely covered by the fluid or when the net flow rate (volume of fluid entering the geometry per unit of time minus volume of fluid exiting the geometry per unit of time) is zero. Disabling this criterion lets the run to reach the final time.</p>
          </sect2>
          <sect2 id="flmatpro_convergencestrategies_evolutionmultiplematerials">
             <h3>Multiple Materials</h3>
@@ -11067,19 +11688,23 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_convergencestrategies_evolutioninflow">
             <h3>Flow at Inlet</h3>
-            <p>Enable this option to assist converging (foaming) flows based on the flow at the inlet.</p>
+            <p>Enable this option to assist converging flows based on the flow at the inlet. Linearly increases the mass flow rate/volume flow rate/normal velocity, starting from 0 to reach the assigned value at the end of the continuation scheme.</p>
          </sect2>
          <sect2 id="flmatpro_convergencestrategies_evolutionfoaming">
             <h3>Foaming</h3>
             <p>Enable this option to assist converging flows based on foaming.</p>
          </sect2>
+         <sect2 id="flmatpro_convergencestrategies_evolutionfsi">
+            <h3>Fluid Structure Interaction (FSI)</h3>
+            <p>Enable this option to assist converging flows with fluid-structure interaction.</p>
+         </sect2>
          <sect2 id="flmatpro_convergencestrategies_evolutionoutflow">
             <h3>Flow at Outlet</h3>
-            <p>Enable this option to assist converging flows based on the flow at the outlet.</p>
+            <p>Enable this option to assist converging flows based on the flow at the outlet. Linearly increases the mass flow rate/volume flow rate/normal velocity, starting from 0 to reach the assigned value at the end of the continuation scheme.</p>
          </sect2>
          <sect2 id="flmatpro_convergencestrategies_evolutiontakeupforce">
-            <h3>Take-up at Extrudate Exit</h3>
-            <p>Enable this option to assist converging flows based on the take-up velocity at the extrudate exit.</p>
+            <h3>Take-Up at Extrudate Exit</h3>
+            <p>Enable this option to assist converging flows based on a take-up velocity/force/force density applied on an extrudate exit. Linearly increases the velocity/force/force density, starting from 0 to reach the assigned value at the end of the continuation scheme.</p>
          </sect2>
          <sect2 id="flmatpro_derivedquantities_addviscousheating">
             <h3>Viscous heating</h3>
@@ -11283,7 +11908,7 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_outputcontrols_moreoutputs_ensight_output">
             <h3>EnSight</h3>
-            <p>Creates output that contains the geometry and the computed fields for use with EnSight.</p>
+            <p>Creates output that contains the geometry and the computed fields for use with EnSight. By default, results are always available in this format as they are required by the workspace for visualizing results.</p>
          </sect2>
          <sect2 id="flmatpro_outputcontrols_moreoutputs_fieldview_output">
             <h3>FieldView</h3>
@@ -11329,25 +11954,9 @@ face values.</p>
             <h3>Bubble Radius Convergence</h3>
             <p>Monitor the convergence of the bubble radius in foaming flows.</p>
          </sect2>
-         <sect2 id="flmatpro_caseinfo_casefilenamedirstripped">
-            <h3>Case</h3>
-            <p>help text for case</p>
-         </sect2>
-         <sect2 id="flmatpro_caseinfo_solvername">
-            <h3>Solver</h3>
-            <p>help text for solver</p>
-         </sect2>
-         <sect2 id="flmatpro_caseinfo_hostname">
-            <h3>Host</h3>
-            <p>help text for host</p>
-         </sect2>
-         <sect2 id="flmatpro_caseinfo_configuration">
-            <h3>Configuration</h3>
-            <p>States case details including dimensions, precision, turbulence model and whether the case is steady-state or transient</p>
-         </sect2>
-         <sect2 id="flmatpro_caseinfo_dimension">
-            <h3>Dimension</h3>
-            <p>Select the dimension type.</p>
+         <sect2 id="flmatpro_monitors_displacementresidual">
+            <h3>Displacement Convergence</h3>
+            <p>Monitor the convergence of the displacement residuals.</p>
          </sect2>
          <sect2 id="flmatpro_calculation_analysistype">
             <h3>Analysis Type</h3>
@@ -11377,14 +11986,6 @@ face values.</p>
             <h3>Value</h3>
             <p>Choose a particular solver method (discretization scheme) option, or use the default setting.</p>
          </sect2>
-         <sect2 id="flmatpro_controls_courantnumber">
-            <h3>Courant Number</h3>
-            <p>help text for courant number</p>
-         </sect2>
-         <sect2 id="flmatpro_residuals_convergencecriteriontype">
-            <h3>Convergence Criterion Type</h3>
-            <p>help text for convergence criterion type</p>
-         </sect2>
          <sect2 id="flmatpro_equation_checkconvergence">
             <h3>Check Convergence</h3>
             <p>Enable this option to check the convergence for this specific equation.</p>
@@ -11392,50 +11993,6 @@ face values.</p>
          <sect2 id="flmatpro_equation_absolutecriterion">
             <h3>Absolute Criterion</h3>
             <p>Specify the absolute criterion for this specific equation, or use the default value.</p>
-         </sect2>
-         <sect2 id="flmatpro_equation_relativecriterion">
-            <h3>Relative Criterion</h3>
-            <p>help text for relative criterion</p>
-         </sect2>
-         <sect2 id="flmatpro_solutionanimations_graphics">
-            <h3>Graphics</h3>
-            <p>help text for graphics</p>
-         </sect2>
-         <sect2 id="flmatpro_solutionanimations_recordafter">
-            <h3>Record After Every</h3>
-            <p>help text for record after every</p>
-         </sect2>
-         <sect2 id="flmatpro_solutionanimations_sequence">
-            <h3>Sequence</h3>
-            <p>help text for sequence</p>
-         </sect2>
-         <sect2 id="flmatpro_solutionanimations_integerindex">
-            <h3>Index</h3>
-            <p>help text for index</p>
-         </sect2>
-         <sect2 id="flmatpro_solutionanimations_realindex">
-            <h3>Wall Clock</h3>
-            <p>help text for wall clock</p>
-         </sect2>
-         <sect2 id="flmatpro_solutionanimations_storagetype">
-            <h3>Storage Type</h3>
-            <p>help text for storage type</p>
-         </sect2>
-         <sect2 id="flmatpro_solutionanimations_storagedirectory">
-            <h3>Storage Directory</h3>
-            <p>help text for storage directory</p>
-         </sect2>
-         <sect2 id="flmatpro_solutionanimations_windowid">
-            <h3>WindowId</h3>
-            <p>help text for windowid</p>
-         </sect2>
-         <sect2 id="flmatpro_solutionanimations_projection">
-            <h3>Projection</h3>
-            <p>help text for projection</p>
-         </sect2>
-         <sect2 id="flmatpro_solutionanimations_view">
-            <h3>View</h3>
-            <p>help text for view</p>
          </sect2>
          <sect2 id="flmatpro_results_reports_name">
             <h3>Name</h3>
@@ -11649,6 +12206,10 @@ face values.</p>
             <h3>Surfaces</h3>
             <p>Select the surface(s) where you want to display the mesh.</p>
          </sect2>
+         <sect2 id="flmatpro_case_results_graphics_mesh_displaylic">
+            <h3>Display LIC</h3>
+            <p>Select to display the line integral convolution.</p>
+         </sect2>
          <sect2 id="flmatpro_case_results_graphics_mesh_shrinkfactor">
             <h3>Shrink Factor</h3>
             <p>Specify a value for the mesh shrink factor. To distinguish individual faces or cells in the display, enlarge the space between adjacent faces or cells by increasing this value.</p>
@@ -11708,6 +12269,10 @@ face values.</p>
          <sect2 id="flmatpro_case_results_graphics_contour_filled">
             <h3>Display Filled Contour</h3>
             <p>Select to visualize the contour plot using filled contours.</p>
+         </sect2>
+         <sect2 id="flmatpro_case_results_graphics_contour_displaylic">
+            <h3>Display LIC</h3>
+            <p>Select to display the line integral convolution.</p>
          </sect2>
          <sect2 id="flmatpro_case_results_graphics_contour_contourlines">
             <h3>Contour Lines</h3>
@@ -11903,7 +12468,7 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_case_results_graphics_pathlines_coarsen">
             <h3>Coarsen</h3>
-            <p>help text for coarsen</p>
+            <p>Reduce the number of pathlines included in the display.</p>
          </sect2>
          <sect2 id="flmatpro_case_results_graphics_pathlines_vectorfield">
             <h3>Vector Field</h3>
@@ -12019,11 +12584,11 @@ face values.</p>
          </sect2>
          <sect2 id="flmatpro_case_results_graphics_pathlines_plot_xaxisfunction">
             <h3>X Axis Function</h3>
-            <p>help text for x axis function.</p>
+            <p>Lists the X-axis function.</p>
          </sect2>
          <sect2 id="flmatpro_case_results_graphics_pathlines_plot_enabled">
             <h3>Enabled</h3>
-            <p>help text for enabled.</p>
+            <p>Enable pathline plots.</p>
          </sect2>
          <sect2 id="flmatpro_case_results_graphics_pathlines_colormap_visible">
             <h3>Visible</h3>
@@ -12191,6 +12756,26 @@ the periodic repeat.</p>
          <sect2 id="flmatpro_case_results_graphics_volumerender_maxvalue">
             <h3>TBD</h3>
             <p>TBD</p>
+         </sect2>
+         <sect2 id="flmatpro_case_results_graphics_licsettings_vectorfield">
+            <h3>Vector Field</h3>
+            <p>Choose an existing vector variable to display on the surface.</p>
+         </sect2>
+         <sect2 id="flmatpro_case_results_graphics_licsettings_contrast">
+            <h3>Contrast</h3>
+            <p>Select to do a pass of image contrast enhancement.</p>
+         </sect2>
+         <sect2 id="flmatpro_case_results_graphics_licsettings_length">
+            <h3>Length</h3>
+            <p>Specify a maximum length of 20 pixel units in the positive and negative directions. Length is a scaling factor of this 20 pixels. Range is 0 to 1.</p>
+         </sect2>
+         <sect2 id="flmatpro_case_results_graphics_licsettings_integrationstep">
+            <h3>Integration Step</h3>
+            <p>Specify the step size in pixel units for each integration step. Range is 0 to 1.</p>
+         </sect2>
+         <sect2 id="flmatpro_case_results_graphics_licsettings_brightness">
+            <h3>Brightness</h3>
+            <p>Specify the surface brightness. Range is 0 to 1.</p>
          </sect2>
          <sect2 id="flmatpro_case_results_graphics_volumerender_colormap_visible">
             <h3>Visible</h3>
@@ -12544,16 +13129,16 @@ the periodic repeat.</p>
             <h3>Scale</h3>
             <p>Specify the size of the boundary markers.</p>
          </sect2>
+         <sect2 id="flmatpro_displaysettings_lighting">
+            <h3>Lighting</h3>
+            <p>Select to apply light sources to your viewport.</p>
+         </sect2>
       </sect1>
    </chapter>
    <article id="flu_ws_aer">
       <h3>Ansys Fluent Aero Workspace - Dialog-Level Quick Help &amp; Field-Level Help</h3>
       <sect1 id="aerws">
          <h3>Aero Workspace</h3>
-         <sect2 id="app_runtype">
-            <h3>Run Type</h3>
-            <p>Help text for Run Type</p>
-         </sect2>
          <sect2 id="app_runtype_airflow">
             <h3>Airflow</h3>
             <p>Help text for Airflow</p>
@@ -12566,17 +13151,9 @@ the periodic repeat.</p>
             <h3>Mode</h3>
             <p>Help text for Mode</p>
          </sect2>
-         <sect2 id="app_solution">
-            <h3>Solution</h3>
-            <p>Help text for Solution</p>
-         </sect2>
          <sect2 id="app_solution_airflowrun">
             <h3>Airflow Run</h3>
             <p>Help text for Airflow Run</p>
-         </sect2>
-         <sect2 id="app_solution_airflowrun_airflowfluentoutputsolution">
-            <h3>Airflow Fluent Output Solution</h3>
-            <p>Help text for Airflow Fluent Output Solution</p>
          </sect2>
          <sect2 id="app_bc">
             <h3>B C</h3>
@@ -12652,7 +13229,7 @@ the periodic repeat.</p>
          </sect2>
          <sect2 id="app_bc_airflowmassflowinlet_turbintermittency">
             <h3>Intermittency</h3>
-            <p>Specify Intermittency to&#160;measure the probability that a given point is located insidea turbulent region.</p>
+            <p>Specify Intermittency to&#160;measure the probability that a given point is located inside a turbulent region.</p>
          </sect2>
          <sect2 id="app_bc_airflowmassflowinlet_temperatureinput">
             <h3>Temperature Input</h3>
@@ -12727,6 +13304,38 @@ each Design Point.</p>
          <sect2 id="app_bc_airflowvelocityinlet_turbviscratio">
             <h3>Turbulent Viscosity Ratio</h3>
             <p>Specify the values for the&#160;turbulent viscosity ratio.</p>
+         </sect2>
+         <sect2 id="app_bc_airflowvelocityinlet_supersonicpressureinput">
+            <h3>Supersonic/Initial Pressure</h3>
+            <p>Choose how the value of the input parameter is distributed across each Design Point.</p>
+         </sect2>
+         <sect2 id="app_bc_airflowvelocityinlet_supersonicpressure">
+            <h3>Supersonic/Initial Pressure [Pa]</h3>
+            <p>Specify the Supersonic/Initial Pressure for this boundary condition.</p>
+         </sect2>
+         <sect2 id="app_bc_airflowvelocityinlet_supersonicpressurecustom">
+            <h3>Parameter Name</h3>
+            <p>Specify the name of the custom variable that is used to control the supersonic/initial pressure of the pressure inlet zone. The default name of the expression uses the following format: zone_name_P.</p>
+         </sect2>
+         <sect2 id="app_bc_airflowwall_bcsync">
+            <h3>Conditions</h3>
+            <p>Choose Edit to expose the boundary condition settings for this zone or Case Settings to have Fluent use whichever boundary conditions settings defined on this zone in the input Case file.</p>
+         </sect2>
+         <sect2 id="app_bc_airflowwall_heatfluxinput">
+            <h3>Heat Flux</h3>
+            <p>Choose how the value of the input parameter is distributed across each Design Point.</p>
+         </sect2>
+         <sect2 id="app_bc_airflowwall_temperatureinput">
+            <h3>Temperature</h3>
+            <p>Choose how the value of the input parameter is distributed across each Design Point.</p>
+         </sect2>
+         <sect2 id="app_bc_airflowwall_temperaturecustom">
+            <h3>Parameter</h3>
+            <p>Specify the name of the custom variable that is used to control the temperature of the wall zone. The default name of the expression uses the following format: zone_name_T.</p>
+         </sect2>
+         <sect2 id="app_bc_airflowwall_heatfluxcustom">
+            <h3>Parameter</h3>
+            <p>Specify the name of the custom variable that is used to control the heat flux of the wall zone. The default name of the expression uses the following format: zone_name_q.</p>
          </sect2>
          <sect2 id="app_bc_airflowpressureoutlet_bcsync">
             <h3>B C Sync</h3>
@@ -13279,23 +13888,6 @@ each Design Point.</p>
             <h3>Solution</h3>
             <p>Choose the Design Point that you want to use for creating the contour plot.</p>
          </sect2>
-         <sect2 id="aeroworkflow_modelssettings_turbulencemodel">
-            <h3>Turbulence Model</h3>
-            <p>Choose the Turbulence model to use with the calculation.</p>
-         </sect2>
-         <sect2 id="aeroworkflow_modelssettings_transsstroughconst">
-            <h3>Trans S S T Rough Const</h3>
-            <p>Specify to apply viscous heating and Transition SST Roughness Constant correlation.</p>
-         </sect2>
-         <sect2 id="aeroworkflow_modelssettings_twotempmodel">
-            <h3>Two Temp Model</h3>
-            <p>Choose to control the Two Temperature Model in your Fluent Aero simulation. This model
-is only available if Solver Type is set to Density based.</p>
-         </sect2>
-         <sect2 id="aeroworkflow_materialssettings_fluidproperties">
-            <h3>Fluid Properties</h3>
-            <p>Choose from two types of air material properties depending on the activation of the Two Temperature Model.</p>
-         </sect2>
          <sect2 id="aeroworkflow_solutionsettings_solvermethods">
             <h3>Solver Methods</h3>
             <p>Choose to apply Fluent Aero&#8217;s Default Solution Methods or choose&#160;Case settings to use those currently set in the Solution Workspace.</p>
@@ -13355,6 +13947,10 @@ conditions in the first set of iterations.</p>
             <h3>Initialize Between D Ps</h3>
             <p>Select to perform an Initialization at the beginning of the calculation of each Design Point.</p>
          </sect2>
+         <sect2 id="aeroworkflow_solution_solve_initializationsettings_fmgviscous">
+            <h3>FMG Viscous</h3>
+            <p>Choose the viscous mode of the FMG initialization.</p>
+         </sect2>
          <sect2 id="aeroworkflow_convergencesettings_convcutoff">
             <h3>Conv Cutoff</h3>
             <p>Specify the convergence residual value at which the calculation of a design
@@ -13363,7 +13959,7 @@ point will stop if all the solver residuals drop below this value.</p>
          <sect2 id="aeroworkflow_convergencesettings_outputparamsconvcutoff">
             <h3>Output Params Conv Cutoff</h3>
             <p>Specify the convergence cutoff for the Lift, the Drag and the Moment coefficients.
-The default value is 2e-4.</p>
+The default value is 2e-5.</p>
          </sect2>
          <sect2 id="aeroworkflow_convergencesettings_outputparamsprevvals">
             <h3>Output Params Prev Vals</h3>
@@ -13470,14 +14066,6 @@ Aero would use for a Design Point.</p>
             <h3>Show Advanced</h3>
             <p>Select to configure advanced settings.</p>
          </sect2>
-         <sect2 id="aeroworkflow_solve_solvertype">
-            <h3>Solver Type</h3>
-            <p>Choose the solver type used to perform the calculations.</p>
-         </sect2>
-         <sect2 id="aeroworkflow_solution">
-            <h3>Solution</h3>
-            <p>Help text for Solution</p>
-         </sect2>
          <sect2 id="aeroworkflow_solution_solve_solutionsettings_enhancedcasm">
             <h3>Enhanced CASM</h3>
             <p>Enable the enhanced convergence acceleration for stretched meshes.</p>
@@ -13555,6 +14143,162 @@ each Design Point.</p>
          <sect2 id="aeroworkflow_flowspeed_massflownum">
             <h3>Number of Points</h3>
             <p>Specify the number of design points to consider.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_parameter">
+            <h3>Parameter</h3>
+            <p>Choose the type of input parameter that will be used to defi&#8203;ne the turbulence specification method.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_distributionintermittency">
+            <h3>Distribution: Intermittency</h3>
+            <p>Choose how the value of the input parameter is distributed across each Design Point.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_intermittencymin">
+            <h3>Minimum Intermittency</h3>
+            <p>Specify the minimum intermittency for each Design Point.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_intermittencymax">
+            <h3>Maximum Intermittency</h3>
+            <p>Specify the maximum intermittency for each Design Point.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_intermittencynum">
+            <h3>Number of Points</h3>
+            <p>Specify the number of points used for the selected parameter.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_intermittency">
+            <h3>Intermittency</h3>
+            <p>Specify the value for intermittency.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_distributionintensity">
+            <h3>Distribution: Turbulent Intensity</h3>
+            <p>Choose how the value of the input parameter is distributed across each Design Point.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_intensitymin">
+            <h3>Minimum Turbulent Intensity</h3>
+            <p>Specify the minimum turbulent intensity for each Design Point.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_intensitymax">
+            <h3>Maximum Turbulent Intensity</h3>
+            <p>Specify the maximum turbulent intensity for each Design Point.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_intensitynum">
+            <h3>Number of Points</h3>
+            <p>Specify the number of points used for the selected parameter.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_intensity">
+            <h3>Turbulent Intensity</h3>
+            <p>Specify the values for the turbulent intensity.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_distributionlengthscale">
+            <h3>Distribution: Turbulent Length Scale</h3>
+            <p>Choose how the value of the input parameter is distributed across each Design Point.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_distributionviscratio">
+            <h3>Distribution: Turbulent Viscosity Ratio</h3>
+            <p>Choose how the value of the input parameter is distributed across each Design Point.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_viscratiomin">
+            <h3>Minimum Turbulent Viscosity Ratio</h3>
+            <p>Specify the minimum turbulent viscosity ratio for each Design Point.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_viscratiomax">
+            <h3>Maximum Turbulent Viscosity Ratio</h3>
+            <p>Specify the maximum turbulent viscosity ratio for each Design Point.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_viscrationum">
+            <h3>Number of Points</h3>
+            <p>Specify the number of points used for the selected parameter.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_viscratio">
+            <h3>Turbulent Viscosity Ratio</h3>
+            <p>Specify the values for the turbulent viscosity ratio.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_lengthscale">
+            <h3>Turbulent Length Scale [m]</h3>
+            <p>Specify the values for the turbulent length scale.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_lengthscalemin">
+            <h3>Minimum Turbulent Length Scale [m]</h3>
+            <p>Specify the minimum turbulent scale for each Design Point.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_lengthscalemax">
+            <h3>Maximum Turbulent Length Scale [m]</h3>
+            <p>Specify the maximum turbulent scale for each Design Point.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_turbulence_lengthscalenum">
+            <h3>Number of Points</h3>
+            <p>Specify the number of points used for the selected parameter.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_flightconditions_flowdirection_aoa_sum">
+            <h3>Number of Points</h3>
+            <p>Specify the number of points used for the selected parameter.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_wallconditions_allwalls">
+            <h3>Apply to All Walls</h3>
+            <p>Set the same wall conditions for all walls inside the Component Groups step.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_wallconditions_wallthermalconditions_parameter">
+            <h3>Parameter</h3>
+            <p>Specify the thermal conditions method: Heat Flux and Temperature can be selected.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_wallconditions_wallthermalconditions_distribution">
+            <h3>Distribution</h3>
+            <p>Choose how the value of the input parameters selected above is distributed across each design point.</p>
+         </sect2>
+         <sect2 id="flow_heatflux">
+            <h3>Heat Flux</h3>
+            <p>Specify a constant heat flux value that will be applied to all wall zones for all the design points.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_wallconditions_wallthermalconditions_heatfluxmin">
+            <h3>Minimum Heat Flux [W/m2]</h3>
+            <p>Specify the minimum heat flux value.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_wallconditions_wallthermalconditions_heatfluxmax">
+            <h3>Maximum Heat Flux [W/m2]</h3>
+            <p>Specify the maximum heat flux value.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_wallconditions_wallthermalconditions_heatfluxnum">
+            <h3>Number of Points</h3>
+            <p>Specify the number of points used for the selected parameter.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_wallconditions_wallthermalconditions_temperature">
+            <h3>Temperature [K]</h3>
+            <p>Specify a constant temperature value that will be applied to all wall zones for all the design points.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_wallconditions_wallthermalconditions_temperaturemin">
+            <h3>Minimum Temperature [K]</h3>
+            <p>Specify the minimum temperature value.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_wallconditions_wallthermalconditions_temperaturemax">
+            <h3>Maximum Temperature [K]</h3>
+            <p>Specify the maximum temperature value.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_setup_simulationconditions_wallconditions_wallthermalconditions_temperaturenum">
+            <h3>Number of Points</h3>
+            <p>Specify the number of points used for the selected parameter.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_solution_solve_solvemode">
+            <h3>Convergence Settings</h3>
+            <p>Choose which type of default Solve settings to use when calculating design points.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_solution_solve_solutionsettings_casmcutoff">
+            <h3>CASM Cutoff</h3>
+            <p>Specify the Cut-off Multiplier for the Convergence Acceleration for Stretched Meshes method.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_solution_solve_solutionsettings_hotrrelax">
+            <h3>HOTR Relaxation Factor</h3>
+            <p> Specify the Relaxation Factor for the High Order Term Relaxation method.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_solution_solve_solutionsettings_steeringstageoneiterations">
+            <h3>Steering Stage 1 Iterations</h3>
+            <p>Specify the number of iterations to calculate in stage 1 of the solution steering, using the initial courant number.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_solution_solve_solutionsettings_steeringstagetwoupdatecflafter">
+            <h3>Steering Stage 2 Update CFL After</h3>
+            <p>Specify the number of iterations to calculate in stage 2 of the solution steering, where the courant number increases from its initial to maximum value.</p>
+         </sect2>
+         <sect2 id="aeroworkflow_solution_solve_solutionsettings_steeringstagetwoupdatecflinterval">
+            <h3>Steering Stage 2 Update CFL Interval</h3>
+            <p>Specify the iteration interval after which the courant number will increase during stage 2 of the solution steering.</p>
          </sect2>
          <sect2 id="aeroworkflow_flowspeed_mach">
             <h3>Mach</h3>
@@ -13826,6 +14570,10 @@ parameter.</p>
             <h3>Domain Type</h3>
             <p>Choose a domain type to simulate the airflow around an aircraft during typical in-flight conditions or inside an experimental wind tunnel test section.</p>
          </sect2>
+         <sect2 id="aeroworkflow_geometricproperties_domaindimension">
+            <h3>Domain Dimension</h3>
+            <p>Choose whether the domain consists of a full 3D geometry (3D), or a 2D geometry that has been extruded to construct a 1 cell thick 3D mesh (2.5D).</p>
+         </sect2>
          <sect2 id="aeroworkflow_geometricproperties_liftdir">
             <h3>Lift Dir</h3>
             <p>Choose which cartesian direction corresponds to the direction of the Lift vector in the scenario that the geometry is operating at a 0 degree angle of attack.</p>
@@ -13861,6 +14609,27 @@ parameter.</p>
          <sect2 id="aeroworkflow_geometricproperties_prjarea">
             <h3>Prj Area</h3>
             <p>Select to compute the reference area of your geometry.</p>
+         </sect2>
+         <sect2 id="airflowphysics_solver_type">
+            <h3>Type</h3>
+            <p>Choose the solver type used to perform the calculations.</p>
+         </sect2>
+         <sect2 id="airflowphysics_models_turbulencemodel">
+            <h3>Turbulence</h3>
+            <p>Choose the Turbulence model to use with the calculation.</p>
+         </sect2>
+         <sect2 id="airflowphysics_models_transsstroughconst">
+            <h3>Trans SST Roughness Constant</h3>
+            <p>Specify to apply viscous heating and Transition SST Roughness Constant correlation.</p>
+         </sect2>
+         <sect2 id="airflowphysics_models_twotempmodel">
+            <h3>Two Temp Model</h3>
+            <p>Choose to control the Two Temperature Model in your Fluent Aero simulation. This model
+is only available if Solver Type is set to Density based.</p>
+         </sect2>
+         <sect2 id="airflowphysics_materials_fluidproperties">
+            <h3>Fluid Properties</h3>
+            <p>Choose the group of Air Material Properties to use in your Fluent Aero Simulation.</p>
          </sect2>
          <sect2 id="aeroworkflow_componentgroups">
             <h3>Component Groups</h3>
@@ -14074,10 +14843,6 @@ parameter.</p>
             <h3>Intermittency</h3>
             <p>Specify Intermittency to&#160;measure the probability that a given point is located inside a turbulent region.</p>
          </sect2>
-         <sect2 id="flow_thermalconditions">
-            <h3>Thermal Conditions</h3>
-            <p>Help text for Thermal Conditions</p>
-         </sect2>
          <sect2 id="flow_temperature">
             <h3>Temperature</h3>
             <p>Help text for Temperature</p>
@@ -14085,10 +14850,6 @@ parameter.</p>
          <sect2 id="flow_backflowtotaltemperature">
             <h3>Backflow Total Temperature</h3>
             <p>Help text for Backflow Total Temperature</p>
-         </sect2>
-         <sect2 id="flow_heatflux">
-            <h3>Heat Flux</h3>
-            <p>Help text for Heat Flux</p>
          </sect2>
          <sect2 id="flow_heattransfercoefficient">
             <h3>Heat Transfer Coefficient</h3>
@@ -16412,10 +17173,6 @@ parameter.</p>
             <h3>Particle Tracks Field</h3>
             <p>Specify how the particle tracks are colored</p>
          </sect2>
-         <sect2 id="gpuapp_remotesession_case_results_graphics_xyplot_options">
-            <h3>Options</h3>
-            <p>Help text for Options</p>
-         </sect2>
          <sect2 id="gpuapp_remotesession_case_results_graphics_xyplot_options_nodevalues">
             <h3>Node Values</h3>
             <p>Enable to plot values at nodes.</p>
@@ -16432,17 +17189,9 @@ parameter.</p>
             <h3>Z Component</h3>
             <p>Help text for Z Component</p>
          </sect2>
-         <sect2 id="gpuapp_remotesession_case_results_graphics_xyplot_yaxisfunction">
-            <h3>Y Axis Function</h3>
-            <p>Help text for Y Axis Function</p>
-         </sect2>
          <sect2 id="gpuapp_remotesession_case_results_graphics_xyplot_yaxisfunction_positiononcurrentaxis">
             <h3>Position On Y Axis</h3>
             <p>Enable to plot position on the y-axis.</p>
-         </sect2>
-         <sect2 id="gpuapp_remotesession_case_results_graphics_xyplot_yaxisfunction_directionvector">
-            <h3>Direction Vector</h3>
-            <p>Help text for Direction Vector</p>
          </sect2>
          <sect2 id="gpuapp_remotesession_case_results_graphics_xyplot_yaxisfunction_directionvector_xcomponent">
             <h3>X Component</h3>
@@ -16460,17 +17209,9 @@ parameter.</p>
             <h3>Field</h3>
             <p>Select the field to plot on the y-axis.</p>
          </sect2>
-         <sect2 id="gpuapp_remotesession_case_results_graphics_xyplot_xaxisfunction">
-            <h3>X Axis Function</h3>
-            <p>Help text for X Axis Function</p>
-         </sect2>
          <sect2 id="gpuapp_remotesession_case_results_graphics_xyplot_xaxisfunction_positiononcurrentaxis">
             <h3>Position On X Axis</h3>
             <p>Enable to plot position on the x-axis.</p>
-         </sect2>
-         <sect2 id="gpuapp_remotesession_case_results_graphics_xyplot_xaxisfunction_directionvector">
-            <h3>Direction Vector</h3>
-            <p>Help text for Direction Vector</p>
          </sect2>
          <sect2 id="gpuapp_remotesession_case_results_graphics_xyplot_xaxisfunction_directionvector_xcomponent">
             <h3>X Component</h3>
@@ -16728,17 +17469,9 @@ parameter.</p>
             <h3>Filename</h3>
             <p>Specify the file that contains the plot information.</p>
          </sect2>
-         <sect2 id="gpuapp_remotesession_case_results_plots_plotfromfile_yaxisfunction">
-            <h3>Y Axis Function</h3>
-            <p>Help text for Y Axis Function</p>
-         </sect2>
          <sect2 id="gpuapp_remotesession_case_results_plots_plotfromfile_yaxisfunction_field">
             <h3>Field</h3>
             <p>Select the field to plot on the y-axis.</p>
-         </sect2>
-         <sect2 id="gpuapp_remotesession_case_results_plots_plotfromfile_xaxisfunction">
-            <h3>X Axis Function</h3>
-            <p>Help text for X Axis Function</p>
          </sect2>
          <sect2 id="gpuapp_remotesession_case_results_plots_plotfromfile_xaxisfunction_field">
             <h3>Field</h3>
@@ -16878,11 +17611,11 @@ parameter.</p>
          </sect2>
          <sect2 id="gpuapp_remotesession_case_results_graphics_pathlines_plot_xaxisfunction">
             <h3>X Axis Function</h3>
-            <p>help text for x axis function.</p>
+            <p>Lists the X-axis function.</p>
          </sect2>
          <sect2 id="gpuapp_remotesession_case_results_graphics_pathlines_plot_enabled">
             <h3>Enabled</h3>
-            <p>help text for enabled.</p>
+            <p>Enable pathline plots.</p>
          </sect2>
          <sect2 id="gpuapp_remotesession_case_results_graphics_pathlines_step">
             <h3>Step</h3>
@@ -16894,7 +17627,7 @@ parameter.</p>
          </sect2>
          <sect2 id="gpuapp_remotesession_case_results_graphics_pathlines_coarsen">
             <h3>Coarsen</h3>
-            <p>help text for coarsen</p>
+            <p>Reduce the number of pathlines included in the display.</p>
          </sect2>
          <sect2 id="gpuapp_remotesession_case_results_graphics_pathlines_pathlinesfield">
             <h3>Pathlines Field</h3>
@@ -17009,6 +17742,54 @@ parameter.</p>
          <sect2 id="post_analysis_annotation_justification">
             <h3>Justification</h3>
             <p>Choose to give the annotation text left, right or center justification.</p>
+         </sect2>
+         <sect2 id="post_analysis_case_results_differencefield_field">
+            <h3>Field</h3>
+            <p>Select the field variable to be used in the difference.</p>
+         </sect2>
+         <sect2 id="post_analysis_case_results_differencefield_sourcedataset">
+            <h3>SourceDataset</h3>
+            <p>Choose the dataset with which the difference will be computed.</p>
+         </sect2>
+         <sect2 id="post_analysis_case_results_differencefield_surfaces">
+            <h3>Surfaces</h3>
+            <p>Select the surfaces where the difference will be created.</p>
+         </sect2>
+         <sect2 id="post_analysis_case_results_differencefield_volumes">
+            <h3>Volumes</h3>
+            <p>Select the volumes where the difference will be created.</p>
+         </sect2>
+         <sect2 id="post_analysis_case_results_differencefield_interpolationoptions_mappingoption">
+            <h3>Mapping Option</h3>
+            <p>Choose how the node under Source Dataset, used for the comparison, will be found.</p>
+         </sect2>
+         <sect2 id="post_analysis_case_results_differencefield_interpolationoptions_searchoption">
+            <h3>Search Option</h3>
+            <p>Choose how the node under Source Dataset, used for the comparison, will be searched.</p>
+         </sect2>
+         <sect2 id="post_analysis_case_results_createdifferencefields_fields">
+            <h3>Fields</h3>
+            <p>Select the field variable to be used in the difference.</p>
+         </sect2>
+         <sect2 id="post_analysis_case_results_createdifferencefields_sourcedataset">
+            <h3>SourceDataset</h3>
+            <p>Choose the dataset with which the difference will be computed.</p>
+         </sect2>
+         <sect2 id="post_analysis_case_results_createdifferencefields_surfaces">
+            <h3>Surfaces</h3>
+            <p>Select the surfaces where the difference will be created.</p>
+         </sect2>
+         <sect2 id="post_analysis_case_results_createdifferencefields_volumes">
+            <h3>Volumes</h3>
+            <p>Select the volumes where the difference will be created.</p>
+         </sect2>
+         <sect2 id="post_analysis_case_results_createdifferencefields_interpolationoptions_mappingoption">
+            <h3>Mapping Option</h3>
+            <p>Choose how the node under Source Dataset, used for the comparison, will be found.</p>
+         </sect2>
+         <sect2 id="post_analysis_case_results_createdifferencefields_interpolationoptions_searchoption">
+            <h3>Search Option</h3>
+            <p>Choose how the node under Source Dataset, used for the comparison, will be searched.</p>
          </sect2>
          <sect2 id="post_analysis_case_results_surfacedefs_isoclipsettings_field">
             <h3>Field</h3>
@@ -17202,6 +17983,26 @@ parameter.</p>
             <h3>Z Origin [m]</h3>
             <p>Specify the z-coordinate of the mirror plane origin.</p>
          </sect2>
+         <sect2 id="post_analysis_case_results_graphics_licsettings_vectorfield">
+            <h3>Vector Field</h3>
+            <p>Choose an existing vector variable to display on the surface.</p>
+         </sect2>
+         <sect2 id="post_analysis_case_results_graphics_licsettings_contrast">
+            <h3>Contrast</h3>
+            <p>Select to do a pass of image contrast enhancement.</p>
+         </sect2>
+         <sect2 id="post_analysis_case_results_graphics_licsettings_length">
+            <h3>Length</h3>
+            <p>Specify a maximum length of 20 pixel units in the positive and negative directions. Length is a scaling factor of this 20 pixels. Range is 0 to 1.</p>
+         </sect2>
+         <sect2 id="post_analysis_case_results_graphics_licsettings_integrationstep">
+            <h3>Integration Step</h3>
+            <p>Specify the step size in pixel units for each integration step. Range is 0 to 1.</p>
+         </sect2>
+         <sect2 id="post_analysis_case_results_graphics_licsettings_brightness">
+            <h3>Brightness</h3>
+            <p>Specify the surface brightness. Range is 0 to 1.</p>
+         </sect2>
          <sect2 id="post_analysis_case_results_graphics_mesh_surfaces">
             <h3>Surfaces</h3>
             <p>Select the surface(s) where you want to display the mesh.</p>
@@ -17269,6 +18070,10 @@ parameter.</p>
          <sect2 id="post_analysis_case_results_graphics_contour_filled">
             <h3>Filled</h3>
             <p>Select to visualize the contour plot using filled contours.</p>
+         </sect2>
+         <sect2 id="post_analysis_case_results_graphics_contour_displaylic">
+            <h3>Display LIC</h3>
+            <p>Select to display the line integral convolution.</p>
          </sect2>
          <sect2 id="post_analysis_case_results_graphics_contour_contourlines">
             <h3>Contour Lines</h3>
@@ -17596,7 +18401,7 @@ parameter.</p>
          </sect2>
          <sect2 id="post_analysis_case_results_graphics_pathlines_coarsen">
             <h3>Coarsen</h3>
-            <p>help text for coarsen</p>
+            <p>Reduce the number of pathlines included in the display.</p>
          </sect2>
          <sect2 id="post_analysis_case_results_graphics_pathlines_pathlinesfield">
             <h3>Pathlines Field</h3>
@@ -17712,11 +18517,11 @@ parameter.</p>
          </sect2>
          <sect2 id="post_analysis_case_results_graphics_pathlines_plot_xaxisfunction">
             <h3>X Axis Function</h3>
-            <p>help text for x axis function.</p>
+            <p>Lists the X-axis function.</p>
          </sect2>
          <sect2 id="post_analysis_case_results_graphics_pathlines_plot_enabled">
             <h3>Enabled</h3>
-            <p>help text for enabled.</p>
+            <p>Enable pathline plots.</p>
          </sect2>
          <sect2 id="post_analysis_case_results_graphics_pathlines_colormap_visible">
             <h3>Visible</h3>
@@ -18213,6 +19018,18 @@ the periodic repeat.</p>
             <h3>Size</h3>
             <p>Choose a size to apply to the curve marker.</p>
          </sect2>
+         <sect2 id="post_analysis_casecomparison_active">
+            <h3>Active</h3>
+            <p>Select to activate the case comparison.</p>
+         </sect2>
+         <sect2 id="post_analysis_casecomparison_datasets">
+            <h3>Datasets</h3>
+            <p>Select the datasets to use for the case comparison.</p>
+         </sect2>
+         <sect2 id="post_analysis_casecomparison_viewportlayout">
+            <h3>Viewport Layout</h3>
+            <p>Choose the layout orientation for the case comparison.</p>
+         </sect2>
       </sect1>
    </article>
    <article id="flu_ws_post_file">
@@ -18314,6 +19131,54 @@ the periodic repeat.</p>
          <sect2 id="file_results_annotation_justification">
             <h3>Justification</h3>
             <p>Choose to give the annotation text left, right or center justification.</p>
+         </sect2>
+         <sect2 id="file_results_case_results_differencefield_field">
+            <h3>Field</h3>
+            <p>Select the field variable to be used in the difference.</p>
+         </sect2>
+         <sect2 id="file_results_case_results_differencefield_sourcedataset">
+            <h3>SourceDataset</h3>
+            <p>Choose the dataset with which the difference will be computed.</p>
+         </sect2>
+         <sect2 id="file_results_case_results_differencefield_surfaces">
+            <h3>Surfaces</h3>
+            <p>Select the surfaces where the difference will be created.</p>
+         </sect2>
+         <sect2 id="file_results_case_results_differencefield_volumes">
+            <h3>Volumes</h3>
+            <p>Select the volumes where the difference will be created.</p>
+         </sect2>
+         <sect2 id="file_results_case_results_differencefield_interpolationoptions_mappingoption">
+            <h3>Mapping Option</h3>
+            <p>Choose how the node under Source Dataset, used for the comparison, will be found.</p>
+         </sect2>
+         <sect2 id="file_results_case_results_differencefield_interpolationoptions_searchoption">
+            <h3>Search Option</h3>
+            <p>Choose how the node under Source Dataset, used for the comparison, will be searched.</p>
+         </sect2>
+         <sect2 id="file_results_case_results_createdifferencefields_fields">
+            <h3>Fields</h3>
+            <p>Select the field variable to be used in the difference.</p>
+         </sect2>
+         <sect2 id="file_results_case_results_createdifferencefields_sourcedataset">
+            <h3>SourceDataset</h3>
+            <p>Choose the dataset with which the difference will be computed.</p>
+         </sect2>
+         <sect2 id="file_results_case_results_createdifferencefields_surfaces">
+            <h3>Surfaces</h3>
+            <p>Select the surfaces where the difference will be created.</p>
+         </sect2>
+         <sect2 id="file_results_case_results_createdifferencefields_volumes">
+            <h3>Volumes</h3>
+            <p>Select the volumes where the difference will be created.</p>
+         </sect2>
+         <sect2 id="file_results_case_results_createdifferencefields_interpolationoptions_mappingoption">
+            <h3>Mapping Option</h3>
+            <p>Choose how the node under Source Dataset, used for the comparison, will be found.</p>
+         </sect2>
+         <sect2 id="file_results_case_results_createdifferencefields_interpolationoptions_searchoption">
+            <h3>Search Option</h3>
+            <p>Choose how the node under Source Dataset, used for the comparison, will be searched.</p>
          </sect2>
          <sect2 id="file_results_case_results_surfacedefs_isoclipsettings_field">
             <h3>Field</h3>
@@ -18511,6 +19376,26 @@ the periodic repeat.</p>
             <h3>Z Origin [m]</h3>
             <p>Specify the z-coordinate of the mirror plane origin.</p>
          </sect2>
+         <sect2 id="file_results_case_results_graphics_licsettings_vectorfield">
+            <h3>Vector Field</h3>
+            <p>Choose an existing vector variable to display on the surface.</p>
+         </sect2>
+         <sect2 id="file_results_case_results_graphics_licsettings_contrast">
+            <h3>Contrast</h3>
+            <p>Select to do a pass of image contrast enhancement.</p>
+         </sect2>
+         <sect2 id="file_results_case_results_graphics_licsettings_length">
+            <h3>Length</h3>
+            <p>Specify a maximum length of 20 pixel units in the positive and negative directions. Length is a scaling factor of this 20 pixels. Range is 0 to 1.</p>
+         </sect2>
+         <sect2 id="file_results_case_results_graphics_licsettings_integrationstep">
+            <h3>Integration Step</h3>
+            <p>Specify the step size in pixel units for each integration step. Range is 0 to 1.</p>
+         </sect2>
+         <sect2 id="file_results_case_results_graphics_licsettings_brightness">
+            <h3>Brightness</h3>
+            <p>Specify the surface brightness. Range is 0 to 1.</p>
+         </sect2>
          <sect2 id="file_results_case_results_graphics_mesh_shrinkfactor">
             <h3>Shrink Factor</h3>
             <p>Specify a value for the mesh shrink factor. To distinguish individual faces or cells in the display, enlarge the space between adjacent faces or cells by increasing this value.</p>
@@ -18574,6 +19459,10 @@ the periodic repeat.</p>
          <sect2 id="file_results_case_results_graphics_contour_filled">
             <h3>Filled</h3>
             <p>Select to visualize the contour plot using filled contours.</p>
+         </sect2>
+         <sect2 id="file_results_case_results_graphics_contour_displaylic">
+            <h3>Display LIC</h3>
+            <p>Select to display the line integral convolution.</p>
          </sect2>
          <sect2 id="file_results_case_results_graphics_contour_contourlines">
             <h3>Contour Lines</h3>
@@ -18901,7 +19790,7 @@ the periodic repeat.</p>
          </sect2>
          <sect2 id="file_results_case_results_graphics_pathlines_coarsen">
             <h3>Coarsen</h3>
-            <p>help text for coarsen</p>
+            <p>Reduce the number of pathlines included in the display.</p>
          </sect2>
          <sect2 id="file_results_case_results_graphics_pathlines_pathlinesfield">
             <h3>Pathlines Field</h3>
@@ -19017,11 +19906,11 @@ the periodic repeat.</p>
          </sect2>
          <sect2 id="file_results_case_results_graphics_pathlines_plot_xaxisfunction">
             <h3>X Axis Function</h3>
-            <p>help text for x axis function.</p>
+            <p>Lists the X-axis function.</p>
          </sect2>
          <sect2 id="file_results_case_results_graphics_pathlines_plot_enabled">
             <h3>Enabled</h3>
-            <p>help text for enabled.</p>
+            <p>Enable pathline plots.</p>
          </sect2>
          <sect2 id="file_results_case_results_graphics_pathlines_colormap_visible">
             <h3>Visible</h3>
@@ -19514,6 +20403,18 @@ the periodic repeat.</p>
             <h3>Size</h3>
             <p>Choose a size to apply to the curve marker.</p>
          </sect2>
+         <sect2 id="file_results_casecomparison_active">
+            <h3>Active</h3>
+            <p>Select to activate the case comparison.</p>
+         </sect2>
+         <sect2 id="file_results_casecomparison_datasets">
+            <h3>Datasets</h3>
+            <p>Select the datasets to use for the case comparison.</p>
+         </sect2>
+         <sect2 id="file_results_casecomparison_viewportlayout">
+            <h3>Viewport Layout</h3>
+            <p>Choose the layout orientation for the case comparison.</p>
+         </sect2>
       </sect1>
    </article>
    <article id="flu_ws_post_live">
@@ -19611,6 +20512,54 @@ the periodic repeat.</p>
          <sect2 id="live_results_annotation_justification">
             <h3>Justification</h3>
             <p>Choose to give the annotation text left, right or center justification.</p>
+         </sect2>
+         <sect2 id="live_results_case_results_differencefield_field">
+            <h3>Field</h3>
+            <p>Select the field variable to be used in the difference.</p>
+         </sect2>
+         <sect2 id="live_results_case_results_differencefield_sourcedataset">
+            <h3>SourceDataset</h3>
+            <p>Choose the dataset with which the difference will be computed.</p>
+         </sect2>
+         <sect2 id="live_results_case_results_differencefield_surfaces">
+            <h3>Surfaces</h3>
+            <p>Select the surfaces where the difference will be created.</p>
+         </sect2>
+         <sect2 id="live_results_case_results_differencefield_volumes">
+            <h3>Volumes</h3>
+            <p>Select the volumes where the difference will be created.</p>
+         </sect2>
+         <sect2 id="live_results_case_results_differencefield_interpolationoptions_mappingoption">
+            <h3>Mapping Option</h3>
+            <p>Choose how the node under Source Dataset, used for the comparison, will be found.</p>
+         </sect2>
+         <sect2 id="live_results_case_results_differencefield_interpolationoptions_searchoption">
+            <h3>Search Option</h3>
+            <p>Choose how the node under Source Dataset, used for the comparison, will be searched.</p>
+         </sect2>
+         <sect2 id="live_results_case_results_createdifferencefields_fields">
+            <h3>Fields</h3>
+            <p>Select the field variable to be used in the difference.</p>
+         </sect2>
+         <sect2 id="live_results_case_results_createdifferencefields_sourcedataset">
+            <h3>SourceDataset</h3>
+            <p>Choose the dataset with which the difference will be computed.</p>
+         </sect2>
+         <sect2 id="live_results_case_results_createdifferencefields_surfaces">
+            <h3>Surfaces</h3>
+            <p>Select the surfaces where the difference will be created.</p>
+         </sect2>
+         <sect2 id="live_results_case_results_createdifferencefields_volumes">
+            <h3>Volumes</h3>
+            <p>Select the volumes where the difference will be created.</p>
+         </sect2>
+         <sect2 id="live_results_case_results_createdifferencefields_interpolationoptions_mappingoption">
+            <h3>Mapping Option</h3>
+            <p>Choose how the node under Source Dataset, used for the comparison, will be found.</p>
+         </sect2>
+         <sect2 id="live_results_case_results_createdifferencefields_interpolationoptions_searchoption">
+            <h3>Search Option</h3>
+            <p>Choose how the node under Source Dataset, used for the comparison, will be searched.</p>
          </sect2>
          <sect2 id="live_results_case_results_surfacedefs_isoclipsettings_field">
             <h3>Field</h3>
@@ -19804,6 +20753,26 @@ the periodic repeat.</p>
             <h3>Z Origin [m]</h3>
             <p>Specify the z-coordinate of the mirror plane origin.</p>
          </sect2>
+         <sect2 id="live_results_case_results_graphics_licsettings_vectorfield">
+            <h3>Vector Field</h3>
+            <p>Choose an existing vector variable to display on the surface.</p>
+         </sect2>
+         <sect2 id="live_results_case_results_graphics_licsettings_contrast">
+            <h3>Contrast</h3>
+            <p>Select to do a pass of image contrast enhancement.</p>
+         </sect2>
+         <sect2 id="live_results_case_results_graphics_licsettings_length">
+            <h3>Length</h3>
+            <p>Specify a maximum length of 20 pixel units in the positive and negative directions. Length is a scaling factor of this 20 pixels. Range is 0 to 1.</p>
+         </sect2>
+         <sect2 id="live_results_case_results_graphics_licsettings_integrationstep">
+            <h3>Integration Step</h3>
+            <p>Specify the step size in pixel units for each integration step. Range is 0 to 1.</p>
+         </sect2>
+         <sect2 id="live_results_case_results_graphics_licsettings_brightness">
+            <h3>Brightness</h3>
+            <p>Specify the surface brightness. Range is 0 to 1.</p>
+         </sect2>
          <sect2 id="live_results_case_results_graphics_mesh_surfaces">
             <h3>Surfaces</h3>
             <p>Select the surface(s) where you want to display the mesh.</p>
@@ -19867,6 +20836,10 @@ the periodic repeat.</p>
          <sect2 id="live_results_case_results_graphics_contour_filled">
             <h3>Filled</h3>
             <p>Select to visualize the contour plot using filled contours.</p>
+         </sect2>
+         <sect2 id="live_results_case_results_graphics_contour_displaylic">
+            <h3>Display LIC</h3>
+            <p>Select to display the line integral convolution.</p>
          </sect2>
          <sect2 id="live_results_case_results_graphics_contour_contourlines">
             <h3>Contour Lines</h3>
@@ -20198,7 +21171,7 @@ the periodic repeat.</p>
          </sect2>
          <sect2 id="live_results_case_results_graphics_pathlines_coarsen">
             <h3>Coarsen</h3>
-            <p>help text for coarsen</p>
+            <p>Reduce the number of pathlines included in the display.</p>
          </sect2>
          <sect2 id="live_results_case_results_graphics_pathlines_pathlinesfield">
             <h3>Pathlines Field</h3>
@@ -20314,11 +21287,11 @@ the periodic repeat.</p>
          </sect2>
          <sect2 id="live_results_case_results_graphics_pathlines_plot_xaxisfunction">
             <h3>X Axis Function</h3>
-            <p>help text for x axis function.</p>
+            <p>Lists the X-axis function.</p>
          </sect2>
          <sect2 id="live_results_case_results_graphics_pathlines_plot_enabled">
             <h3>Enabled</h3>
-            <p>help text for enabled.</p>
+            <p>Enable pathline plots.</p>
          </sect2>
          <sect2 id="live_results_case_results_graphics_pathlines_colormap_visible">
             <h3>Visible</h3>
@@ -20810,6 +21783,18 @@ the periodic repeat.</p>
          <sect2 id="live_results_case_results_graphics_xyplot_curves_markerstyle_size">
             <h3>Size</h3>
             <p>Choose a size to apply to the curve marker.</p>
+         </sect2>
+         <sect2 id="live_results_casecomparison_active">
+            <h3>Active</h3>
+            <p>Select to activate the case comparison.</p>
+         </sect2>
+         <sect2 id="live_results_casecomparison_datasets">
+            <h3>Datasets</h3>
+            <p>Select the datasets to use for the case comparison.</p>
+         </sect2>
+         <sect2 id="live_results_casecomparison_viewportlayout">
+            <h3>Viewport Layout</h3>
+            <p>Choose the layout orientation for the case comparison.</p>
          </sect2>
       </sect1>
    </article>
@@ -21601,6 +22586,10 @@ the periodic repeat.</p>
             <h3>define/models/battery-model/solution-method</h3>
             <p>Sets solution method options (see <a href="flu_bat_MSMD_sec_battery_model_options"/> for details).</p>
          </sect2>
+         <sect2 id="flu_define_models_battery_model_swelling_model_parameters_">
+            <h3>define/models/battery-model/swelling-model-parameters </h3>
+            <p>Sets parameters for the physics-based swelling model (see <a href="flu_bat_MSMD_sec_Newman_input"/> for details).</p>
+         </sect2>
          <sect2 id="flu_define_models_battery_model_thermal_abuse_model">
             <h3>define/models/battery-model/thermal-abuse-model</h3>
             <p>Allows you to choose a thermal abuse model and specify its parameters (see <a href="flu_bat_MSMD_using_abuse"/> for more details).</p>
@@ -22307,9 +23296,44 @@ the periodic repeat.</p>
             <h3>define/dynamic-mesh/controls/remeshing-parameters/prism-controls/</h3>
             <p>Enters the dynamic mesh prism controls menu, which provides text commands that can be useful when you want to modify the algorithm that attempts to retain the size distribution during unified remeshing. Each prism control definition is applied to one or more boundary zones, and then affects the height distribution and number of layers of the wedge cells in the adjacent boundary layers.</p>
          </sect2>
+         <sect2 id="flu_define_dynamic_mesh_controls_remeshing_parameters_prism_controls_add_">
+            <h3>define/dynamic-mesh/controls/remeshing-parameters/prism-controls/add </h3>
+            <p>Adds a new prism controls definition.   After being prompted for a name, you can enter the following to complete the definition: <div class="itemizedlist">
+                  <ul>
+                     <li>
+                        <p>
+                           <systemitem moreinfo="none">first-height</systemitem>  Sets the height of the first layer of wedge cells in the boundary layer adjacent to the specified <systemitem moreinfo="none">zones</systemitem>. </p>
+                     </li>
+                     <li>
+                        <p>
+                           <systemitem moreinfo="none">growth-method</systemitem>  Specifies the method used to determine the increase in height of the wedge cell layers beyond the first layer. The only available option is <code>geometric</code>, so that the height of each layer is the height of the previous layer multiplied by the <systemitem moreinfo="none">rate</systemitem>. </p>
+                     </li>
+                     <li>
+                        <p>
+                           <systemitem moreinfo="none">name</systemitem>  Specifies the name of the prism controls definition. </p>
+                     </li>
+                     <li>
+                        <p>
+                           <systemitem moreinfo="none">nlayers</systemitem>  Sets the number of layers of wedge cells in the boundary layer adjacent to the specified <systemitem moreinfo="none">zones</systemitem>. </p>
+                     </li>
+                     <li>
+                        <p>
+                           <systemitem moreinfo="none">rate</systemitem>  Sets the coefficient for the <systemitem moreinfo="none">growth-method</systemitem> used to determine the increase in height of the wedge cell layers beyond the first layer. </p>
+                     </li>
+                     <li>
+                        <p>
+                           <systemitem moreinfo="none">zones</systemitem>  Specifies all of the boundary zones on which this prism controls definition is applied. </p>
+                     </li>
+                  </ul>
+               </div> Enter <systemitem moreinfo="none">q</systemitem> when the definition is complete to return to the text command menu. </p>
+         </sect2>
          <sect2 id="flu_define_dynamic_mesh_controls_remeshing_parameters_prism_controls_delete_">
             <h3>define/dynamic-mesh/controls/remeshing-parameters/prism-controls/delete </h3>
             <p>Deletes an existing prism controls definition.</p>
+         </sect2>
+         <sect2 id="flu_define_dynamic_mesh_controls_remeshing_parameters_prism_controls_edit_">
+            <h3>define/dynamic-mesh/controls/remeshing-parameters/prism-controls/edit </h3>
+            <p>Edits an existing prism controls definition. You can revise the fields listed previously for the <systemitem moreinfo="none">define/dynamic-mesh/controls/remeshing-parameters/prism-controls/add</systemitem> text command.</p>
          </sect2>
          <sect2 id="flu_define_dynamic_mesh_controls_remeshing_parameters_prism_controls_list_">
             <h3>define/dynamic-mesh/controls/remeshing-parameters/prism-controls/list </h3>
@@ -23427,14 +24451,6 @@ the periodic repeat.</p>
             <h3>define/models/cht/explicit-time-averaged-coupling</h3>
             <p>Enters the explicit time averaged thermal coupling 	menu.</p>
          </sect2>
-         <sect2 id="flu_define_models_cht_explicit_time_averaged_coupling_conformal_coupled_walls">
-            <h3>define/models/cht/explicit-time-averaged-coupling/conformal-coupled-walls</h3>
-            <p>Specify explicit coupling controls for coupled conformal walls. Note this operation will slit the coupled wall pair.</p>
-         </sect2>
-         <sect2 id="flu_define_models_cht_explicit_time_averaged_coupling_fuse_explicit_cht_zones">
-            <h3>define/models/cht/explicit-time-averaged-coupling/fuse-explicit-cht-zones</h3>
-            <p>Fuses slitted conformal coupled walls marked for transient explicit thermal coupling.</p>
-         </sect2>
          <sect2 id="flu_define_models_crevice_modelquestion">
             <h3>define/models/crevice-model?</h3>
             <p>Enables/disables the crevice model.</p>
@@ -24022,6 +25038,10 @@ the periodic repeat.</p>
          <sect2 id="flu_define_models_dpm_options_pressure_gradient_force">
             <h3>define/models/dpm/options/pressure-gradient-force</h3>
             <p>Enables/disables inclusion of pressure gradient effects in the particle force balance.</p>
+         </sect2>
+         <sect2 id="flu_define_models_dpm_options_remove_wall_film_temperature_limiterquestion">
+            <h3>define/models/dpm/options/remove-wall-film-temperature-limiter?</h3>
+            <p>Answering <userinput moreinfo="none">yes</userinput> at the prompt removes the wall temperature limiter for Lagrangian wall-film walls. If you enter <userinput moreinfo="none">no</userinput> (default), two additional prompts will appear in the console allowing you to define the temperature difference above the boiling point and to enable/disable the reporting of the Leidenfrost temperature on the wall faces.</p>
          </sect2>
          <sect2 id="flu_define_models_dpm_options_scr_urea_deposition_risk_analysis_">
             <h3>define/models/dpm/options/scr-urea-deposition-risk-analysis/</h3>
@@ -26838,7 +27858,7 @@ the periodic repeat.</p>
          </sect2>
          <sect2 id="flu_display_display_custom_vector">
             <h3>display/display-custom-vector</h3>
-            <p>Displays custom vector.  This command is only visible when the <systemitem moreinfo="none">/preferences/graphics/enable-non-object-based-workflow</systemitem> TUI command is set to <systemitem moreinfo="none">yes</systemitem>.</p>
+            <p>Displays custom vector.</p>
          </sect2>
          <sect2 id="flu_display_embedded_windows_">
             <h3>display/embedded-windows/</h3>
@@ -29507,6 +30527,10 @@ the periodic repeat.</p>
             <h3>mesh/adapt/cell-registers/apply-poor-mesh-numerics </h3>
             <p>Applies poor mesh numerics to the mesh of a cell register.</p>
          </sect2>
+         <sect2 id="flu_mesh_adapt_cell_registers_coarsen_">
+            <h3>mesh/adapt/cell-registers/coarsen </h3>
+            <p>Coarsen the mesh based on a cell register.</p>
+         </sect2>
          <sect2 id="flu_mesh_adapt_cell_registers_delete_">
             <h3>mesh/adapt/cell-registers/delete </h3>
             <p>Deletes a cell register.</p>
@@ -29522,6 +30546,14 @@ the periodic repeat.</p>
          <sect2 id="flu_mesh_adapt_cell_registers_list_properties">
             <h3>mesh/adapt/cell-registers/list-properties</h3>
             <p>Lists the properties of a cell register.</p>
+         </sect2>
+         <sect2 id="flu_mesh_adapt_cell_registers_refine_">
+            <h3>mesh/adapt/cell-registers/refine </h3>
+            <p>Refine the mesh based on a cell register.</p>
+         </sect2>
+         <sect2 id="flu_mesh_adapt_coarsening_criteria">
+            <h3>mesh/adapt/coarsening-criteria</h3>
+            <p>Allows you to provide an expression for the coarsening criterion.</p>
          </sect2>
          <sect2 id="flu_mesh_adapt_display_adaption_cells">
             <h3>mesh/adapt/display-adaption-cells</h3>
@@ -29646,6 +30678,10 @@ the periodic repeat.</p>
          <sect2 id="flu_mesh_adapt_profile_print">
             <h3>mesh/adapt/profile/print</h3>
             <p>Prints adaption profiling results.</p>
+         </sect2>
+         <sect2 id="flu_mesh_adapt_refinement_criteria">
+            <h3>mesh/adapt/refinement-criteria</h3>
+            <p>Allows you to provide an expression for the refinement criterion.</p>
          </sect2>
          <sect2 id="flu_mesh_adapt_set_">
             <h3>mesh/adapt/set/</h3>
@@ -31609,6 +32645,10 @@ the periodic repeat.</p>
             <h3>solve/cell-registers/apply-poor-mesh-numerics</h3>
             <p>Applies poor mesh numerics to the mesh of a cell register.</p>
          </sect2>
+         <sect2 id="flu_solve_cell_registers_coarsen_">
+            <h3>solve/cell-registers/coarsen </h3>
+            <p>Coarsen the mesh based on a cell register.</p>
+         </sect2>
          <sect2 id="flu_solve_cell_registers_delete">
             <h3>solve/cell-registers/delete</h3>
             <p>Deletes a cell register.</p>
@@ -31624,6 +32664,10 @@ the periodic repeat.</p>
          <sect2 id="flu_solve_cell_registers_list_properties">
             <h3>solve/cell-registers/list-properties</h3>
             <p>Lists the properties of a cell register.</p>
+         </sect2>
+         <sect2 id="flu_solve_cell_registers_refine_">
+            <h3>solve/cell-registers/refine </h3>
+            <p>Refine the mesh based on a cell register.</p>
          </sect2>
          <sect2 id="flu_solve_convergence_conditions_">
             <h3>solve/convergence-conditions/</h3>
@@ -32468,6 +33512,18 @@ the periodic repeat.</p>
             <h3>solve/set/multiphase-numerics/advanced-stability-controls/p-v-coupling/skewness-correction/limit-pressure-correction-gradient?</h3>
             <p>Enables/disables the limited pressure correction  gradient in skewness terms for the PISO, SIMPLEC, or  fractional step pressure-coupling schemes.</p>
          </sect2>
+         <sect2 id="flu_solve_set_multiphase_numerics_advanced_stability_controls_pseudo_transient_">
+            <h3>solve/set/multiphase-numerics/advanced-stability-controls/pseudo-transient/</h3>
+            <p>Enters the stability control menu for  steady-state multiphase cases with the pseudo time method option  enabled.</p>
+         </sect2>
+         <sect2 id="flu_solve_set_multiphase_numerics_advanced_stability_controls_pseudo_transient_false_time_step_linearizationquestion_">
+            <h3>solve/set/multiphase-numerics/advanced-stability-controls/pseudo-transient/false-time-step-linearization? </h3>
+            <p>When enabled, provides additional stability for buoyancy-driven flows with the pseudo time method option enabled by increasing the diagonal dominance using the false time step size.</p>
+         </sect2>
+         <sect2 id="flu_solve_set_multiphase_numerics_advanced_stability_controls_pseudo_transient_smoothed_density_stabilization_methodquestion">
+            <h3>solve/set/multiphase-numerics/advanced-stability-controls/pseudo-transient/smoothed-density-stabilization-method?</h3>
+            <p>Smooths the cell density near the interface, therefore avoiding unphysical acceleration of the lighter phase in the vicinity of interface. The default number of density smoothings is 2. In case of very large unphysical velocities across the interface, you can increase this number when prompted with <systemitem moreinfo="none">Number of density smoothings</systemitem>.</p>
+         </sect2>
          <sect2 id="flu_solve_set_multiphase_numerics_boiling_parameters_">
             <h3>solve/set/multiphase-numerics/boiling-parameters/</h3>
             <p>Enters the menu for the multiphase boiling model parameters.</p>
@@ -32599,6 +33655,10 @@ the periodic repeat.</p>
          <sect2 id="flu_solve_set_multiphase_numerics_solution_stabilization_additional_stabilization_controls_blended_compressive_schemequestion">
             <h3>solve/set/multiphase-numerics/solution-stabilization/additional-stabilization-controls/blended-compressive-scheme?</h3>
             <p>Enables/disables the blended compressive discretization scheme.</p>
+         </sect2>
+         <sect2 id="flu_solve_set_multiphase_numerics_solution_stabilization_additional_stabilization_controls_pseudo_transient_stabilizationquestion">
+            <h3>solve/set/multiphase-numerics/solution-stabilization/additional-stabilization-controls/pseudo-transient-stabilization?</h3>
+            <p>Enables/disables the pseudo-transient momentum stabilization and false time step linearization methods.</p>
          </sect2>
          <sect2 id="flu_solve_set_multiphase_numerics_solution_stabilization_execute_additional_stability_controlsquestion_">
             <h3>solve/set/multiphase-numerics/solution-stabilization/execute-additional-stability-controls?  </h3>
@@ -32822,6 +33882,10 @@ the periodic repeat.</p>
             <h3>solve/set/pseudo-time-method/advanced-options/ </h3>
             <p>Enters the advanced options menu, which allows you to enable / disable the pseudo time method for individual equations and define their pseudo time scale factors or under-relaxation factors, respectively. These settings only apply when the global time step formulation is selected.</p>
          </sect2>
+         <sect2 id="flu_solve_set_pseudo_time_method_formulation_">
+            <h3>solve/set/pseudo-time-method/formulation </h3>
+            <p>Enables and sets the pseudo time step size formulation or disables the pseudo time method option.</p>
+         </sect2>
          <sect2 id="flu_solve_set_pseudo_time_method_global_time_step_settings_">
             <h3>solve/set/pseudo-time-method/global-time-step-settings </h3>
             <p>Defines the pseudo time settings for the calculation when the global time step formulation is selected.</p>
@@ -32829,6 +33893,10 @@ the periodic repeat.</p>
          <sect2 id="flu_solve_set_pseudo_time_method_local_time_step_settings_">
             <h3>solve/set/pseudo-time-method/local-time-step-settings </h3>
             <p>Defines the pseudo time Courant number when the local time step formulation is selected.</p>
+         </sect2>
+         <sect2 id="flu_solve_set_pseudo_time_method_relaxation_factors_">
+            <h3>solve/set/pseudo-time-method/relaxation-factors/ </h3>
+            <p>Enters the relaxation factors menu, where you can set the pseudo time explicit relaxation factors for individual equations. These factors only apply when the global time step formulation is selected.</p>
          </sect2>
          <sect2 id="flu_solve_set_pseudo_time_method_verbosity_">
             <h3>solve/set/pseudo-time-method/verbosity </h3>
@@ -36168,7 +37236,13 @@ the periodic repeat.</p>
          <sect2 id="flu_meshing_file_start_transcript">
             <h3>file/start-transcript</h3>
             <p>Starts recording input and output in a file.   A transcript file contains a complete record of all standard input to and output from Fluent (usually all keyboard and user interface input and all screen output).Start the transcription process with the <systemitem moreinfo="none">file/start-transcript</systemitem> command, and end it with the <systemitem moreinfo="none">file/stop-</systemitem>
-               <systemitem moreinfo="none">transcript</systemitem> command (or by exiting the program). </p>
+               <systemitem moreinfo="none">transcript</systemitem> command (or by exiting the program). <indexterm significance="normal">
+                  <primary>file/start-transcript</primary>
+               </indexterm>
+               <indexterm significance="normal">
+                  <primary>file/stop-transcript</primary>
+               </indexterm>
+            </p>
          </sect2>
          <sect2 id="flu_meshing_file_stop_journal">
             <h3>file/stop-journal</h3>

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -157,7 +157,7 @@ class Base:
                 attr_type_or_types = (attr_type_or_types,)
             if isinstance(val, attr_type_or_types):
                 return val
-            if val is not None and issubclass(bool, attr_type_or_types):  # cast to bool for boolean attributes
+            if val is not None and any(issubclass(x, bool) for x in attr_type_or_types):  # cast to bool for boolean attributes
                 return bool(val)
             return None
         return val

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -153,10 +153,12 @@ class Base:
             val = attrs[attr]
 
         if attr_type_or_types:
-            if not type(attr_type_or_types) == tuple:
+            if not isinstance(attr_type_or_types, tuple):
                 attr_type_or_types = (attr_type_or_types,)
-            if type(val) in attr_type_or_types:
+            if isinstance(val, attr_type_or_types):
                 return val
+            if val is not None and issubclass(bool, attr_type_or_types):  # cast to bool for boolean attributes
+                return bool(val)
             return None
         return val
 

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -660,12 +660,12 @@ def test_accessor_methods_on_settings_object(load_static_mixer_case):
     modified = solver.file.read.file_type.allowed_values()
     assert existing == modified
 
-    existing = solver.file.read.file_type.get_attr("read-only?")
+    existing = solver.file.read.file_type.get_attr("read-only?", bool)
     modified = solver.file.read.file_type.is_read_only()
     assert existing == modified
 
     existing = solver.setup.boundary_conditions.velocity_inlet.get_attr(
-        "user-creatable?"
+        "user-creatable?", bool
     )
     modified = solver.setup.boundary_conditions.velocity_inlet.user_creatable()
     assert existing == modified

--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -408,7 +408,6 @@ def test_primitives():
     assert r.g_1.b_3() is False
     r.g_1.s_4 = "foo"
     assert r.g_1.s_4() == "foo"
-    return True
 
 
 def test_group():
@@ -419,7 +418,6 @@ def test_group():
     assert r.g_1() == {"r_1": 3.2, "i_2": -3, "b_3": False, "s_4": "bar"}
     r.g_1.i_2 = 4
     assert r.g_1() == {"r_1": 3.2, "i_2": 4, "b_3": False, "s_4": "bar"}
-    return True
 
 
 def test_settings_input_set_state():
@@ -462,8 +460,6 @@ def test_named_object():
     assert r.n_1.get_object_names() == ["n2", "n4", "n1", "n5"]
     assert r.n_1["n5"]() == {"rl_1": [4.3, 2.1], "sl_1": ["oof", "rab"]}
 
-    return True
-
 
 def test_list_object():
     r = flobject.get_root(Proxy())
@@ -483,8 +479,6 @@ def test_list_object():
     ]
     r.l_1 = [{"il_1": [3], "bl_1": [True, False]}]
     assert r.l_1() == [{"il_1": [3], "bl_1": [True, False]}]
-
-    return True
 
 
 def test_command():

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -273,11 +273,11 @@ def test_get_fluent_mode(new_mesh_session):
 
 @pytest.mark.dev
 @pytest.mark.fluent_232
-def test_start_transcript_file_write(new_mesh_session, tmp_path=pyfluent.EXAMPLES_PATH):
+def test_start_transcript_file_write(new_mesh_session):
     fd, file_path = tempfile.mkstemp(
         suffix=f"-{os.getpid()}.txt",
         prefix="pyfluent-",
-        dir=str(tmp_path),
+        dir=str(pyfluent.EXAMPLES_PATH),
     )
     os.close(fd)
 


### PR DESCRIPTION
Fluent bugs 774607, 774755, 774903

For all these defects, `is_active()` returns a list from Fluent for which we need to cast to boolean type in PyFluent. There are many such occurrences in Fluent code, it is probably not possible to find and change the Fluent code everywhere. 