### PR TITLE
Datamodel event callback registration

### DIFF
--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -229,9 +229,6 @@ class _FluentConnection:
 
         self._cleanup_on_exit = cleanup_on_exit
 
-        self.callback_id1 = None
-        self.callback_id2 = None
-
         if start_transcript:
             self.transcript.start()
 

--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -212,7 +212,6 @@ class _FluentConnection:
         self.datamodel_events = DatamodelEvents(self.datamodel_service_se)
         self.datamodel_events.start()
 
-
         self._scheme_eval_service = SchemeEvalService(self._channel, self._metadata)
         self.scheme_eval = SchemeEval(self._scheme_eval_service)
         self.settings_service = SettingsService(

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -514,6 +514,26 @@ class PyMenu(PyStateContainer):
         self.service.event_streaming.register_callback(subscription.tag, self, cb)
         return subscription
 
+    def add_on_affected(self, cb: Callable) -> EventSubscription:
+        """Register a callback for when the object is affected.
+
+        Parameters
+        ----------
+        cb : Callable
+            Callback function
+
+        Returns
+        -------
+        EventSubscription
+            EventSubscription instance which can be used to unregister the callback
+        """
+        request = DataModelProtoModule.SubscribeEventsRequest()
+        e = request.eventrequest.add(rules=self.rules)
+        e.affectedEventRequest.path = convert_path_to_se_path(self.path)
+        subscription = EventSubscription(self.service, request)
+        self.service.event_streaming.register_callback(subscription.tag, self, cb)
+        return subscription
+
 
 class PyParameter(PyStateContainer):
     """Object class using StateEngine based DatamodelService as backend.

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -534,6 +534,31 @@ class PyMenu(PyStateContainer):
         self.service.event_streaming.register_callback(subscription.tag, self, cb)
         return subscription
 
+    def add_on_affected_at_type_path(
+        self, child_type: str, cb: Callable
+    ) -> EventSubscription:
+        """Register a callback for when the object is affected at child type
+
+        Parameters
+        ----------
+        child_type : str
+            child type
+        cb : Callable
+            Callback function
+
+        Returns
+        -------
+        EventSubscription
+            EventSubscription instance which can be used to unregister the callback
+        """
+        request = DataModelProtoModule.SubscribeEventsRequest()
+        e = request.eventrequest.add(rules=self.rules)
+        e.affectedEventRequest.path = convert_path_to_se_path(self.path)
+        e.affectedEventRequest.subtype = child_type
+        subscription = EventSubscription(self.service, request)
+        self.service.event_streaming.register_callback(subscription.tag, self, cb)
+        return subscription
+
 
 class PyParameter(PyStateContainer):
     """Object class using StateEngine based DatamodelService as backend.

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -494,6 +494,26 @@ class PyMenu(PyStateContainer):
         self.service.event_streaming.register_callback(subscription.tag, self, cb)
         return subscription
 
+    def add_on_changed(self, cb: Callable) -> EventSubscription:
+        """Register a callback for when the object is modified.
+
+        Parameters
+        ----------
+        cb : Callable
+            Callback function
+
+        Returns
+        -------
+        EventSubscription
+            EventSubscription instance which can be used to unregister the callback
+        """
+        request = DataModelProtoModule.SubscribeEventsRequest()
+        e = request.eventrequest.add(rules=self.rules)
+        e.modifiedEventRequest.path = convert_path_to_se_path(self.path)
+        subscription = EventSubscription(self.service, request)
+        self.service.event_streaming.register_callback(subscription.tag, self, cb)
+        return subscription
+
 
 class PyParameter(PyStateContainer):
     """Object class using StateEngine based DatamodelService as backend.
@@ -508,6 +528,26 @@ class PyParameter(PyStateContainer):
 
     def is_read_only(self):
         return true_if_none(self.get_attr(Attribute.IS_READ_ONLY.value))
+
+    def add_on_changed(self, cb: Callable) -> EventSubscription:
+        """Register a callback for when the object is modified.
+
+        Parameters
+        ----------
+        cb : Callable
+            Callback function
+
+        Returns
+        -------
+        EventSubscription
+            EventSubscription instance which can be used to unregister the callback
+        """
+        request = DataModelProtoModule.SubscribeEventsRequest()
+        e = request.eventrequest.add(rules=self.rules)
+        e.modifiedEventRequest.path = convert_path_to_se_path(self.path)
+        subscription = EventSubscription(self.service, request)
+        self.service.event_streaming.register_callback(subscription.tag, self, cb)
+        return subscription
 
 
 def true_if_none(val):

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -3,7 +3,6 @@ from enum import Enum
 import itertools
 from typing import Any, Callable, Dict, Iterator, List, Tuple
 import warnings
-import weakref
 
 import grpc
 
@@ -152,7 +151,9 @@ class DatamodelService(StreamingService):
 
     def begin_event_streaming(self, started_evt):
         """Begin datamodel event streaming."""
-        self._streams = self._stub.BeginEventStreaming(self.request, metadata=self._metadata)
+        self._streams = self._stub.BeginEventStreaming(
+            self.request, metadata=self._metadata
+        )
         started_evt.set()
         while True:
             try:
@@ -356,9 +357,14 @@ class PyStateContainer(PyCallableStateObject):
     docstring = None
 
 
-class EventSubscription():
+class EventSubscription:
     """EventSubscription class for any datamodel event."""
-    def __init__(self, service: DatamodelService, request: DataModelProtoModule.SubscribeEventsRequest):
+
+    def __init__(
+        self,
+        service: DatamodelService,
+        request: DataModelProtoModule.SubscribeEventsRequest,
+    ):
         """Subscribe to a datamodel event."""
         self._service = service
         response = service.subscribe_events(request)
@@ -401,7 +407,6 @@ class PyMenu(PyStateContainer):
     """
 
     def __init__(self, service: DatamodelService, rules: str, path: Path = None):
-        self.events = weakref.WeakSet()
         super().__init__(service, rules, path)
 
     def __setattr__(self, name: str, value: Any):

--- a/src/ansys/fluent/core/services/datamodel_se.py
+++ b/src/ansys/fluent/core/services/datamodel_se.py
@@ -559,6 +559,59 @@ class PyMenu(PyStateContainer):
         self.service.event_streaming.register_callback(subscription.tag, self, cb)
         return subscription
 
+    def add_on_attribute_changed(
+        self, attribute: str, cb: Callable
+    ) -> EventSubscription:
+        """Register a callback for when an attribute is changed
+
+        Parameters
+        ----------
+        attribute : str
+            attribute name
+        cb : Callable
+            Callback function
+
+        Returns
+        -------
+        EventSubscription
+            EventSubscription instance which can be used to unregister the callback
+        """
+        request = DataModelProtoModule.SubscribeEventsRequest()
+        e = request.eventrequest.add(rules=self.rules)
+        e.attributeChangedEventRequest.path = convert_path_to_se_path(self.path)
+        e.attributeChangedEventRequest.attribute = attribute
+        subscription = EventSubscription(self.service, request)
+        self.service.event_streaming.register_callback(subscription.tag, self, cb)
+        return subscription
+
+    def add_on_command_attribute_changed(
+        self, command: str, attribute: str, cb: Callable
+    ) -> EventSubscription:
+        """Register a callback for when an attribute is changed
+
+        Parameters
+        ----------
+        command : str
+            command name
+        attribute : str
+            attribute name
+        cb : Callable
+            Callback function
+
+        Returns
+        -------
+        EventSubscription
+            EventSubscription instance which can be used to unregister the callback
+        """
+        request = DataModelProtoModule.SubscribeEventsRequest()
+        e = request.eventrequest.add(rules=self.rules)
+        e.commandAttributeChangedEventRequest.path = convert_path_to_se_path(self.path)
+        e.commandAttributeChangedEventRequest.command = command
+        e.commandAttributeChangedEventRequest.attribute = attribute
+        subscription = EventSubscription(self.service, request)
+        self.service.event_streaming.register_callback(subscription.tag, self, cb)
+        return subscription
+
 
 class PyParameter(PyStateContainer):
     """Object class using StateEngine based DatamodelService as backend.
@@ -590,6 +643,31 @@ class PyParameter(PyStateContainer):
         request = DataModelProtoModule.SubscribeEventsRequest()
         e = request.eventrequest.add(rules=self.rules)
         e.modifiedEventRequest.path = convert_path_to_se_path(self.path)
+        subscription = EventSubscription(self.service, request)
+        self.service.event_streaming.register_callback(subscription.tag, self, cb)
+        return subscription
+
+    def add_on_attribute_changed(
+        self, attribute: str, cb: Callable
+    ) -> EventSubscription:
+        """Register a callback for when an attribute is changed
+
+        Parameters
+        ----------
+        attribute : str
+            attribute name
+        cb : Callable
+            Callback function
+
+        Returns
+        -------
+        EventSubscription
+            EventSubscription instance which can be used to unregister the callback
+        """
+        request = DataModelProtoModule.SubscribeEventsRequest()
+        e = request.eventrequest.add(rules=self.rules)
+        e.attributeChangedEventRequest.path = convert_path_to_se_path(self.path)
+        e.attributeChangedEventRequest.attribute = attribute
         subscription = EventSubscription(self.service, request)
         self.service.event_streaming.register_callback(subscription.tag, self, cb)
         return subscription

--- a/src/ansys/fluent/core/streaming_services/datamodel_event_streaming.py
+++ b/src/ansys/fluent/core/streaming_services/datamodel_event_streaming.py
@@ -43,5 +43,7 @@ class DatamodelEvents(StreamingService):
                                 childname = response.createdEventResponse.childname
                                 child = getattr(cb[0], childtype)[childname]
                                 cb[1](child)
+                            elif response.HasField("modifiedEventResponse"):
+                                cb[1](cb[0])
             except StopIteration:
                 break

--- a/src/ansys/fluent/core/streaming_services/datamodel_event_streaming.py
+++ b/src/ansys/fluent/core/streaming_services/datamodel_event_streaming.py
@@ -45,5 +45,9 @@ class DatamodelEvents(StreamingService):
                                 cb[1](child)
                             elif response.HasField("modifiedEventResponse"):
                                 cb[1](cb[0])
+                            elif response.HasField("deletedEventResponse"):
+                                cb[1](cb[0])
+                            elif response.HasField("affectedEventResponse"):
+                                cb[1](cb[0])
             except StopIteration:
                 break

--- a/src/ansys/fluent/core/streaming_services/datamodel_event_streaming.py
+++ b/src/ansys/fluent/core/streaming_services/datamodel_event_streaming.py
@@ -1,0 +1,47 @@
+import threading
+from typing import Callable
+
+from ansys.api.fluent.v0 import datamodel_se_pb2
+from ansys.fluent.core.streaming_services.streaming import StreamingService
+
+
+class DatamodelEvents(StreamingService):
+    """Encapsulates a datamodel events streaming service."""
+
+    def __init__(self, service):
+        """Instantiate DatamodelEvents."""
+        super().__init__(
+            target=DatamodelEvents._process_streaming,
+            streaming_service=service,
+        )
+        self._cbs = {}
+        service.event_streaming = self
+        self._lock = threading.RLock()
+
+    def register_callback(self, tag: str, obj, cb: Callable):
+        """Register a callback."""
+        with self._lock:
+            self._cbs[tag] = obj, cb
+
+    def unregister_callback(self, tag: str):
+        """Unregister a callback."""
+        with self._lock:
+            self._cbs.pop(tag, None)
+
+    def _process_streaming(self, started_evt):
+        """Processes datamodel events."""
+        responses = self._streaming_service.begin_event_streaming(started_evt)
+        while True:
+            try:
+                response: datamodel_se_pb2.EventResponse = next(responses)
+                with self._lock:
+                    self._streaming = True
+                    for tag, cb in self._cbs.items():
+                        if tag == response.tag:
+                            if response.HasField("createdEventResponse"):
+                                childtype = response.createdEventResponse.childtype
+                                childname = response.createdEventResponse.childname
+                                child = getattr(cb[0], childtype)[childname]
+                                cb[1](child)
+            except StopIteration:
+                break

--- a/src/ansys/fluent/core/streaming_services/datamodel_event_streaming.py
+++ b/src/ansys/fluent/core/streaming_services/datamodel_event_streaming.py
@@ -43,11 +43,15 @@ class DatamodelEvents(StreamingService):
                                 childname = response.createdEventResponse.childname
                                 child = getattr(cb[0], childtype)[childname]
                                 cb[1](child)
-                            elif response.HasField("modifiedEventResponse"):
-                                cb[1](cb[0])
-                            elif response.HasField("deletedEventResponse"):
-                                cb[1](cb[0])
-                            elif response.HasField("affectedEventResponse"):
+                            elif (
+                                response.HasField("modifiedEventResponse")
+                                or response.HasField("deletedEventResponse")
+                                or response.HasField("affectedEventResponse")
+                                or response.HasField("attributeChangedEventResponse")
+                                or response.HasField(
+                                    "commandAttributeChangedEventResponse"
+                                )
+                            ):
                                 cb[1](cb[0])
             except StopIteration:
                 break

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -354,6 +354,25 @@ class WorkflowWrapper:
         """
         return self._workflow.add_on_child_created(child_type, cb)
 
+    def add_on_affected_at_type_path(
+        self, child_type: str, cb: Callable
+    ) -> EventSubscription:
+        """Register a callback for when the object is affected at child type
+
+        Parameters
+        ----------
+        child_type : str
+            child type
+        cb : Callable
+            Callback function
+
+        Returns
+        -------
+        EventSubscription
+            EventSubscription instance which can be used to unregister the callback
+        """
+        return self._workflow.add_on_affected_at_type_path(child_type, cb)
+
 
 class _MakeReadOnly:
     """Removes 'set_state()' attribute to implement read-only behaviour."""

--- a/src/ansys/fluent/core/workflow.py
+++ b/src/ansys/fluent/core/workflow.py
@@ -1,6 +1,9 @@
-from typing import Tuple
+from typing import Callable, Tuple
 
-from ansys.fluent.core.services.datamodel_se import PyCallableStateObject
+from ansys.fluent.core.services.datamodel_se import (
+    EventSubscription,
+    PyCallableStateObject,
+)
 
 
 def _new_command_for_task(task, session):
@@ -333,6 +336,23 @@ class WorkflowWrapper:
     def _task_by_id(self, task_id):
         workflow_state = self._workflow_state()
         return self._task_by_id_impl(task_id, workflow_state)
+
+    def add_on_child_created(self, child_type: str, cb: Callable) -> EventSubscription:
+        """Register a callback for when a child object is created.
+
+        Parameters
+        ----------
+        child_type : str
+            Type of the child object
+        cb : Callable
+            Callback function
+
+        Returns
+        -------
+        EventSubscription
+            EventSubscription instance which can be used to unregister the callback
+        """
+        return self._workflow.add_on_child_created(child_type, cb)
 
 
 class _MakeReadOnly:

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -91,3 +91,21 @@ def test_add_on_child_created(new_mesh_session):
     meshing.workflow.InitializeWorkflow(WorkflowType="Fault-tolerant Meshing")
     sleep(5)
     assert child_paths == []
+
+
+@pytest.mark.dev
+@pytest.mark.fluent_232
+def test_add_on_changed(new_mesh_session):
+    meshing = new_mesh_session
+    task_list = meshing.workflow.Workflow.TaskList
+    assert isinstance(task_list(), list)
+    assert len(task_list()) == 0
+    data = []
+    meshing.workflow.Workflow.TaskList.add_on_changed(
+        lambda obj: data.append(len(obj()))
+    )
+    assert data == []
+    meshing.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")
+    sleep(5)
+    assert len(data) > 0
+    assert data[0] > 0

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -120,3 +120,23 @@ def test_add_on_affected(new_mesh_session):
     meshing.workflow.InitializeWorkflow(WorkflowType="Fault-tolerant Meshing")
     sleep(5)
     assert data == []
+
+
+@pytest.mark.dev
+@pytest.mark.fluent_232
+def test_add_on_affected_at_type_path(new_mesh_session):
+    meshing = new_mesh_session
+    data = []
+    subscription = meshing.workflow.add_on_affected_at_type_path(
+        "TaskObject", lambda obj: data.append(True)
+    )
+    assert data == []
+    meshing.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")
+    sleep(5)
+    assert len(data) > 0
+    assert data[0] == True
+    data.clear()
+    subscription.unsubscribe()
+    meshing.workflow.InitializeWorkflow(WorkflowType="Fault-tolerant Meshing")
+    sleep(5)
+    assert data == []

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -1,0 +1,79 @@
+from time import sleep
+
+import pytest
+from util.meshing_workflow import new_mesh_session  # noqa: F401
+
+from ansys.api.fluent.v0 import datamodel_se_pb2
+from ansys.fluent.core.services.datamodel_se import convert_path_to_se_path
+
+
+@pytest.mark.dev
+@pytest.mark.fluent_232
+def test_event_subscription(new_mesh_session):
+    session = new_mesh_session
+    session.workflow.InitializeWorkflow(WorkflowType='Watertight Geometry')
+    tags = [
+        "/workflow/created/TaskObject",
+        "/workflow/modified/TaskObject:TaskObject1/Arguments",
+        "/workflow/deleted/TaskObject:TaskObject1",
+        "/workflow/affected/TaskObject:TaskObject1",
+        "/workflow/affected/TaskObject",
+        "/workflow/attribute_changed/TaskObject:TaskObject1/TaskList/isActive",
+        "/workflow/command_attribute_changed/InitializeWorkflow/arguments"
+    ]
+    request = datamodel_se_pb2.SubscribeEventsRequest()
+    e1 = request.eventrequest.add(rules="workflow")
+    e1.createdEventRequest.parentpath = ""
+    e1.createdEventRequest.childtype = "TaskObject"
+    e2 = request.eventrequest.add(rules="workflow")
+    e2.modifiedEventRequest.path = "TaskObject:TaskObject1/Arguments"
+    e3 = request.eventrequest.add(rules="workflow")
+    e3.deletedEventRequest.path = "TaskObject:TaskObject1"
+    e4 = request.eventrequest.add(rules="workflow")
+    e4.affectedEventRequest.path = "TaskObject:TaskObject1"
+    e5 = request.eventrequest.add(rules="workflow")
+    e5.affectedEventRequest.path = ""
+    e5.affectedEventRequest.subtype = "TaskObject"
+    e6 = request.eventrequest.add(rules="workflow")
+    e6.attributeChangedEventRequest.path = "TaskObject:TaskObject1/TaskList"
+    e6.attributeChangedEventRequest.attribute = "isActive"
+    e7 = request.eventrequest.add(rules="workflow")
+    e7.commandAttributeChangedEventRequest.path = ""
+    e7.commandAttributeChangedEventRequest.command = "InitializeWorkflow"
+    e7.commandAttributeChangedEventRequest.attribute = "arguments"
+    response = session.fluent_connection.datamodel_service_se.subscribe_events(request)
+    assert all([r.status == datamodel_se_pb2.STATUS_SUBSCRIBED and r.tag == t for r, t in zip(response.response, tags)])
+
+    request = datamodel_se_pb2.UnsubscribeEventsRequest()
+    request.tag.extend(tags)
+    response = session.fluent_connection.datamodel_service_se.unsubscribe_events(request)
+    assert all([r.status == datamodel_se_pb2.STATUS_UNSUBSCRIBED and r.tag == t for r, t in zip(response.response, tags)])
+
+
+@pytest.mark.dev
+@pytest.mark.fluent_232
+def test_add_on_child_created(new_mesh_session):
+    meshing = new_mesh_session
+    child_paths = []
+    subscription = meshing.workflow.add_on_child_created("TaskObject", lambda obj: child_paths.append(convert_path_to_se_path(obj.path)))
+    assert child_paths == []
+    meshing.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")
+    sleep(5)
+    assert child_paths == [
+        "/TaskObject:Import Geometry",
+        "/TaskObject:Add Local Sizing",
+        "/TaskObject:Generate the Surface Mesh",
+        "/TaskObject:Describe Geometry",
+        "/TaskObject:Apply Share Topology",
+        "/TaskObject:Enclose Fluid Regions (Capping)",
+        "/TaskObject:Update Boundaries",
+        "/TaskObject:Create Regions",
+        "/TaskObject:Update Regions",
+        "/TaskObject:Add Boundary Layers",
+        "/TaskObject:Generate the Volume Mesh"
+        ]
+    child_paths.clear()
+    subscription.unsubscribe()
+    meshing.workflow.InitializeWorkflow(WorkflowType="Fault-tolerant Meshing")
+    sleep(5)
+    assert child_paths == []

--- a/tests/test_datamodel_service.py
+++ b/tests/test_datamodel_service.py
@@ -11,7 +11,7 @@ from ansys.fluent.core.services.datamodel_se import convert_path_to_se_path
 @pytest.mark.fluent_232
 def test_event_subscription(new_mesh_session):
     session = new_mesh_session
-    session.workflow.InitializeWorkflow(WorkflowType='Watertight Geometry')
+    session.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")
     tags = [
         "/workflow/created/TaskObject",
         "/workflow/modified/TaskObject:TaskObject1/Arguments",
@@ -19,7 +19,7 @@ def test_event_subscription(new_mesh_session):
         "/workflow/affected/TaskObject:TaskObject1",
         "/workflow/affected/TaskObject",
         "/workflow/attribute_changed/TaskObject:TaskObject1/TaskList/isActive",
-        "/workflow/command_attribute_changed/InitializeWorkflow/arguments"
+        "/workflow/command_attribute_changed/InitializeWorkflow/arguments",
     ]
     request = datamodel_se_pb2.SubscribeEventsRequest()
     e1 = request.eventrequest.add(rules="workflow")
@@ -42,12 +42,24 @@ def test_event_subscription(new_mesh_session):
     e7.commandAttributeChangedEventRequest.command = "InitializeWorkflow"
     e7.commandAttributeChangedEventRequest.attribute = "arguments"
     response = session.fluent_connection.datamodel_service_se.subscribe_events(request)
-    assert all([r.status == datamodel_se_pb2.STATUS_SUBSCRIBED and r.tag == t for r, t in zip(response.response, tags)])
+    assert all(
+        [
+            r.status == datamodel_se_pb2.STATUS_SUBSCRIBED and r.tag == t
+            for r, t in zip(response.response, tags)
+        ]
+    )
 
     request = datamodel_se_pb2.UnsubscribeEventsRequest()
     request.tag.extend(tags)
-    response = session.fluent_connection.datamodel_service_se.unsubscribe_events(request)
-    assert all([r.status == datamodel_se_pb2.STATUS_UNSUBSCRIBED and r.tag == t for r, t in zip(response.response, tags)])
+    response = session.fluent_connection.datamodel_service_se.unsubscribe_events(
+        request
+    )
+    assert all(
+        [
+            r.status == datamodel_se_pb2.STATUS_UNSUBSCRIBED and r.tag == t
+            for r, t in zip(response.response, tags)
+        ]
+    )
 
 
 @pytest.mark.dev
@@ -55,7 +67,9 @@ def test_event_subscription(new_mesh_session):
 def test_add_on_child_created(new_mesh_session):
     meshing = new_mesh_session
     child_paths = []
-    subscription = meshing.workflow.add_on_child_created("TaskObject", lambda obj: child_paths.append(convert_path_to_se_path(obj.path)))
+    subscription = meshing.workflow.add_on_child_created(
+        "TaskObject", lambda obj: child_paths.append(convert_path_to_se_path(obj.path))
+    )
     assert child_paths == []
     meshing.workflow.InitializeWorkflow(WorkflowType="Watertight Geometry")
     sleep(5)
@@ -70,8 +84,8 @@ def test_add_on_child_created(new_mesh_session):
         "/TaskObject:Create Regions",
         "/TaskObject:Update Regions",
         "/TaskObject:Add Boundary Layers",
-        "/TaskObject:Generate the Volume Mesh"
-        ]
+        "/TaskObject:Generate the Volume Mesh",
+    ]
     child_paths.clear()
     subscription.unsubscribe()
     meshing.workflow.InitializeWorkflow(WorkflowType="Fault-tolerant Meshing")


### PR DESCRIPTION
Example:
`subscription1 = meshing.workflow.add_on_child_created("TaskObject", lambda obj: print(obj.path))`

The datamodel event streaming service is activated by default. Each callback registration will subscribe the corresponding event to the server and add the callback function to `datamodel_event_streaming.py::DatamodelEvents` instance. The callback function gets executed when a matching event is streamed from server. The event is matched using a string tag which is computed in the server during the event subscription. The callback registration returns a `datamodel_se.py::EventSubscription` instance. `subscription1.unsubscribe()` will unsubscribe the event in server and remove the callback function from `DatamodelEvents` instance.