### PR TITLE
Remove path from zipped doc archive

### DIFF
--- a/.github/workflows/nightly-dev-doc-build.yml
+++ b/.github/workflows/nightly-dev-doc-build.yml
@@ -71,7 +71,8 @@ jobs:
       - name: Zip HTML Documentation before upload
         run: |
           sudo apt install zip -y
-          zip -r HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}.zip doc/_build/html
+          cd doc/_build/html
+          zip -r HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}.zip .
 
       - name: Upload HTML Documentation
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
I think this is why the `dev` link is broken, the `doc/_build/html` part of the path is messing up finding the index.html.