### PR TITLE
Fix bug in wildcard - flobject.py

### DIFF
--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -584,7 +584,7 @@ class WildcardPath(Group):
     def items(self):
         """Items."""
         for key, value in self._parent.items():
-            if fnmatch.fnmatch(key, self._path.split("/")[-1]):
+            if fnmatch.fnmatch(key, self._path.rsplit(sep="/", maxsplit=1)[-1]):
                 yield key, value
 
     def __iter__(self):

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -589,7 +589,7 @@ class WildcardPath(Group):
 
     def __iter__(self):
         for item in self._parent:
-            if fnmatch.fnmatch(item, self._path.split("/")[-1]):
+            if fnmatch.fnmatch(item, self._path.rsplit(sep="/", maxsplit=1)[-1]):
                 yield item
 
     def to_scheme_keys(self, value):

--- a/src/ansys/fluent/core/solver/flobject.py
+++ b/src/ansys/fluent/core/solver/flobject.py
@@ -535,7 +535,7 @@ class WildcardPath(Group):
     """Class wrapping a wildcard path to perform get_var and set_var on
     flproxy."""
 
-    def __init__(self, flproxy, path: str, state_cls, settings_cls):
+    def __init__(self, flproxy, path: str, state_cls, settings_cls, parent):
         """__init__ of WildcardPath class."""
         self._setattr("_flproxy", flproxy)
         self._setattr("_path", path)
@@ -547,6 +547,7 @@ class WildcardPath(Group):
         # _settings_cls is the settings cls at the wildcard path level. It is used to
         # construct the scheme path for children.
         self._setattr("_settings_cls", settings_cls)
+        self._setattr("_parent", parent)
 
     @property
     def flproxy(self):
@@ -572,12 +573,24 @@ class WildcardPath(Group):
                 self.path + "/" + scheme_name,
                 self._state_cls,
                 child_settings_cls,
+                self,
             )
         raise KeyError(
             allowed_name_error_message(
                 "Settings objects", name, self.get_object_names()
             )
         )
+
+    def items(self):
+        """Items."""
+        for key, value in self._parent.items():
+            if fnmatch.fnmatch(key, self._path.split("/")[-1]):
+                yield key, value
+
+    def __iter__(self):
+        for item in self._parent:
+            if fnmatch.fnmatch(item, self._path.split("/")[-1]):
+                yield item
 
     def to_scheme_keys(self, value):
         """Convert value to have keys with scheme names."""
@@ -598,6 +611,7 @@ class NamedObjectWildcardPath(WildcardPath):
             self.path + "/" + name,
             self._state_cls,
             self._settings_cls.child_object_type,
+            self,
         )
 
     def __setitem__(self, name, value):
@@ -732,7 +746,11 @@ class NamedObject(SettingsBase[DictStateType], Generic[ChildTypeT]):
             if self.flproxy.has_wildcard(name):
                 child_cls = self.__class__.child_object_type
                 return WildcardPath(
-                    self.flproxy, self.path + "/" + name, self.__class__, child_cls
+                    self.flproxy,
+                    self.path + "/" + name,
+                    self.__class__,
+                    child_cls,
+                    self,
                 )
             raise KeyError(
                 allowed_name_error_message(

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -113,3 +113,43 @@ def test_wildcard_fnmatch(new_solver_session):
         list(solver.results.graphics.mesh["mesh-[!2-5]"]().keys()).sort()
         == ["mesh-1", "mesh-a"].sort()
     )
+
+
+@pytest.mark.dev
+@pytest.mark.fluent_232
+def test_wildcard_path_is_iterable(new_solver_session):
+    solver = new_solver_session
+    case_path = download_file("elbow_source_terms.cas.h5", "pyfluent/mixing_elbow")
+    solver.file.read_case(file_name=case_path)
+
+    assert [x for x in solver.setup.boundary_conditions.velocity_inlet] == [
+        "inlet2",
+        "inlet1",
+    ]
+
+    assert [x for x in solver.setup.boundary_conditions.velocity_inlet["*let*"]] == [
+        "inlet2",
+        "inlet1",
+    ]
+
+    assert [x for x in solver.setup.boundary_conditions.velocity_inlet["*1*"]] == [
+        "inlet1"
+    ]
+
+    test_data = []
+    for k, v in solver.setup.boundary_conditions.velocity_inlet.items():
+        test_data.append((k, v))
+
+    assert test_data[0][0] == "inlet2"
+    assert test_data[0][1].path == r"setup/boundary-conditions/velocity-inlet/inlet2"
+    assert test_data[1][0] == "inlet1"
+    assert test_data[1][1].path == r"setup/boundary-conditions/velocity-inlet/inlet1"
+
+    test_data = []
+    for k, v in solver.setup.boundary_conditions.velocity_inlet["*let*"].items():
+        test_data.append((k, v))
+
+    assert test_data[0][0] == "inlet2"
+    assert test_data[0][1].path == r"setup/boundary-conditions/velocity-inlet/inlet2"
+    assert test_data[1][0] == "inlet1"
+    assert test_data[1][1].path == r"setup/boundary-conditions/velocity-inlet/inlet1"


### PR DESCRIPTION
```
>>> [x for x in solver.setup.boundary_conditions.velocity_inlet]          
['inlet2', 'inlet1']
>>> [x for x in solver.setup.boundary_conditions.velocity_inlet['\*let*']]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'WildcardPath' object is not iterable
```

The above behavior is fixed.

Similar changes have been applied on the PyConsole side as well.