### PR TITLE
Case Reader to parse numerical values with units.

### DIFF
--- a/src/ansys/fluent/core/filereader/case_file.py
+++ b/src/ansys/fluent/core/filereader/case_file.py
@@ -68,7 +68,12 @@ class InputParameter:
         float
             Numeric value of the Fluent input parameter.
         """
-        return float(self._component(0))
+        try:
+            num_val = float(self._component(0))
+        except ValueError:
+            num_val = float(self._component(0).split("[")[0])
+
+        return num_val
 
     def _component(self, idx: int):
         try:


### PR DESCRIPTION
Case Reader was not able to parse numerical values like: 2[m/s].

That behavior has been fixed.