### PR TITLE
CI to build+deploy release doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,16 +197,6 @@ jobs:
           path: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}.zip
           retention-days: 7
 
-#      - name: Deploy stable documentation
-#        uses: pyansys/actions/doc-deploy-stable@v3
-#        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev')
-#        with:
-#            doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
-#            decompress_artifact: true
-#            cname: ${{ env.DOCUMENTATION_CNAME }}
-#            token: ${{ secrets.GITHUB_TOKEN }}
-
-
   build:
     name: Build
     needs: test-import

--- a/.github/workflows/release-doc-build.yml
+++ b/.github/workflows/release-doc-build.yml
@@ -1,9 +1,11 @@
-name: Nightly Development Documentation Build
+name: Release Documentation Build
 
 on:
-  schedule:  # UTC at 0400
-    - cron:  '0 4 * * *'
   workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+      - '!*dev*'
 
 env:
   DOCUMENTATION_CNAME: 'fluent.docs.pyansys.com'
@@ -12,10 +14,6 @@ env:
 jobs:
   nightly_docs_build:
     runs-on: [self-hosted, pyfluent]
-    strategy:
-      fail-fast: false
-      matrix:
-        image-tag: [v22.2.0, v23.1.0, v23.2.0]
 
     steps:
       - uses: actions/checkout@v3
@@ -43,7 +41,7 @@ jobs:
       - name: Pull Fluent docker image
         run: make docker-pull
         env:
-          FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
+          FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
 
       - name: Run API codegen
         run: make api-codegen
@@ -51,14 +49,14 @@ jobs:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
           PYFLUENT_LAUNCH_CONTAINER: 1
-          FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
+          FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
 
       - name: Build All Documentation
         run: make build-all-docs
         env:
           ANSYSLMD_LICENSE_FILE: ${{ format('1055@{0}', secrets.LICENSE_SERVER) }}
           PYFLUENT_START_INSTANCE: 0
-          FLUENT_IMAGE_TAG: ${{ matrix.image-tag }}
+          FLUENT_IMAGE_TAG: ${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}
 
       - name: Zip HTML Documentation before upload
         run: |
@@ -74,9 +72,8 @@ jobs:
           path: HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}.zip
           retention-days: 7
 
-      - name: "Deploy development documentation"
-        if: matrix.image-tag == env.DOC_DEPLOYMENT_IMAGE_TAG
-        uses: pyansys/actions/doc-deploy-dev@v3
+      - name: "Deploy release documentation"
+        uses: pyansys/actions/doc-deploy-stable@v3
         with:
             doc-artifact-name: 'HTML-Documentation-tag-${{ env.DOC_DEPLOYMENT_IMAGE_TAG }}'
             decompress_artifact: true


### PR DESCRIPTION
Added a new CI to build and deploy the release doc. We have disabled that step from ci.yml as we now build only pyfluent source doc in ci.yml. The CI will be triggered when a non-dev tag is pushed. 