### PR TITLE
Turn off the expandable navigation 

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -176,6 +176,7 @@ html_theme_options = {
     },
     "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],
     "navigation_depth": -1,
+    "collapse_navigation": True,
 }
 
 # -- Options for HTMLHelp output ---------------------------------------------


### PR DESCRIPTION
It is possible to turn off the expandable navigation entirely by setting the collapse_navigation config option to `True`:

```py
html_theme_options = {
  "collapse_navigation": True
}
```

This tends to help improve documentation build times.

See: https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/navigation.html