### PR TITLE
Suggest closest matching names for config-vars error.

### DIFF
--- a/src/ansys/fluent/core/filereader/case.py
+++ b/src/ansys/fluent/core/filereader/case.py
@@ -25,6 +25,7 @@ from typing import List
 import h5py
 
 from . import lispy
+from ..allowed_name_error_msg import allowed_name_error_message
 
 
 class InputParameter:
@@ -99,7 +100,11 @@ class _CaseVariable:
         if not name:
             error_name = self._path[:-1] if self._path else self._path
             raise RuntimeError(f"Invalid variable {error_name}")
-        return self._variables[name]
+        try:
+            return self._variables[name]
+        except KeyError:
+            raise RuntimeError(allowed_name_error_message(
+                "config-vars", name, list(self._variables.keys())))
 
     def __getattr__(self, name: str):
         for orig, sub in (

--- a/src/ansys/fluent/core/filereader/case.py
+++ b/src/ansys/fluent/core/filereader/case.py
@@ -103,7 +103,7 @@ class _CaseVariable:
         try:
             return self._variables[name]
         except KeyError:
-            raise RuntimeError(allowed_name_error_message(
+            raise ValueError(allowed_name_error_message(
                 "config-vars", name, list(self._variables.keys())))
 
     def __getattr__(self, name: str):

--- a/tests/test_casereader.py
+++ b/tests/test_casereader.py
@@ -207,7 +207,7 @@ def test_case_reader_get_rp_and_config_vars():
     with pytest.raises(BaseException):
         reader.rp_var.defaults.pre_r19__dot0_early()
 
-    with pytest.raises(RuntimeError) as msg:
+    with pytest.raises(ValueError) as msg:
         reader.config_var("rp-3d")
 
     assert msg.value.args[0] == "rp-3d is not an allowed config-vars name.\n" \

--- a/tests/test_casereader.py
+++ b/tests/test_casereader.py
@@ -207,6 +207,12 @@ def test_case_reader_get_rp_and_config_vars():
     with pytest.raises(BaseException):
         reader.rp_var.defaults.pre_r19__dot0_early()
 
+    with pytest.raises(RuntimeError) as msg:
+        reader.config_var("rp-3d")
+
+    assert msg.value.args[0] == "rp-3d is not an allowed config-vars name.\n" \
+                                "The most similar names are: rp-3d?, rp-des?."
+
 
 def test_case_reader_input_parameter():
     number = InputParameter(raw_data=(("name", "n"), ("definition", "12.4")))


### PR DESCRIPTION
If the config-vars gets a key-error, we return the closest matching names along with the error message.