### PR TITLE
Stop streaming services before exiting channel.

### DIFF
--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -301,14 +301,14 @@ class _FluentConnection:
         remote_instance,
     ) -> None:
         if channel:
+            transcript.stop()
+            events_manager.stop()
+            monitors_manager.stop()
             if cleanup_on_exit:
                 try:
                     scheme_eval.exec(("(exit-server)",))
                 except Exception:
                     pass
-            transcript.stop()
-            events_manager.stop()
-            monitors_manager.stop()
             channel.close()
             channel = None
 


### PR DESCRIPTION
Stop all the streaming services before exiting the active channel on which fluent is running. This was the issue for 'pyfluent' hanging during exit immediately after initialization as reported by @mkundu1 .