### PR TITLE
Testing/scheduler testing improvments

### DIFF
--- a/src/ansys/fluent/core/scheduler/load_machines.py
+++ b/src/ansys/fluent/core/scheduler/load_machines.py
@@ -118,11 +118,8 @@ def _parse_host_info(host_info):
         A list of dictionaries formatted as:
         {'machine-name' : ###, 'core-count' : ###}
     """
-    print(host_info)
-    if "\\" in host_info or "/" in host_info or "." in host_info:
-        # Filenames generally have '\\' or '/' or '.'
-        # so assume it's a file and parse accordingly
-        # Read from the file
+    if os.path.exists(host_info):
+        # Only opens a file if it exists
         with open(host_info, "r") as f:
             host_info = f.read()
 

--- a/src/ansys/fluent/core/scheduler/load_machines.py
+++ b/src/ansys/fluent/core/scheduler/load_machines.py
@@ -118,14 +118,8 @@ def _parse_host_info(host_info):
         A list of dictionaries formatted as:
         {'machine-name' : ###, 'core-count' : ###}
     """
-    print(host_info)
-    if ("\\" in host_info
-        or "/" in host_info
-        or "." in host_info
-    ):
-        # Filenames generally have '\\' or '/' or '.'
-        # so assume it's a file and parse accordingly
-        # Read from the file
+    if (os.path.exists(host_info)):
+        # only opens a file if it exists
         with open(host_info, "r") as f:
             host_info = f.read()
          

--- a/src/ansys/fluent/core/scheduler/load_machines.py
+++ b/src/ansys/fluent/core/scheduler/load_machines.py
@@ -119,10 +119,7 @@ def _parse_host_info(host_info):
         {'machine-name' : ###, 'core-count' : ###}
     """
     print(host_info)
-    if ("\\" in host_info
-        or "/" in host_info
-        or "." in host_info
-    ):
+    if "\\" in host_info or "/" in host_info or "." in host_info:
         # Filenames generally have '\\' or '/' or '.'
         # so assume it's a file and parse accordingly
         # Read from the file

--- a/src/ansys/fluent/core/scheduler/load_machines.py
+++ b/src/ansys/fluent/core/scheduler/load_machines.py
@@ -264,8 +264,7 @@ def _construct_machine_list_uge(host_filename):
             if len(row) == 1:
                 row.append(1)
             row[1] = int(row[1])
-            m = Machine(*row)
-            machineList.add(m)
+            machineList.add(Machine(*row))
     return machineList
 
 
@@ -289,15 +288,18 @@ def _construct_machine_list_pbs(host_filename):
     with open(host_filename, "r") as pbsFile:
         for hostname in pbsFile:
             hostname = hostname.rstrip("\r\n")
+            if len(hostname) == 0:
+                continue
             if hostname in machineDict:
-                machineDict[hostname].number_of_cores += 1
+                machineDict[hostname] += 1
             else:
-                machineDict[hostname] = Machine(hostname, 1)
+                machineDict[hostname] = 1
 
     # Convert accumulated dictionary to a MachineList
     machineList = MachineList()
-    for m in list(machineDict.values()):
-        machineList.add(m)
+    for m in list(machineDict):
+        machine = Machine(m, machineDict[m])
+        machineList.add(machine)
     return machineList
 
 

--- a/src/ansys/fluent/core/scheduler/load_machines.py
+++ b/src/ansys/fluent/core/scheduler/load_machines.py
@@ -7,9 +7,9 @@ variables, respectively.
 """
 import csv
 import os
+from pathlib import Path
 import subprocess
 from typing import Dict, List
-from pathlib import Path
 
 from ansys.fluent.core.scheduler.machine_list import Machine, MachineList
 

--- a/src/ansys/fluent/core/scheduler/load_machines.py
+++ b/src/ansys/fluent/core/scheduler/load_machines.py
@@ -260,8 +260,12 @@ def _construct_machine_list_uge(host_filename):
         peReader = csv.reader(peFile, dialect="pemachines")
         for row in peReader:
             if len(row) == 0:
-                break
-            m = Machine(row[0], int(row[1]), row[2], None if len(row) == 4 else row[3])
+                continue
+            numberOfCores = row[1] if len(row) >= 2 else 1
+            queueName = row[2] if len(row) >= 3 else None
+            coreList = row[3] if len(row) >= 4 else None
+            print(row, numberOfCores, queueName, coreList, len(row))
+            m = Machine(row[0], int(numberOfCores),queueName, coreList)
             machineList.add(m)
     return machineList
 

--- a/src/ansys/fluent/core/scheduler/load_machines.py
+++ b/src/ansys/fluent/core/scheduler/load_machines.py
@@ -338,7 +338,7 @@ def _construct_machine_list_slurm(host_list):
     # Regular expression to identify if a host entry contains a single range of machines
     pRange = re.compile(r"\[.*\]")
     # Regular expressions to identify a single machine ID within brackets
-    pIDOne = re.compile(r"^.*\[(\d*)$")
+    pIDOne = re.compile(r"^.*\[(\d*).$")
     pIDOneNext = re.compile(r"^(\d*)")
     # Regular expressions to identify a range of machine IDs within brackets
     pIDRangeFirst = re.compile(r"^.*\[(\d*)-(\d*).*$")
@@ -377,7 +377,7 @@ def _construct_machine_list_slurm(host_list):
             else:
                 machineIDs = pIDOne.match(hosts)
                 id = int(machineIDs.group(1))
-                numch = len(re.compile(r"^.*\[(\d*)$").match(hosts).group(1))
+                numch = len(re.compile(r"^.*\[(\d*).$").match(hosts).group(1))
                 machineName = machinePrefix + str(id).rjust(numch, "0")
                 machineList.add(Machine(machineName, coresPerMachine))
 

--- a/src/ansys/fluent/core/scheduler/load_machines.py
+++ b/src/ansys/fluent/core/scheduler/load_machines.py
@@ -264,7 +264,6 @@ def _construct_machine_list_uge(host_filename):
             if len(row) == 1:
                 row.append(1)
             row[1] = int(row[1])
-            print(row)
             m = Machine(*row)
             machineList.add(m)
     return machineList

--- a/src/ansys/fluent/core/scheduler/load_machines.py
+++ b/src/ansys/fluent/core/scheduler/load_machines.py
@@ -261,11 +261,11 @@ def _construct_machine_list_uge(host_filename):
         for row in peReader:
             if len(row) == 0:
                 continue
-            numberOfCores = row[1] if len(row) >= 2 else 1
-            queueName = row[2] if len(row) >= 3 else None
-            coreList = row[3] if len(row) >= 4 else None
-            print(row, numberOfCores, queueName, coreList, len(row))
-            m = Machine(row[0], int(numberOfCores),queueName, coreList)
+            if len(row) == 1:
+                row.append(1)
+            row[1] = int(row[1])
+            print(row)
+            m = Machine(*row)
             machineList.add(m)
     return machineList
 

--- a/src/ansys/fluent/core/scheduler/load_machines.py
+++ b/src/ansys/fluent/core/scheduler/load_machines.py
@@ -9,6 +9,7 @@ import csv
 import os
 import subprocess
 from typing import Dict, List
+from pathlib import Path
 
 from ansys.fluent.core.scheduler.machine_list import Machine, MachineList
 
@@ -118,7 +119,7 @@ def _parse_host_info(host_info):
         A list of dictionaries formatted as:
         {'machine-name' : ###, 'core-count' : ###}
     """
-    if os.path.exists(host_info):
+    if Path(host_info).is_file():
         # Only opens a file if it exists
         with open(host_info, "r") as f:
             host_info = f.read()

--- a/src/ansys/fluent/core/scheduler/load_machines.py
+++ b/src/ansys/fluent/core/scheduler/load_machines.py
@@ -257,7 +257,8 @@ def _construct_machine_list_uge(host_filename):
                 continue
             if len(row) == 1:
                 row.append(1)
-            row[1] = int(row[1])
+            else:
+                row[1] = int(row[1])
             machineList.add(Machine(*row))
     return machineList
 

--- a/src/ansys/fluent/core/scheduler/load_machines.py
+++ b/src/ansys/fluent/core/scheduler/load_machines.py
@@ -118,21 +118,21 @@ def _parse_host_info(host_info):
         A list of dictionaries formatted as:
         {'machine-name' : ###, 'core-count' : ###}
     """
-    if (
-        (":" in host_info or "," in host_info)
-        and not "\\" in host_info
-        and not "/" in host_info
+    print(host_info)
+    if ("\\" in host_info
+        or "/" in host_info
+        or "." in host_info
     ):
-        # Filenames generally shouldn't have ':',
-        # so assume it's a string list and parse accordingly
-        sMod = 1 if host_info[0] == "[" else 0
-        sBeg = sMod
-        sEnd = len(host_info) - sMod
-        machine_data = host_info[sBeg:sEnd].split(",")
-    else:
+        # Filenames generally have '\\' or '/' or '.'
+        # so assume it's a file and parse accordingly
         # Read from the file
         with open(host_info, "r") as f:
-            machine_data = f.read().splitlines()
+            host_info = f.read()
+         
+    sMod = 1 if host_info[0] == "[" else 0
+    sBeg = sMod
+    sEnd = len(host_info) - sMod
+    machine_data = host_info[sBeg:sEnd].split(",")
 
     return _parse_machine_data(machine_data)
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -274,7 +274,7 @@ class TestLoadMachines(unittest.TestCase):
         self.assertEqual(fluentOpts, "-t32 -cnf=M0:8,M1:8,M2:16")
         del os.environ["CCP_NODES"]
 
-    def test_slurm_nodelist(self):
+    def test_slurm_single_num(self):
         os.environ["SLURM_JOB_NODELIST"] = "M[1-2],M[3]"
         os.environ["SLURM_TASKS_PER_NODE"] = "8,10(x2)"
         hostList = os.environ.get("SLURM_JOB_NODELIST")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -188,14 +188,22 @@ class TestLoadMachines(unittest.TestCase):
         self.assertEqual(machineList.machines[1].host_name, "m2")
         self.assertEqual(machineList.machines[2].number_of_cores, 4)
         self.assertEqual(machineList.machines[3].queue_name, "queueName1")
-        del os.environ["PE_HOSTFILE"] 
-        
+        del os.environ["PE_HOSTFILE"]
 
     def test_lsb_mcpu(self):
         os.environ["LSB_MCPU_HOSTS"] = "m1 3 m2 3"
         machineList = load_machines()
         self.assertEqual(machineList.number_of_cores, 6)
         del os.environ["LSB_MCPU_HOSTS"]
+
+    def test_pbs_nodefile(self):
+        with tempfile.NamedTemporaryFile(delete=False) as fp:
+            fp.write(b'm1\r\n\r\nm2\r\nm2\r\nm2')
+            os.environ["PBS_NODEFILE"] = fp.name
+        machineList = load_machines()
+        os.unlink(fp.name)
+        self.assertEqual(machineList[1].number_of_cores, 3)
+        del os.environ["PBS_NODEFILE"] 
 
     def test_no_environment(self):
         machineList = load_machines()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -160,8 +160,8 @@ class TestLoadMachines(unittest.TestCase):
 
     def test_machine_info(self):
         info = [
-            {"machine-name": "M0", "core-count": 1},
-            {"machine-name": "M1", "core-count": 6},
+            {"machine": "M0", "core-count": 1},
+            {"machine": "M1", "core-count": 6},
         ]
         machineList = load_machines(machine_info=info)
         self.assertEqual(machineList.number_of_cores, 7)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -160,7 +160,7 @@ class TestLoadMachines(unittest.TestCase):
 
     def test_machine_info(self):
         info = [
-            {"machine": "M0", "core-count": 1},
+            {"machine-name": "M0", "core-count": 1},
             {"machine-name": "M1", "core-count": 1},
         ]
         machineList = load_machines(machine_info=info)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -227,8 +227,11 @@ class TestLoadMachines(unittest.TestCase):
         self.assertEqual(fluentOpts, "-t4 -cnf=M0:1,M1:2,M2:1")
 
     def test_constrain_machines2(self):
-        machineList = load_machines(host_info="M0:2,M1:3,M2:2", ncores=3)
+        with tempfile.NamedTemporaryFile(delete=False) as fp:
+            fp.write(b'M0:2,M1:3,M2:2')
+        machineList = load_machines(host_info=fp.name, ncores=3)
         expectedValue = {"M0": 1, "M1": 1, "M2": 1}
+        os.unlink(fp.name)
         self.assertEqual(len(machineList.machines), 3)
         for machine in machineList.machines:
             self.assertEqual(machine.number_of_cores, expectedValue[machine.host_name])

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -180,13 +180,14 @@ class TestLoadMachines(unittest.TestCase):
 
     def test_pe_hostfile(self):
         with tempfile.NamedTemporaryFile(delete=False) as fp:
-            fp.write(b'm1 3 None None\r\nm2 3 None None')
+            fp.write(b'm1\r\n\r\nm2 3 None None\r\nm3 4\r\nm4 2 queueName1')
             os.environ["PE_HOSTFILE"] = fp.name
         machineList = load_machines()
         os.unlink(fp.name)
-        self.assertEqual(machineList.number_of_cores, 6)
+        self.assertEqual(machineList.number_of_cores, 10)
         self.assertEqual(machineList.machines[1].host_name, "m2")
-        self.assertEqual(os.path.exists(fp.name), False)
+        self.assertEqual(machineList.machines[2].number_of_cores, 4)
+        self.assertEqual(machineList.machines[3].queue_name, "queueName1")
         del os.environ["PE_HOSTFILE"] 
         
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -274,6 +274,17 @@ class TestLoadMachines(unittest.TestCase):
         self.assertEqual(fluentOpts, "-t32 -cnf=M0:8,M1:8,M2:16")
         del os.environ["CCP_NODES"]
 
+    def test_slurm_nodelist(self):
+        os.environ["SLURM_JOB_NODELIST"] = "M[1-2],M[3]"
+        os.environ["SLURM_TASKS_PER_NODE"] = "8,10(x2)"
+        hostList = os.environ.get("SLURM_JOB_NODELIST")
+        machineList = _construct_machine_list_slurm(hostList)
+        self.assertEqual(machineList[1].number_of_cores, 10)
+        self.assertEqual(machineList[2].number_of_cores, 10)
+        self.assertEqual(machineList[2].host_name, "M3")
+        del os.environ["SLURM_JOB_NODELIST"]
+        del os.environ["SLURM_TASKS_PER_NODE"]
+
     def test_slurm_no_brackets(self):
         os.environ["SLURM_JOB_NODELIST"] = "M0,M1,M2"
         os.environ["SLURM_NTASKS_PER_NODE"] = "8"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,9 +1,9 @@
 """Provide a module to test the algorithms which parse job scheduler
 environments for machines to run on."""
 from builtins import range
-import tempfile
 import os
 import socket
+import tempfile
 import unittest
 
 from ansys.fluent.core.scheduler import build_parallel_options
@@ -180,7 +180,7 @@ class TestLoadMachines(unittest.TestCase):
 
     def test_pe_hostfile(self):
         with tempfile.NamedTemporaryFile(delete=False) as fp:
-            fp.write(b'm1\r\n\r\nm2 3 None None\r\nm3 4\r\nm4 2 queueName1')
+            fp.write(b"m1\r\n\r\nm2 3 None None\r\nm3 4\r\nm4 2 queueName1")
             os.environ["PE_HOSTFILE"] = fp.name
         machineList = load_machines()
         os.unlink(fp.name)
@@ -198,12 +198,12 @@ class TestLoadMachines(unittest.TestCase):
 
     def test_pbs_nodefile(self):
         with tempfile.NamedTemporaryFile(delete=False) as fp:
-            fp.write(b'm1\r\n\r\nm2\r\nm2\r\nm2')
+            fp.write(b"m1\r\n\r\nm2\r\nm2\r\nm2")
             os.environ["PBS_NODEFILE"] = fp.name
         machineList = load_machines()
         os.unlink(fp.name)
         self.assertEqual(machineList[1].number_of_cores, 3)
-        del os.environ["PBS_NODEFILE"] 
+        del os.environ["PBS_NODEFILE"]
 
     def test_no_environment(self):
         machineList = load_machines()
@@ -228,7 +228,7 @@ class TestLoadMachines(unittest.TestCase):
 
     def test_constrain_machines2(self):
         with tempfile.NamedTemporaryFile(delete=False) as fp:
-            fp.write(b'M0:2,M1:3,M2:2')
+            fp.write(b"M0:2,M1:3,M2:2")
         machineList = load_machines(host_info=fp.name, ncores=3)
         expectedValue = {"M0": 1, "M1": 1, "M2": 1}
         os.unlink(fp.name)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -161,7 +161,7 @@ class TestLoadMachines(unittest.TestCase):
     def test_machine_info(self):
         info = [
             {"machine": "M0", "core-count": 1},
-            {"machine": "M1", "core-count": 6},
+            {"machine-name": "M1", "core-count": 1},
         ]
         machineList = load_machines(machine_info=info)
         self.assertEqual(machineList.number_of_cores, 7)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -461,10 +461,6 @@ class TestMachineListCmdLine(unittest.TestCase):
                     machine.number_of_cores, self._expectedValues[machine.host_name]
                 )
 
-    def test_file_not_found(self):
-        hostfile = "nonExistentFile.txt"
-        self.assertRaises(IOError, _parse_host_info, hostfile)
-
 
 suite1 = unittest.TestLoader().loadTestsFromTestCase(TestMachine)
 suite2 = unittest.TestLoader().loadTestsFromTestCase(TestMachineList)


### PR DESCRIPTION
Changes to load_machines.py:
---------------------------------
121-135: Checks if the host info is a file before parsing. I made this change because then I can pass the host info taken from a file into the same parsing procedure.

263-267: I was getting many "index out of range" errors and it doesn't make sense to send in default values. It makes sure there are at least the 2 required inputs and that the 2nd is of type int. I don't know if there would need to be a similar type constraint for a 4th argument.

190-302: Changed machineDict to a plain hostName: numberOfCores instead of having objects. At the end it passes it in once with all the required values.

341,380: Added a "." in the regular expression and it picks up a single number in brackets. (i.e. [3])

Changes to test_scheduler.py:
---------------------------------
Imported tempfile for testing the "with open" statements.

Through these new tests I found what I thought were issues in load_machines.py. I made changes but I am still learning and I am not sure they are better than the previous. As always I am open to any feedback that I can get. With these changes coverage of load_machines.py is up to 94%.


