### PR TITLE
Edit support email address

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ For comprehensive information on PyFluent, see the latest release
 
 On the `PyFluent Issues <https://github.com/pyansys/pyfluent/issues>`_ page, you can create
 issues to submit questions, report bugs, and request new features. To reach
-the PyAnsys support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
+the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ For comprehensive information on PyFluent, see the latest release
 
 On the `PyFluent Issues <https://github.com/pyansys/pyfluent/issues>`_ page, you can create
 issues to submit questions, report bugs, and request new features. To reach
-the PyAnsys support team, email `pyansys.support@ansys.com <pyansys.support@ansys.com>`_.
+the PyAnsys support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 
 Installation
 ------------
@@ -91,7 +91,7 @@ To launch Fluent from Python, use the ``launch_fluent`` method:
 
 On Windows systems the environment variable ``AWP_ROOT<ver>`` is configured
 when Fluent is installed, where ``<ver>`` is the Fluent release number such as
-``231`` for release 2023 R1.  PyFluent automatically uses this environment
+``231`` for release 2023 R1. PyFluent automatically uses this environment
 variable to locate the latest Fluent installation. On Linux systems configure
 ``AWP_ROOT<ver>`` to point to the absolute path of an Ansys installation such as
 ``/apps/ansys_inc/v231``.

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -1,8 +1,8 @@
 .. _ref_contributing:
 
-============
-Contributing
-============
+==========
+Contribute
+==========
 Overall guidance on contributing to a PyAnsys library appears in the
 `Contributing <https://dev.docs.pyansys.com/dev/how-to/contributing.html>`_ topic
 in the *PyAnsys Developer's Guide*. Ensure that you are thoroughly familiar with

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -83,6 +83,11 @@ In addition to installation and usage information, the PyFluent documentation
 provides :ref:`ref_index_api`, :ref:`ref_example_gallery`, and
 :ref:`ref_contributing` sections.
 
+In the upper right corner of the documentation's title bar, there is an option
+for switching from viewing the documentation for the latest stable release
+to viewing the documentation for the development version or previously
+released versions.
+
 On the `PyFluent Issues <https://github.com/pyansys/pyfluent/issues>`_ page, you
 can create issues to submit questions, report bugs, and request new features. To
 reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -85,8 +85,7 @@ provides :ref:`ref_index_api`, :ref:`ref_example_gallery`, and
 
 On the `PyFluent Issues <https://github.com/pyansys/pyfluent/issues>`_ page, you
 can create issues to submit questions, report bugs, and request new features. To
-reach the PyAnsys support team, email `pyansys.support@ansys.com
-<pyansys.support@ansys.com>`_.
+reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 
 License
 -------

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     long_description_content_type="text/x-rst",
     license="MIT",
     author="ANSYS, Inc.",
-    author_email="pyansys.support@ansys.com",
+    author_email="pyansys.core@ansys.com",
     maintainer="PyAnsys developers",
     maintainer_email="pyansys.maintainers@ansys.com",
     classifiers=[


### PR DESCRIPTION
In doing a search of the repo, I found two more occurrences of pyansys.supoprt@ansys.com in pyfluent\src\ansys_fluent_core.egg-info\PKG-INFO, lines 7 and 61. However, I didn't know if these email addresses would somehow get updated to pyansys.core@ansys.com when the changes I made within the other repo files were updated. Please advise.