### PR TITLE
Testing/increasing coverage

### DIFF
--- a/.github/workflows/nightly-doc-build.yml
+++ b/.github/workflows/nightly-doc-build.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   DOCUMENTATION_CNAME: 'fluent.docs.pyansys.com'
-  DOC_DEPLOYMENT_IMAGE_TAG: v22.2.0
+  DOC_DEPLOYMENT_IMAGE_TAG: v23.1.0
 
 jobs:
   nightly_docs_build:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -157,6 +157,10 @@ class TestLoadMachines(unittest.TestCase):
     def tearDown(self):
         self._machineList.reset()
 
+    def test_machine_info(self):
+        machineList = load_machines(machine_info=[{'machine-name' : 1, 'core-count' : 6}, {'machine-name' : 2, 'core-count' : 6}])
+        self.assertEqual(machineList.number_of_cores, 12)
+
     def test_no_environment(self):
         machineList = load_machines()
         self.assertEqual(machineList[0].host_name, socket.gethostname())

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -174,7 +174,7 @@ class TestLoadMachines(unittest.TestCase):
     def test_lsb_mcpu(self):
         os.environ['LSB_MCPU_HOSTS'] = 'm1 3 m2 3'
         machineList = load_machines()
-        os.environ.pop('LSB_MCPU_HOSTS')
+        del os.environ['LSB_MCPU_HOSTS']
         self.assertEqual(machineList.number_of_cores, 6)
 
     def test_no_environment(self):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -159,6 +159,7 @@ class TestLoadMachines(unittest.TestCase):
         self._machineList.reset()
     
     def test_machine_info(self):
+        print('wacky')
         info = [{'machine-name' : 'M0', 'core-count' : 1},
                 {'machine-name' : 'M1', 'core-count' : 6}]
         machineList = load_machines(machine_info = info)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -158,12 +158,6 @@ class TestLoadMachines(unittest.TestCase):
     def tearDown(self):
         self._machineList.reset()
 
-    def test_machine_info(self):
-        info = [{'machine-name' : 'M0', 'core-count' : 1},
-                {'machine-name' : 'M1', 'core-count' : 6}]
-        machineList = load_machines(machine_info = info)
-        self.assertEqual(machineList.number_of_cores, 7)
-
     def test_restrict_machines(self):
         info = [{'machine-name' : 'M0', 'core-count' : 1},
                 {'machine-name' : 'M1', 'core-count' : 1}]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -157,6 +157,12 @@ class TestLoadMachines(unittest.TestCase):
 
     def tearDown(self):
         self._machineList.reset()
