### PR TITLE
Fix failing CI run due to settings api update.

### DIFF
--- a/tests/test_flobject.py
+++ b/tests/test_flobject.py
@@ -7,6 +7,7 @@ import weakref
 import pytest
 from util.solver_workflow import new_solver_session_no_transcript  # noqa: F401
 
+from ansys.fluent.core.examples import download_file
 from ansys.fluent.core.solver import flobject
 
 
@@ -729,6 +730,11 @@ def test_accessor_methods_on_settings_object_types(load_static_mixer_case):
 @pytest.mark.fluent_232
 def test_settings_matching_names(new_solver_session_no_transcript) -> None:
     solver = new_solver_session_no_transcript
+
+    case_path = download_file("elbow_source_terms.cas.h5", "pyfluent/mixing_elbow")
+    solver.file.read_case(file_name=case_path)
+
+    solver.solution.initialization.hybrid_initialize()
 
     with pytest.raises(AttributeError) as msg:
         solver.setup.mod

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -4,9 +4,15 @@ from util.solver_workflow import new_solver_session  # noqa: F401
 from ansys.fluent.core.examples import download_file
 
 
+@pytest.mark.dev
+@pytest.mark.fluent_231
+@pytest.mark.fluent_232
 def test_setup_models_viscous_model_settings(new_solver_session) -> None:
     solver_session = new_solver_session
-    assert solver_session.setup.models.viscous.model() == "laminar"
+    case_path = download_file("elbow_source_terms.cas.h5", "pyfluent/mixing_elbow")
+    solver_session.file.read_case(file_name=case_path)
+    solver_session.solution.initialization.hybrid_initialize()
+    assert solver_session.setup.models.viscous.model() == "k-epsilon"
     assert "inviscid" in solver_session.setup.models.viscous.model.get_attr(
         "allowed-values"
     )


### PR DESCRIPTION
There is a recent change in Fluent to hide case-settings in settings API before case is read. We need to update pyfluent unittests for that.