### PR TITLE
Remove 23.2 API files from package/cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,7 +412,7 @@ jobs:
 # Don't upload anything to artifacts/cache/release-package from here
   build_test_232:
     name: Build and Test with 23.2 Fluent
-    needs: build
+    needs: test-import
     runs-on: [self-hosted, pyfluent]
 
     steps:
@@ -431,14 +431,11 @@ jobs:
           restore-keys: |
             Python-${{ runner.os }}-${{ matrix.python-version }}
 
-      - name: Download package
-        uses: actions/download-artifact@v3
-        with:
-          name: PyFluent-packages
-          path: dist
+      - name: Add version information
+        run: make version-info
 
       - name: Install pyfluent
-        run: pip install -q --force-reinstall dist/*.whl > /dev/null
+        run: make install
 
       - name: Retrieve PyFluent version
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,125 +86,6 @@ jobs:
       - name: Test import
         run: make test-import
 
-  docs_build:
-    name: Build Documentation
-    needs: [docs-style]
-    runs-on: [self-hosted, pyfluent]
-    env:
-      DOC_DEPLOYMENT_IMAGE_TAG: v23.1.0
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
-
-      - name: Install OS packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install pandoc libegl1 make xvfb libfontconfig1 libxrender1 libxkbcommon-x11-0 -y
-
-      - name: Cache pip
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements/requirements_doc.txt') }}
-          restore-keys: |
-            Python-${{ runner.os }}-${{ matrix.python-version }}
-
-      - name: Install pyfluent
-        run: make install
-
-      - name: Retrieve PyFluent version
-        run: |
-          echo "PYFLUENT_VERSION=$(python -c "from ansys.fluent.core import __version__; print(__version__)")" >> $GITHUB_OUTPUT
-          echo "PYFLUENT version is: $(python -c "from ansys.fluent.core import __version__; print(__version__)")"
-        id: version
-
-      - name: Cache API Code
-        uses: actions/cache@v3
-        id: cache-api-code
-        with:
-          path: |
-            src/ansys/fluent/core/datamodel_231
-            src/ansys/fluent/core/fluent_version_231.py
-            src/ansys/fluent/core/meshing/tui_231.py
-            src/ansys/fluent/core/solver/settings_231
-            src/ansys/fluent/core/solver/tui_231.py
-            doc/source/api/meshing/tui
-            doc/source/api/meshing/datamodel
-            doc/source/api/solver/tui
-            doc/source/api/solver/datamodel
-          key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}-${{ hashFiles('codegen/**') }}
-          restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
-
-      - name: Login to GitHub Container Registry
-        if: steps.cache-api-code.outputs.cache-hit != 'true'
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.GH_USERNAME }}
-          password: ${{ secrets.REPO_DOWNLOAD_PAT }}
-
-      - name: Pull Fluent docker image
-        if: steps.cache-api-code.outputs.cache-hit != 'true'
-        run: make docker-pull
-        env:
-          FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
-
-      - name: Run API codegen
-        if: steps.cache-api-code.outputs.cache-hit != 'true'
-        run: make api-codegen
-        env:
-          ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
-          PYFLUENT_START_INSTANCE: 0
-          PYFLUENT_LAUNCH_CONTAINER: 1
-          FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
-
-      - name: Install again after codegen
-        run: |
-          rm -rf dist
-          make install > /dev/null
-
-      - name: Cache examples
-        uses: actions/cache@v3
-        with:
-          path: doc/source/examples
-          key: Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}-${{ hashFiles('examples/**', 'doc/source/conf.py') }}
-          restore-keys: |
-            Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
-
-      - name: Build Documentation
-        run: make build-doc
-        env:
-          ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
-          PYFLUENT_START_INSTANCE: 0
-          FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
-
-      - name: Zip HTML Documentation before upload
-        run: |
-          sudo apt install zip -y
-          zip -r doc.zip doc/_build/html
-
-      - name: Upload HTML Documentation
-        uses: actions/upload-artifact@v3
-        with:
-          name: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
-          path: doc.zip
-          retention-days: 7
-
-      - name: Deploy stable documentation
-        uses: pyansys/actions/doc-deploy-stable@v3
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
-        with:
-            doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
-            decompress_artifact: true
-            cname: ${{ env.DOCUMENTATION_CNAME }}
-            token: ${{ secrets.GITHUB_TOKEN }}
-
-
   build:
     name: Build
     needs: test-import
@@ -319,43 +200,6 @@ jobs:
           cat src/ansys/fluent/core/fluent_version_231.py
           python -c "from ansys.fluent.core.solver.settings_231 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
 
-      - name: Cache 23.2 API Code
-        uses: actions/cache@v3
-        id: cache-232-api-code
-        with:
-          path:
-            src/ansys/fluent/core/datamodel_232
-            src/ansys/fluent/core/fluent_version_232.py
-            src/ansys/fluent/core/meshing/tui_232.py
-            src/ansys/fluent/core/solver/settings_232
-            src/ansys/fluent/core/solver/tui_232
-            doc/source/api/core/meshing/tui
-            doc/source/api/core/meshing/datamodel
-            doc/source/api/core/solver/tui
-            doc/source/api/core/solver/datamodel
-          key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v23.2.0-${{ hashFiles('codegen/**') }}
-          restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-v23.2.0
-
-      - name: Pull 23.2 Fluent docker image
-        if: steps.cache-232-api-code.outputs.cache-hit != 'true'
-        run: make docker-pull
-        env:
-          FLUENT_IMAGE_TAG: v23.2.0
-
-      - name: Run 23.2 API codegen
-        if: steps.cache-232-api-code.outputs.cache-hit != 'true'
-        run: make api-codegen
-        env:
-          ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
-          PYFLUENT_START_INSTANCE: 0
-          PYFLUENT_LAUNCH_CONTAINER: 1
-          FLUENT_IMAGE_TAG: v23.2.0
-
-      - name: Print 23.2 Fluent version info
-        run: |
-          cat src/ansys/fluent/core/fluent_version_232.py
-          python -c "from ansys.fluent.core.solver.settings_232 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
-
       - name: Install again after codegen
         run: |
           rm -rf dist
@@ -375,6 +219,85 @@ jobs:
             dist/*.tar.gz
           retention-days: 7
 
+  docs_build:
+    name: Build Documentation
+    needs: [docs-style, build]
+    runs-on: [self-hosted, pyfluent]
+    env:
+      DOC_DEPLOYMENT_IMAGE_TAG: v23.1.0
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Install OS packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install pandoc libegl1 make xvfb libfontconfig1 libxrender1 libxkbcommon-x11-0 -y
+
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements/requirements_doc.txt') }}
+          restore-keys: |
+            Python-${{ runner.os }}-${{ matrix.python-version }}
+
+      - name: Download package
+        uses: actions/download-artifact@v3
+        with:
+          name: PyFluent-packages
+          path: dist
+
+      - name: Install pyfluent
+        run: pip install -q --force-reinstall dist/*.whl > /dev/null
+
+      - name: Retrieve PyFluent version
+        run: |
+          echo "PYFLUENT_VERSION=$(python -c "from ansys.fluent.core import __version__; print(__version__)")" >> $GITHUB_OUTPUT
+          echo "PYFLUENT version is: $(python -c "from ansys.fluent.core import __version__; print(__version__)")"
+        id: version
+
+      - name: Cache examples
+        uses: actions/cache@v3
+        with:
+          path: doc/source/examples
+          key: Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}-${{ hashFiles('examples/**', 'doc/source/conf.py') }}
+          restore-keys: |
+            Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
+
+      - name: Build Documentation
+        run: make build-doc
+        env:
+          ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
+          PYFLUENT_START_INSTANCE: 0
+          FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
+
+      - name: Zip HTML Documentation before upload
+        run: |
+          sudo apt install zip -y
+          zip -r doc.zip doc/_build/html
+
+      - name: Upload HTML Documentation
+        uses: actions/upload-artifact@v3
+        with:
+          name: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
+          path: doc.zip
+          retention-days: 7
+
+      - name: Deploy stable documentation
+        uses: pyansys/actions/doc-deploy-stable@v3
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
+        with:
+            doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
+            decompress_artifact: true
+            cname: ${{ env.DOCUMENTATION_CNAME }}
+            token: ${{ secrets.GITHUB_TOKEN }}
+
   test:
     name: Unit Testing
     needs: build
@@ -387,8 +310,6 @@ jobs:
             version: 222
           - image-tag: v23.1.0
             version: 231
-          - image-tag: v23.2.0
-            version: 232
 
     steps:
 
@@ -447,10 +368,78 @@ jobs:
           name: coverage_report
           path: ./htmlcov
 
+# Separate build+test job for 23.2 Fluent
+# Don't upload anything to artifacts/cache/release-package from here
+  build_test_232:
+    name: Build and Test with 23.2 Fluent
+    needs: test-import
+    runs-on: [self-hosted, pyfluent]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements/requirements_*.txt') }}
+          restore-keys: |
+            Python-${{ runner.os }}-${{ matrix.python-version }}
+
+      - name: Download package
+        uses: actions/download-artifact@v3
+        with:
+          name: PyFluent-packages
+          path: dist
+
+      - name: Install pyfluent
+        run: pip install -q --force-reinstall dist/*.whl > /dev/null
+
+      - name: Retrieve PyFluent version
+        run: |
+          echo "PYFLUENT_VERSION=$(python -c "from ansys.fluent.core import __version__; print(__version__)")" >> $GITHUB_OUTPUT
+          echo "PYFLUENT version is: $(python -c "from ansys.fluent.core import __version__; print(__version__)")"
+        id: version
+
+      - name: Pull 23.2 Fluent docker image
+        run: make docker-pull
+        env:
+          FLUENT_IMAGE_TAG: v23.2.0
+
+      - name: Run 23.2 API codegen
+        run: make api-codegen
+        env:
+          ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
+          PYFLUENT_START_INSTANCE: 0
+          PYFLUENT_LAUNCH_CONTAINER: 1
+          FLUENT_IMAGE_TAG: v23.2.0
+
+      - name: Print 23.2 Fluent version info
+        run: |
+          cat src/ansys/fluent/core/fluent_version_232.py
+          python -c "from ansys.fluent.core.solver.settings_232 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
+
+      - name: Install again after codegen
+        run: |
+          rm -rf dist
+          make install > /dev/null
+
+      - name: Unit Testing
+        run: make unittest-dev-232
+        env:
+          ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
+          PYFLUENT_START_INSTANCE: 0
+          FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
+
   release:
     name: Release
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    needs: test
+    needs: [test, build_test_232]
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,7 +372,7 @@ jobs:
 # Don't upload anything to artifacts/cache/release-package from here
   build_test_232:
     name: Build and Test with 23.2 Fluent
-    needs: test-import
+    needs: build
     runs-on: [self-hosted, pyfluent]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -443,6 +443,13 @@ jobs:
           echo "PYFLUENT version is: $(python -c "from ansys.fluent.core import __version__; print(__version__)")"
         id: version
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.REPO_DOWNLOAD_PAT }}
+
       - name: Pull 23.2 Fluent docker image
         run: make docker-pull
         env:
@@ -471,7 +478,7 @@ jobs:
         env:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
-          FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
+          FLUENT_IMAGE_TAG: v23.2.0
 
   release:
     name: Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,7 +413,7 @@ jobs:
   build_test_232:
     name: Build and Test with 23.2 Fluent
     needs: test-import
-    runs-on: [self-hosted, pyfluent]
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,125 @@ jobs:
       - name: Test import
         run: make test-import
 
+  docs_build:
+    name: Build Documentation
+    needs: [docs-style]
+    runs-on: [self-hosted, pyfluent]
+    env:
+      DOC_DEPLOYMENT_IMAGE_TAG: v23.1.0
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Install OS packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install pandoc libegl1 make xvfb libfontconfig1 libxrender1 libxkbcommon-x11-0 -y
+
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements/requirements_doc.txt') }}
+          restore-keys: |
+            Python-${{ runner.os }}-${{ matrix.python-version }}
+
+      - name: Install pyfluent
+        run: make install
+
+      - name: Retrieve PyFluent version
+        run: |
+          echo "PYFLUENT_VERSION=$(python -c "from ansys.fluent.core import __version__; print(__version__)")" >> $GITHUB_OUTPUT
+          echo "PYFLUENT version is: $(python -c "from ansys.fluent.core import __version__; print(__version__)")"
+        id: version
+
+      - name: Cache API Code
+        uses: actions/cache@v3
+        id: cache-api-code
+        with:
+          path: |
+            src/ansys/fluent/core/datamodel_231
+            src/ansys/fluent/core/fluent_version_231.py
+            src/ansys/fluent/core/meshing/tui_231.py
+            src/ansys/fluent/core/solver/settings_231
+            src/ansys/fluent/core/solver/tui_231.py
+            doc/source/api/meshing/tui
+            doc/source/api/meshing/datamodel
+            doc/source/api/solver/tui
+            doc/source/api/solver/datamodel
+          key: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}-${{ hashFiles('codegen/**') }}
+          restore-keys: API-Code-v${{ env.API_CODE_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
+
+      - name: Login to GitHub Container Registry
+        if: steps.cache-api-code.outputs.cache-hit != 'true'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.REPO_DOWNLOAD_PAT }}
+
+      - name: Pull Fluent docker image
+        if: steps.cache-api-code.outputs.cache-hit != 'true'
+        run: make docker-pull
+        env:
+          FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
+
+      - name: Run API codegen
+        if: steps.cache-api-code.outputs.cache-hit != 'true'
+        run: make api-codegen
+        env:
+          ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
+          PYFLUENT_START_INSTANCE: 0
+          PYFLUENT_LAUNCH_CONTAINER: 1
+          FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
+
+      - name: Install again after codegen
+        run: |
+          rm -rf dist
+          make install > /dev/null
+
+      - name: Cache examples
+        uses: actions/cache@v3
+        with:
+          path: doc/source/examples
+          key: Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}-${{ hashFiles('examples/**', 'doc/source/conf.py') }}
+          restore-keys: |
+            Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
+
+      - name: Build Documentation
+        run: make build-doc
+        env:
+          ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
+          PYFLUENT_START_INSTANCE: 0
+          FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
+
+      - name: Zip HTML Documentation before upload
+        run: |
+          sudo apt install zip -y
+          zip -r doc.zip doc/_build/html
+
+      - name: Upload HTML Documentation
+        uses: actions/upload-artifact@v3
+        with:
+          name: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
+          path: doc.zip
+          retention-days: 7
+
+      - name: Deploy stable documentation
+        uses: pyansys/actions/doc-deploy-stable@v3
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
+        with:
+            doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
+            decompress_artifact: true
+            cname: ${{ env.DOCUMENTATION_CNAME }}
+            token: ${{ secrets.GITHUB_TOKEN }}
+
+
   build:
     name: Build
     needs: test-import
@@ -218,85 +337,6 @@ jobs:
             dist/*.whl
             dist/*.tar.gz
           retention-days: 7
-
-  docs_build:
-    name: Build Documentation
-    needs: [docs-style, build]
-    runs-on: [self-hosted, pyfluent]
-    env:
-      DOC_DEPLOYMENT_IMAGE_TAG: v23.1.0
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
-
-      - name: Install OS packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install pandoc libegl1 make xvfb libfontconfig1 libxrender1 libxkbcommon-x11-0 -y
-
-      - name: Cache pip
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: Python-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements/requirements_doc.txt') }}
-          restore-keys: |
-            Python-${{ runner.os }}-${{ matrix.python-version }}
-
-      - name: Download package
-        uses: actions/download-artifact@v3
-        with:
-          name: PyFluent-packages
-          path: dist
-
-      - name: Install pyfluent
-        run: pip install -q --force-reinstall dist/*.whl > /dev/null
-
-      - name: Retrieve PyFluent version
-        run: |
-          echo "PYFLUENT_VERSION=$(python -c "from ansys.fluent.core import __version__; print(__version__)")" >> $GITHUB_OUTPUT
-          echo "PYFLUENT version is: $(python -c "from ansys.fluent.core import __version__; print(__version__)")"
-        id: version
-
-      - name: Cache examples
-        uses: actions/cache@v3
-        with:
-          path: doc/source/examples
-          key: Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}-${{ hashFiles('examples/**', 'doc/source/conf.py') }}
-          restore-keys: |
-            Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYFLUENT_VERSION }}-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
-
-      - name: Build Documentation
-        run: make build-doc
-        env:
-          ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
-          PYFLUENT_START_INSTANCE: 0
-          FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
-
-      - name: Zip HTML Documentation before upload
-        run: |
-          sudo apt install zip -y
-          zip -r doc.zip doc/_build/html
-
-      - name: Upload HTML Documentation
-        uses: actions/upload-artifact@v3
-        with:
-          name: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
-          path: doc.zip
-          retention-days: 7
-
-      - name: Deploy stable documentation
-        uses: pyansys/actions/doc-deploy-stable@v3
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
-        with:
-            doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
-            decompress_artifact: true
-            cname: ${{ env.DOCUMENTATION_CNAME }}
-            token: ${{ secrets.GITHUB_TOKEN }}
 
   test:
     name: Unit Testing

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -231,28 +231,26 @@ def test_create_session_from_launch_fluent_by_setting_ip_and_port_env_var(
 
 @pytest.mark.dev
 @pytest.mark.fluent_232
-def test_journal_creation(new_mesh_session, tmp_path=pyfluent.EXAMPLES_PATH):
-    session = new_mesh_session
-
+def test_journal_creation(new_mesh_session):
     fd, file_path = tempfile.mkstemp(
-        suffix=f"-{os.getpid()}.txt",
-        prefix="sample_py_journal-",
-        dir=str(tmp_path),
+        suffix=f"-{os.getpid()}.jou",
+        prefix="pyfluent-",
+        dir=str(pyfluent.EXAMPLES_PATH),
     )
     os.close(fd)
 
+    prev_stat = Path(file_path).stat()
+    prev_mtime = prev_stat.st_mtime
+    prev_size = prev_stat.st_size
+
+    session = new_mesh_session
     session.journal.start(file_path)
-
     session = session.switch_to_solver()
-
     session.journal.stop()
 
-    with open(file_path) as f:
-        returned = f.readlines()
-
-    time.sleep(1)
-
-    assert returned
+    new_stat = Path(file_path).stat()
+    assert new_stat.st_mtime > prev_mtime
+    assert new_stat.st_size > prev_size
 
 
 @pytest.mark.skip("Failing in GitHub CI")
@@ -275,7 +273,7 @@ def test_get_fluent_mode(new_mesh_session):
 @pytest.mark.fluent_232
 def test_start_transcript_file_write(new_mesh_session):
     fd, file_path = tempfile.mkstemp(
-        suffix=f"-{os.getpid()}.txt",
+        suffix=f"-{os.getpid()}.trn",
         prefix="pyfluent-",
         dir=str(pyfluent.EXAMPLES_PATH),
     )


### PR DESCRIPTION
We should remove any 23.2 API files from package, github cache etc. In this PR, I've removed the 23.2 files from the package artifact. The 23.2 build is prepared and unittested under a separate job which doesn't use github cache. 

I'm preparing an internal repo [pyfluent-dev](https://github.com/pyansys/pyfluent-dev) from where we will internally release a package with the 23.2 files.