### PR TITLE
Use random port in unittests

### DIFF
--- a/src/ansys/fluent/core/launcher/fluent_container.py
+++ b/src/ansys/fluent/core/launcher/fluent_container.py
@@ -1,18 +1,12 @@
 import os
 from pathlib import Path
-import socket
 import subprocess
 import tempfile
 import time
 from typing import List
 
 from ansys.fluent.core.session import parse_server_info_file
-
-
-def _get_free_port() -> int:
-    sock = socket.socket()
-    sock.bind(("", 0))
-    return sock.getsockname()[1]
+from ansys.fluent.core.utils.network import get_free_port
 
 
 def start_fluent_container(mounted_from: str, mounted_to: str, args: List[str]) -> int:
@@ -38,7 +32,7 @@ def start_fluent_container(mounted_from: str, mounted_to: str, args: List[str]) 
     os.close(fd)
     timeout = 100
     license_server = os.environ["ANSYSLMD_LICENSE_FILE"]
-    port = _get_free_port()
+    port = get_free_port()
     password = ""
     container_sifile = mounted_to + "/" + Path(sifile).name
     image_tag = os.getenv("FLUENT_IMAGE_TAG", "v23.1.0")

--- a/src/ansys/fluent/core/utils/network.py
+++ b/src/ansys/fluent/core/utils/network.py
@@ -1,0 +1,15 @@
+import socket
+
+
+def get_free_port() -> int:
+    """Identifies a free port to which a new socket connection can be
+    established.
+
+    Returns
+    -------
+    int
+        port number
+    """
+    sock = socket.socket()
+    sock.bind(("", 0))
+    return sock.getsockname()[1]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -20,6 +20,7 @@ from ansys.fluent.core import examples, launch_fluent
 from ansys.fluent.core.examples import download_file
 from ansys.fluent.core.fluent_connection import _FluentConnection
 from ansys.fluent.core.session import _BaseSession
+from ansys.fluent.core.utils.network import get_free_port
 
 
 class MockHealthServicer(health_pb2_grpc.HealthServicer):
@@ -74,7 +75,7 @@ class MockSchemeEvalServicer(scheme_eval_pb2_grpc.SchemeEvalServicer):
 def test_create_session_by_passing_ip_and_port_and_password() -> None:
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
     ip = "127.0.0.1"
-    port = 50051
+    port = get_free_port()
     server.add_insecure_port(f"{ip}:{port}")
     health_pb2_grpc.add_HealthServicer_to_server(MockHealthServicer(), server)
     scheme_eval_pb2_grpc.add_SchemeEvalServicer_to_server(
@@ -95,7 +96,7 @@ def test_create_session_by_setting_ip_and_port_env_var(
 ) -> None:
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
     ip = "127.0.0.1"
-    port = 50051
+    port = get_free_port()
     server.add_insecure_port(f"{ip}:{port}")
     health_pb2_grpc.add_HealthServicer_to_server(MockHealthServicer(), server)
     scheme_eval_pb2_grpc.add_SchemeEvalServicer_to_server(
@@ -114,7 +115,7 @@ def test_create_session_by_setting_ip_and_port_env_var(
 def test_create_session_by_passing_grpc_channel() -> None:
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
     ip = "127.0.0.1"
-    port = 50051
+    port = get_free_port()
     server.add_insecure_port(f"{ip}:{port}")
     health_pb2_grpc.add_HealthServicer_to_server(MockHealthServicer(), server)
     scheme_eval_pb2_grpc.add_SchemeEvalServicer_to_server(
@@ -134,7 +135,7 @@ def test_create_session_by_passing_grpc_channel() -> None:
 def test_create_session_from_server_info_file(tmp_path: Path) -> None:
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
     ip = "127.0.0.1"
-    port = 50051
+    port = get_free_port()
     server.add_insecure_port(f"{ip}:{port}")
     health_pb2_grpc.add_HealthServicer_to_server(MockHealthServicer(), server)
     scheme_eval_pb2_grpc.add_SchemeEvalServicer_to_server(
@@ -157,7 +158,7 @@ def test_create_session_from_server_info_file_with_wrong_password(
 ) -> None:
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
     ip = "127.0.0.1"
-    port = 50051
+    port = get_free_port()
     server.add_insecure_port(f"{ip}:{port}")
     scheme_eval_pb2_grpc.add_SchemeEvalServicer_to_server(
         MockSchemeEvalServicer(), server
@@ -177,7 +178,7 @@ def test_create_session_from_server_info_file_with_wrong_password(
 def test_create_session_from_launch_fluent_by_passing_ip_and_port_and_password() -> None:
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
     ip = "127.0.0.1"
-    port = 50051
+    port = get_free_port()
     server.add_insecure_port(f"{ip}:{port}")
     health_pb2_grpc.add_HealthServicer_to_server(MockHealthServicer(), server)
     scheme_eval_pb2_grpc.add_SchemeEvalServicer_to_server(
@@ -207,7 +208,7 @@ def test_create_session_from_launch_fluent_by_setting_ip_and_port_env_var(
 ) -> None:
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
     ip = "127.0.0.1"
-    port = 50051
+    port = get_free_port()
     server.add_insecure_port(f"{ip}:{port}")
     health_pb2_grpc.add_HealthServicer_to_server(MockHealthServicer(), server)
     scheme_eval_pb2_grpc.add_SchemeEvalServicer_to_server(


### PR DESCRIPTION
I was seeing random issues from these tests, most likely due to sharing the same port number.