### PR TITLE
Fix/examples save path

### DIFF
--- a/src/ansys/fluent/core/examples/downloads.py
+++ b/src/ansys/fluent/core/examples/downloads.py
@@ -52,7 +52,7 @@ def _retrieve_file(url: str, filename: str, save_path: Optional[str] = None) -> 
     # First check if file has already been downloaded
     if os.path.isfile(local_path_no_zip) or os.path.isdir(local_path_no_zip):
         logging.info("File already exists.")
-        logging.info(f"File path: {local_path_no_zip}")
+        logging.info(f"File path: {os.path.abspath(local_path_no_zip)}")
         return local_path_no_zip
 
     logging.info("Downloading specified file...")
@@ -67,7 +67,7 @@ def _retrieve_file(url: str, filename: str, save_path: Optional[str] = None) -> 
         _decompress(local_path)
         local_path = local_path_no_zip
     logging.info("Download successful.")
-    logging.info(f"File path: {local_path}")
+    logging.info(f"File path: {os.path.abspath(local_path)}")
     return local_path
 
 

--- a/src/ansys/fluent/core/examples/downloads.py
+++ b/src/ansys/fluent/core/examples/downloads.py
@@ -47,12 +47,13 @@ def _retrieve_file(url: str, filename: str, save_path: Optional[str] = None) -> 
             pyfluent.EXAMPLES_PATH, os.path.basename(filename)
         )
     else:
+        save_path = os.path.abspath(save_path)
         local_path = os.path.join(save_path, os.path.basename(filename))
     local_path_no_zip = re.sub(".zip$", "", local_path)
     # First check if file has already been downloaded
     if os.path.isfile(local_path_no_zip) or os.path.isdir(local_path_no_zip):
         logging.info("File already exists.")
-        logging.info(f"File path: {os.path.abspath(local_path_no_zip)}")
+        logging.info(f"File path: {local_path_no_zip}")
         return local_path_no_zip
 
     logging.info("Downloading specified file...")
@@ -67,7 +68,7 @@ def _retrieve_file(url: str, filename: str, save_path: Optional[str] = None) -> 
         _decompress(local_path)
         local_path = local_path_no_zip
     logging.info("Download successful.")
-    logging.info(f"File path: {os.path.abspath(local_path)}")
+    logging.info(f"File path: {local_path}")
     return local_path
 
 

--- a/src/ansys/fluent/core/examples/downloads.py
+++ b/src/ansys/fluent/core/examples/downloads.py
@@ -8,6 +8,7 @@ Examples
 >>> filename
 '/home/user/.local/share/ansys_fluent_core/examples/bracket.iges'
 """
+import logging
 import os
 import re
 import shutil
@@ -16,12 +17,6 @@ import urllib.request
 import zipfile
 
 import ansys.fluent.core as pyfluent
-
-
-def get_ext(filename: str) -> str:
-    """Extract the extension of a file."""
-    ext = os.path.splitext(filename)[1].lower()
-    return ext
 
 
 def delete_downloads() -> bool:
@@ -56,7 +51,11 @@ def _retrieve_file(url: str, filename: str, save_path: Optional[str] = None) -> 
     local_path_no_zip = re.sub(".zip$", "", local_path)
     # First check if file has already been downloaded
     if os.path.isfile(local_path_no_zip) or os.path.isdir(local_path_no_zip):
+        logging.info("File already exists.")
+        logging.info(f"File path: {local_path_no_zip}")
         return local_path_no_zip
+
+    logging.info("Downloading specified file...")
 
     # grab the correct url retriever
     urlretrieve = urllib.request.urlretrieve
@@ -64,9 +63,11 @@ def _retrieve_file(url: str, filename: str, save_path: Optional[str] = None) -> 
     # Perform download
     saved_file, _ = urlretrieve(url)
     shutil.move(saved_file, local_path)
-    if get_ext(local_path) in [".zip"]:
+    if local_path.endswith(".zip"):
         _decompress(local_path)
         local_path = local_path_no_zip
+    logging.info("Download successful.")
+    logging.info(f"File path: {local_path}")
     return local_path
 
 

--- a/src/ansys/fluent/core/examples/downloads.py
+++ b/src/ansys/fluent/core/examples/downloads.py
@@ -51,10 +51,9 @@ def _retrieve_file(url: str, filename: str, save_path: Optional[str] = None) -> 
         local_path: str = os.path.join(
             pyfluent.EXAMPLES_PATH, os.path.basename(filename)
         )
-        local_path_no_zip = re.sub(".zip$", "", local_path)
     else:
         local_path = os.path.join(save_path, os.path.basename(filename))
-        local_path_no_zip = re.sub(".zip$", "", local_path)
+    local_path_no_zip = re.sub(".zip$", "", local_path)
     # First check if file has already been downloaded
     if os.path.isfile(local_path_no_zip) or os.path.isdir(local_path_no_zip):
         return local_path_no_zip

--- a/src/ansys/fluent/core/examples/downloads.py
+++ b/src/ansys/fluent/core/examples/downloads.py
@@ -48,16 +48,16 @@ def _get_file_url(filename: str, directory: Optional[str] = None) -> str:
 
 def _retrieve_file(url: str, filename: str, save_path: Optional[str] = None) -> str:
     if save_path is None:
-        # First check if file has already been downloaded
         local_path: str = os.path.join(
             pyfluent.EXAMPLES_PATH, os.path.basename(filename)
         )
         local_path_no_zip = re.sub(".zip$", "", local_path)
-        if os.path.isfile(local_path_no_zip) or os.path.isdir(local_path_no_zip):
-            return local_path_no_zip
     else:
         local_path = os.path.join(save_path, os.path.basename(filename))
         local_path_no_zip = re.sub(".zip$", "", local_path)
+    # First check if file has already been downloaded
+    if os.path.isfile(local_path_no_zip) or os.path.isdir(local_path_no_zip):
+        return local_path_no_zip
 
     # grab the correct url retriever
     urlretrieve = urllib.request.urlretrieve


### PR DESCRIPTION
Related to this issue: https://github.com/pyansys/pyfluent/issues/1393 (see my comment there as well)

A few other changes:
- In downloads.py the variable `resp` was unused, also not used anywhere else that I could find in pyansys, so I removed it
- Changed `string.replace` to `re.sub("...$")` to force it to remove only the extension, and not potential `.zip` in the middle of the file name (like `test.zip.h` or something of the sort). `re` is also used elsewhere in pyansys, so it is not a completely new import

Notes/thoughts:
- urllib.request.urlretrieve is ported from python2 and may become deprecated in the future (see here https://docs.python.org/3/library/urllib.request.html#urllib.request.urlretrieve)
- maybe add output into the console explaining what is going on? Like " downloading file..." or "file already exists"
- as discussed with @mkundu1 this does not solve the underlying behavior that Fluent will by default save output files based on where it read input files from, but I think this makes sense and can be expected by the user. At least now pyfluent users can specify where to download example files to (and so Fluent will save its output there as well in this basic example workflow).