+    
+    def test_machine_info(self):
+        info = [{'machine-name' : 'M0', 'core-count' : 1},
+                {'machine-name' : 'M1', 'core-count' : 6}]
+        machineList = load_machines(machine_info = info)
+        self.assertEqual(machineList.number_of_cores, 7)
 
     def test_restrict_machines(self):
         info = [{'machine-name' : 'M0', 'core-count' : 1},

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -170,6 +170,12 @@ class TestLoadMachines(unittest.TestCase):
         machineList = load_machines(machine_info = info)
         old_machine_list = _restrict_machines_to_core_count(machineList, ncores= machineList.number_of_cores)
         self.assertEqual(machineList, old_machine_list)
+    
+    def test_lsb_mcpu(self):
+        os.environ['LSB_MCPU_HOSTS'] = 'm1 3 m2 3'
+        machineList = load_machines()
+        os.environ.pop('LSB_MCPU_HOSTS')
+        self.assertEqual(machineList.number_of_cores, 6)
 
     def test_no_environment(self):
         machineList = load_machines()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -157,12 +157,6 @@ class TestLoadMachines(unittest.TestCase):
 
     def tearDown(self):
         self._machineList.reset()
-    
-    def test_machine_info(self):
-        info = [{'machine-name' : 'M0', 'core-count' : 1},
-                {'machine-name' : 'M1', 'core-count' : 6}]
-        machineList = load_machines(machine_info = info)
-        self.assertEqual(machineList.number_of_cores, 7)
 
     def test_restrict_machines(self):
         info = [{'machine-name' : 'M0', 'core-count' : 1},

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -11,6 +11,7 @@ from ansys.fluent.core.scheduler.load_machines import (
     _parse_host_info,
     _parse_machine_data,
     load_machines,
+    _restrict_machines_to_core_count,
 )
 from ansys.fluent.core.scheduler.machine_list import Machine, MachineList
 
@@ -158,8 +159,17 @@ class TestLoadMachines(unittest.TestCase):
         self._machineList.reset()
 
     def test_machine_info(self):
-        machineList = load_machines(machine_info=[{'machine-name' : 1, 'core-count' : 6}, {'machine-name' : 2, 'core-count' : 6}])
-        self.assertEqual(machineList.number_of_cores, 12)
+        info = [{'machine-name' : 'M0', 'core-count' : 1},
+                {'machine-name' : 'M1', 'core-count' : 6}]
+        machineList = load_machines(machine_info = info)
+        self.assertEqual(machineList.number_of_cores, 7)
+
+    def test_restrict_machines(self):
+        info = [{'machine-name' : 'M0', 'core-count' : 1},
+                {'machine-name' : 'M1', 'core-count' : 1}]
+        machineList = load_machines(machine_info = info)
+        old_machine_list = _restrict_machines_to_core_count(machineList, ncores= machineList.number_of_cores)
+        self.assertEqual(machineList, old_machine_list)
 
     def test_no_environment(self):
         machineList = load_machines()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -159,7 +159,6 @@ class TestLoadMachines(unittest.TestCase):
         self._machineList.reset()
     
     def test_machine_info(self):
-        print('wacky')
         info = [{'machine-name' : 'M0', 'core-count' : 1},
                 {'machine-name' : 'M1', 'core-count' : 6}]
         machineList = load_machines(machine_info = info)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -394,6 +394,12 @@ class TestMachineListCmdLine(unittest.TestCase):
                 self.assertEqual(
                     machine.number_of_cores, self._expectedValues[machine.host_name]
                 )
+    
+    def test_no_machine_name(self):
+        hostList = "M0:2,M1:2,"
+        with self.assertRaises(RuntimeError) as cm:
+            _parse_host_info(hostList)
+        self.assertEqual(str(cm.exception), 'Problem with machine list format.')
 
     def test_host_file(self):
         import os.path

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -10,8 +10,8 @@ from ansys.fluent.core.scheduler.load_machines import (
     _construct_machine_list_slurm,
     _parse_host_info,
     _parse_machine_data,
-    load_machines,
     _restrict_machines_to_core_count,
+    load_machines,
 )
 from ansys.fluent.core.scheduler.machine_list import Machine, MachineList
 
@@ -157,24 +157,30 @@ class TestLoadMachines(unittest.TestCase):
 
     def tearDown(self):
         self._machineList.reset()
-    
+
     def test_machine_info(self):
-        info = [{'machine-name' : 'M0', 'core-count' : 1},
-                {'machine-name' : 'M1', 'core-count' : 6}]
-        machineList = load_machines(machine_info = info)
+        info = [
+            {"machine-name": "M0", "core-count": 1},
+            {"machine-name": "M1", "core-count": 6},
+        ]
+        machineList = load_machines(machine_info=info)
         self.assertEqual(machineList.number_of_cores, 7)
 
     def test_restrict_machines(self):
-        info = [{'machine-name' : 'M0', 'core-count' : 1},
-                {'machine-name' : 'M1', 'core-count' : 1}]
-        machineList = load_machines(machine_info = info)
-        old_machine_list = _restrict_machines_to_core_count(machineList, ncores= machineList.number_of_cores)
+        info = [
+            {"machine-name": "M0", "core-count": 1},
+            {"machine-name": "M1", "core-count": 1},
+        ]
+        machineList = load_machines(machine_info=info)
+        old_machine_list = _restrict_machines_to_core_count(
+            machineList, ncores=machineList.number_of_cores
+        )
         self.assertEqual(machineList, old_machine_list)
-    
+
     def test_lsb_mcpu(self):
-        os.environ['LSB_MCPU_HOSTS'] = 'm1 3 m2 3'
+        os.environ["LSB_MCPU_HOSTS"] = "m1 3 m2 3"
         machineList = load_machines()
-        del os.environ['LSB_MCPU_HOSTS']
+        del os.environ["LSB_MCPU_HOSTS"]
         self.assertEqual(machineList.number_of_cores, 6)
 
     def test_no_environment(self):
@@ -400,12 +406,12 @@ class TestMachineListCmdLine(unittest.TestCase):
                 self.assertEqual(
                     machine.number_of_cores, self._expectedValues[machine.host_name]
                 )
-    
+
     def test_no_machine_name(self):
         hostList = "M0:2,M1:2,"
         with self.assertRaises(RuntimeError) as cm:
             _parse_host_info(hostList)
-        self.assertEqual(str(cm.exception), 'Problem with machine list format.')
+        self.assertEqual(str(cm.exception), "Problem with machine list format.")
 
     def test_host_file(self):
         import os.path


### PR DESCRIPTION
I have added 4 extra tests to tests/test_scheduler.py. These tests are as follows:

test_machine_info:
This makes sure that calling load_machines() with machine_info gets correctly sorted through the elif block.  

test_restrict_machines:
This test checks that if test_restrict_machines() is called directly it will not alter a machine list that has less than or equal to the ncores specified.

test_lsb_mcpu:
simply makes sure that "LSB_MCPU_HOSTS" is checked for a possible host list.

test_no_machine_name:
Checks to make sure that _parse_host_info will throw the 'Problem with machine list format.' exception if there is a blank machine name.

Please let me know if there is anything incorrect, poor logic, or unneeded tests here.
If this is accepted this will be my first contribution. I would be happy to receive any feedback and look forward to working on more testing.