### PR TITLE
doc: fix external links in contributing.rst

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -4,10 +4,10 @@
 Contribute
 ==========
 Overall guidance on contributing to a PyAnsys library appears in the
-`Contributing <https://dev.docs.pyansys.com/dev/how-to/contributing.html>`_ topic
+`Contributing <https://dev.docs.pyansys.com/how-to/contributing.html>`_ topic
 in the *PyAnsys Developer's Guide*. Ensure that you are thoroughly familiar with
 this guide, paying particular attention to the `Coding Style
-<https://dev.docs.pyansys.com/dev/coding-style/index.html#coding-style>`_ topic, before
+<https://dev.docs.pyansys.com/coding-style/index.html#coding-style>`_ topic, before
 attempting to contribute to PyFluent.
  
 The following contribution information is specific to PyFluent.


### PR DESCRIPTION
Fixes  `Contributing` and `Coding Style` broken links within `contributing.rst`.

Current:

https://dev.docs.pyansys.com/dev/how-to/contributing.html
https://dev.docs.pyansys.com/dev/coding-style/index.html#coding-style

New:

https://dev.docs.pyansys.com/how-to/contributing.html
https://dev.docs.pyansys.com/coding-style/index.html#coding-style