### PR TITLE
Fix transcript behavior.

### DIFF
--- a/src/ansys/fluent/core/fluent_connection.py
+++ b/src/ansys/fluent/core/fluent_connection.py
@@ -267,11 +267,11 @@ class FluentConnection:
             return "meshing"
 
     def start_transcript(
-        self, file_path: str = None, write_to_interpreter: bool = True
+        self, file_path: str = None, write_to_stdout: bool = True
     ) -> None:
         """Start streaming of Fluent transcript."""
         warnings.warn("Use -> transcript.start()", DeprecationWarning)
-        self.transcript.start(file_path, write_to_interpreter)
+        self.transcript.start(file_path, write_to_stdout)
 
     def stop_transcript(self) -> None:
         """Stop streaming of Fluent transcript."""

--- a/src/ansys/fluent/core/streaming_services/transcript_streaming.py
+++ b/src/ansys/fluent/core/streaming_services/transcript_streaming.py
@@ -33,7 +33,7 @@ class Transcript(StreamingService):
         )
         self.callback_ids = []
 
-    def start(self, file_path: str = None, write_to_interpreter: bool = False) -> None:
+    def start(self, file_path: str = None, write_to_stdout: bool = False) -> None:
         """Start streaming of Fluent transcript.
 
          Parameters
@@ -50,10 +50,13 @@ class Transcript(StreamingService):
             self.callback_ids.append(
                 self.register_callback(append_to_file, keep_new_lines=True)
             )
-        if not Transcript._writing_transcript_to_interpreter:
-            if write_to_interpreter:
-                self.callback_ids.append(self.register_callback(print))
-                Transcript._writing_transcript_to_interpreter = True
+            if not Transcript._writing_transcript_to_interpreter:
+                if write_to_stdout:
+                    self.callback_ids.append(self.register_callback(print))
+                    Transcript._writing_transcript_to_interpreter = True
+        else:
+            self.callback_ids.append(self.register_callback(print))
+            Transcript._writing_transcript_to_interpreter = True
         super().start()
 
     def stop(self) -> None:

--- a/src/ansys/fluent/core/streaming_services/transcript_streaming.py
+++ b/src/ansys/fluent/core/streaming_services/transcript_streaming.py
@@ -50,15 +50,17 @@ class Transcript(StreamingService):
             self.callback_ids.append(
                 self.register_callback(append_to_file, keep_new_lines=True)
             )
-            if not Transcript._writing_transcript_to_interpreter:
-                if write_to_stdout:
-                    self.callback_ids.append(self.register_callback(print))
-                    Transcript._writing_transcript_to_interpreter = True
+            if write_to_stdout:
+                self._write_to_stdout()
         else:
-            if not Transcript._writing_transcript_to_interpreter:
-                self.callback_ids.append(self.register_callback(print))
-                Transcript._writing_transcript_to_interpreter = True
+            self._write_to_stdout()
         super().start()
+
+    def _write_to_stdout(self):
+        """Write transcript to stdout."""
+        if not Transcript._writing_transcript_to_interpreter:
+            self.callback_ids.append(self.register_callback(print))
+            Transcript._writing_transcript_to_interpreter = True
 
     def stop(self) -> None:
         """Stop streaming of Fluent transcript."""

--- a/src/ansys/fluent/core/streaming_services/transcript_streaming.py
+++ b/src/ansys/fluent/core/streaming_services/transcript_streaming.py
@@ -33,7 +33,7 @@ class Transcript(StreamingService):
         )
         self.callback_ids = []
 
-    def start(self, file_path: str = None, write_to_interpreter: bool = True) -> None:
+    def start(self, file_path: str = None, write_to_interpreter: bool = False) -> None:
         """Start streaming of Fluent transcript.
 
          Parameters
@@ -43,10 +43,6 @@ class Transcript(StreamingService):
         write_to_interpreter: bool, optional
             Flag to print transcript on the screen or not
         """
-        if not Transcript._writing_transcript_to_interpreter:
-            if write_to_interpreter:
-                self.callback_ids.append(self.register_callback(print))
-                Transcript._writing_transcript_to_interpreter = True
         if file_path:
             if Path(file_path).exists():
                 os.remove(file_path)
@@ -54,6 +50,10 @@ class Transcript(StreamingService):
             self.callback_ids.append(
                 self.register_callback(append_to_file, keep_new_lines=True)
             )
+        if not Transcript._writing_transcript_to_interpreter:
+            if write_to_interpreter:
+                self.callback_ids.append(self.register_callback(print))
+                Transcript._writing_transcript_to_interpreter = True
         super().start()
 
     def stop(self) -> None:

--- a/src/ansys/fluent/core/streaming_services/transcript_streaming.py
+++ b/src/ansys/fluent/core/streaming_services/transcript_streaming.py
@@ -40,7 +40,7 @@ class Transcript(StreamingService):
         ----------
         file_path: str, optional
             File path to write the transcript stream.
-        write_to_interpreter: bool, optional
+        write_to_stdout: bool, optional
             Flag to print transcript on the screen or not
         """
         if file_path:

--- a/src/ansys/fluent/core/streaming_services/transcript_streaming.py
+++ b/src/ansys/fluent/core/streaming_services/transcript_streaming.py
@@ -55,8 +55,9 @@ class Transcript(StreamingService):
                     self.callback_ids.append(self.register_callback(print))
                     Transcript._writing_transcript_to_interpreter = True
         else:
-            self.callback_ids.append(self.register_callback(print))
-            Transcript._writing_transcript_to_interpreter = True
+            if not Transcript._writing_transcript_to_interpreter:
+                self.callback_ids.append(self.register_callback(print))
+                Transcript._writing_transcript_to_interpreter = True
         super().start()
 
     def stop(self) -> None:

--- a/tests/test_fluent_session.py
+++ b/tests/test_fluent_session.py
@@ -46,7 +46,7 @@ def test_session_starts_no_transcript_if_disabled(
 
     print_transcript.called = False
 
-    session.transcript.start(write_to_interpreter=False)
+    session.transcript.start(write_to_stdout=False)
 
     _read_case(session=session)
 


### PR DESCRIPTION
transcript.start()  # write to stdout only

transcript.start(file_path="a.trn")  # write to file only

transcript.start(file_path="a.trn", write_to_stdout=True)  # write to both file and stdout