### PR TITLE
Add CI to run unittests without codegen

### DIFF
--- a/.github/workflows/test-run-wo-codegen.yml
+++ b/.github/workflows/test-run-wo-codegen.yml
@@ -1,8 +1,8 @@
 name: Nightly Test Run
 
 on:
-  schedule:  # UTC at 0400
-    - cron:  '0 4 * * *'
+  schedule:  # UTC at 0400 on Monday and Thursday
+    - cron:  '0 4 * * MON,THU'
   workflow_dispatch:
 
 jobs:
@@ -50,59 +50,15 @@ jobs:
         env:
           FLUENT_IMAGE_TAG: v22.2.0
 
-      - name: Run 22.2 API codegen
-        run: make api-codegen
-        env:
-          ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
-          PYFLUENT_START_INSTANCE: 0
-          PYFLUENT_LAUNCH_CONTAINER: 1
-          FLUENT_IMAGE_TAG: v22.2.0
-
-      - name: Print 22.2 Fluent version info
-        run: |
-          cat src/ansys/fluent/core/fluent_version_222.py
-          python -c "from ansys.fluent.core.solver.settings_222 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
-
       - name: Pull 23.1 Fluent docker image
         run: make docker-pull
         env:
           FLUENT_IMAGE_TAG: v23.1.0
 
-      - name: Run 23.1 API codegen
-        run: make api-codegen
-        env:
-          ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
-          PYFLUENT_START_INSTANCE: 0
-          PYFLUENT_LAUNCH_CONTAINER: 1
-          FLUENT_IMAGE_TAG: v23.1.0
-
-      - name: Print 23.1 Fluent version info
-        run: |
-          cat src/ansys/fluent/core/fluent_version_231.py
-          python -c "from ansys.fluent.core.solver.settings_231 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
-
       - name: Pull 23.2 Fluent docker image
         run: make docker-pull
         env:
           FLUENT_IMAGE_TAG: v23.2.0
-
-      - name: Run 23.2 API codegen
-        run: make api-codegen
-        env:
-          ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
-          PYFLUENT_START_INSTANCE: 0
-          PYFLUENT_LAUNCH_CONTAINER: 1
-          FLUENT_IMAGE_TAG: v23.2.0
-
-      - name: Print 23.2 Fluent version info
-        run: |
-          cat src/ansys/fluent/core/fluent_version_232.py
-          python -c "from ansys.fluent.core.solver.settings_231 import SHASH; print(f'SETTINGS_HASH = {SHASH}')"
-
-      - name: Install again after codegen
-        run: |
-          rm -rf dist
-          make install > /dev/null
 
       - name: 22.2 Unit Testing
         run: make unittest-all-222
@@ -119,13 +75,6 @@ jobs:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
           FLUENT_IMAGE_TAG: v23.1.0
-
-      - name: Upload 23.1 Coverage Artifacts
-        uses: actions/upload-artifact@v3
-        continue-on-error: true
-        with:
-          name: coverage_report
-          path: ./htmlcov
 
       - name: 23.2 Unit Testing
         run: make unittest-all-232


### PR DESCRIPTION
As in our code we support all pyfluent workflows even when the API files aren't generated through codegen, I'm adding this CI to keep testing the generic code we have for when the API files aren't present. The CI will be run every Monday and Thursday.